### PR TITLE
Fix/add-index-for-mop-sed

### DIFF
--- a/jewellery_erpnext/patches.txt
+++ b/jewellery_erpnext/patches.txt
@@ -2,5 +2,6 @@
 
 [post_model_sync]
 # jewellery_erpnext.patches.sed_copy_to_mop
+jewellery_erpnext.patches.truncate_manufacturing_operation_field
 jewellery_erpnext.patches.remove_se_custom_fields
 jewellery_erpnext.patches.create_custom_field

--- a/jewellery_erpnext/patches/truncate_manufacturing_operation_field.py
+++ b/jewellery_erpnext/patches/truncate_manufacturing_operation_field.py
@@ -1,0 +1,22 @@
+import frappe
+
+def execute():
+    """
+    Truncate 'manufacturing_operation' to 140 characters to allow indexing
+    and avoid schema alteration errors.
+    """
+    # Count affected rows
+    count = frappe.db.count(
+        'Stock Entry Detail',
+        filters={"manufacturing_operation": ("length", ">", 140)}
+    )
+    print(f"Truncating {count} rows in 'manufacturing_operation' field...")
+
+    # Truncate all rows > 191 chars
+    frappe.db.sql("""
+        UPDATE `tabStock Entry Detail`
+        SET `manufacturing_operation` = LEFT(`manufacturing_operation`, 140)
+        WHERE CHAR_LENGTH(`manufacturing_operation`) > 140
+    """)
+
+    print("Truncation completed successfully.")


### PR DESCRIPTION
Truncates values in Stock Entry Detail.manufacturing_operation to 140 characters.

Ensures migration to VARCHAR(140) and adding an index succeeds.

Improves search performance by allowing indexed queries.

Minimal data loss (71 rows exceeded 140 characters).