### PR TITLE
fix: manufacturing operation weight recalculation and stock reservati…

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -16,18 +16,22 @@
 # - whitelisted methods, REST APIs
 # - Stock, Manufacturing, Accounting, MOP Log, jewellery workflows
 #
-# Verified framework integration in hooks.py:
-# - override_doctype_class: Stock Entry, Stock Reconciliation, Stock Ledger Entry,
-#   Serial and Batch Bundle, Submission Queue (5 overrides)
-# - override_whitelisted_methods: Job Card make_stock_entry,
-#   Material Request make_stock_entry, Stock Entry make_stock_in_entry,
-#   Frappe bulk_update.submit_cancel_or_update_docs (4 overrides)
-# - scheduler_events: single daily_long entry -> mop_settings.mop_eod_sync.sync_mop_logs
-# - after_migrate: jewellery_erpnext.migrate.after_migrate (re-applies custom_fields/
-#   and property_setter/ JSON sets on every bench migrate)
-# - patches.txt: 5 active post_model_sync patches (no destructive data patches)
-# - fixtures: narrow allowlist (sketch workflows, 9 sketch/order custom fields,
-#   3 roles); not a wholesale doctype export
+# Documented framework integration points in hooks.py (verify against current source):
+# - override_doctype_class: standard ERPNext Stock Entry, Stock Reconciliation,
+#   Stock Ledger Entry, Serial and Batch Bundle, and Submission Queue
+#   controllers are overridden. Treat as bench-wide blast radius.
+# - override_whitelisted_methods: standard Frappe / ERPNext core endpoints are
+#   intercepted (Job Card / Material Request / Stock Entry SE creators, and a
+#   bench-wide Bulk Update intercept). Treat as upgrade-sensitive.
+# - scheduler_events: a daily_long entry runs the MOP EOD sync.
+# - after_migrate: jewellery_erpnext.migrate.after_migrate re-applies every
+#   JSON file under custom_fields/ and property_setter/ on every bench migrate.
+# - patches.txt: the active post_model_sync patches are documented as
+#   non-destructive; verify any new patch is idempotent and safe to re-run.
+# - fixtures: a narrowly-filtered allowlist (sketch workflows, a small set of
+#   Sketch Order custom fields, a small role list); not a wholesale doctype
+#   export. Coordinate fixture changes with custom_fields/ and property_setter/
+#   JSON to avoid drift.
 #
 # Core review rule:
 # Review the PR diff first.
@@ -538,17 +542,26 @@ Use this app context when the PR touches related areas. Modules: Jewellery Erpne
    - jewellery_erpnext/mop_lineage_audit.py — operational audit harness with
      proof-pack queries (DIR duplicate logs, SE -> multiple MOPs, SNC empty
      source table, Submission Queue DIR timeline, EIR diamond lineage).
-   - jewellery_erpnext/migrate.py after_migrate — re-applies all JSON in
-     custom_fields/ (~41 files) and property_setter/ (~17 files) at every
-     bench migrate; changes there run on every deploy.
-   - scheduler_events: only one entry — daily_long -> sync_mop_logs.
-   - frappe.enqueue is used in interbranch.py, mop_settings.py,
-     doc_events/bulk_update.py, doc_events/quotation.py, and a subcontracting
-     util — all are background-job touch points.
+   - jewellery_erpnext/migrate.py after_migrate — re-applies every JSON file
+     under custom_fields/ and property_setter/ on every bench migrate; changes
+     there ship on the next deploy.
+   - scheduler_events: documented EOD entry runs the MOP sync. When new
+     scheduler entries or background jobs are added or changed, verify retry
+     safety, deduplication, transaction boundaries, batching, and timeout
+     assumptions.
+   - frappe.enqueue is used at multiple sites today (interbranch.py,
+     mop_settings.py, doc_events/bulk_update.py, doc_events/quotation.py,
+     and a subcontracting util). When a PR adds another, confirm the same
+     background-job safety properties.
    - jewellery_erpnext/erpnext_override.py exists; the `import + monkey-patch`
-     blocks in hooks.py are commented out today — flag if a PR re-enables them.
-   - No allow_guest=True methods and no external HTTP / webhook integrations
-     in app code.
+     blocks in hooks.py are commented out — flag if a PR re-enables them.
+   - When a PR adds or changes whitelisted methods, explicitly check whether
+     `allow_guest=True` was introduced, whether permissions are enforced
+     server-side, and whether dynamic doctype / field / method / filter /
+     order_by inputs are allowlisted. If a PR introduces external HTTP
+     integrations, webhooks, website routes, or portal pages, require
+     authentication, error handling, logging, documentation, and operational
+     guidance.
 
 Known repo risk themes (only mention if PR touches them):
 - Duplicate MOP Logs (active rows missing the voucher-scoped idempotency key).
@@ -1061,7 +1074,7 @@ Verification must include:
 ============================================================
 
 Review:
-- patches.txt and patches/ (5 active post_model_sync patches today; sed_copy_to_mop is commented out).
+- patches.txt and patches/ (active post_model_sync patches; sed_copy_to_mop is commented out — re-enabling needs review).
 - DocType JSON changes.
 - Custom Field fixtures.
 - Property Setter fixtures.
@@ -1072,11 +1085,11 @@ Review:
 - Workspace fixtures.
 - after_install / before_migrate / after_migrate / before_uninstall.
 - migrate.py — `after_migrate` re-applies every JSON file under
-  `jewellery_erpnext/custom_fields/` (~41 files) and
-  `jewellery_erpnext/property_setter/` (~17 files) on every `bench migrate`.
-  Any change to those folders runs on every deploy across all sites — treat
-  edits as production-affecting and check for idempotency, missing field
-  options, and accidental overwrites of site-customized fields.
+  `jewellery_erpnext/custom_fields/` and `jewellery_erpnext/property_setter/`
+  on every `bench migrate`. Any change to those folders runs on every deploy
+  across all sites — treat edits as production-affecting and check for
+  idempotency, missing field options, and accidental overwrites of
+  site-customized fields.
 
 Flag:
 - Required fields added without defaults/backfill/staged rollout.
@@ -1111,14 +1124,16 @@ Patch expectations:
 ============================================================
 
 Review:
-- frappe.enqueue (current touch points: interbranch.py,
+- frappe.enqueue sites across the app (verify the current set against source
+  before relying on a fixed list; today they include interbranch.py,
   doctype/mop_settings/mop_settings.py, doc_events/bulk_update.py,
-  doc_events/quotation.py, customization/stock_entry/doc_events/subcontracting_utils.py).
-- scheduler_events (only one entry today: daily_long ->
-  jewellery_erpnext.doctype.mop_settings.mop_eod_sync.sync_mop_logs).
-- Custom Submission Queue (override_doctype_class) — for Employee IR,
-  Department IR, Product Certification, Stock Entry, Main Slip, queues
-  submission to the `long` queue with 4500s timeout. Treat any change here as
+  doc_events/quotation.py, and a customization/stock_entry subcontracting util).
+- scheduler_events: the documented EOD entry runs the MOP sync via
+  jewellery_erpnext.doctype.mop_settings.mop_eod_sync.sync_mop_logs. Verify
+  current source before assuming this is the only entry.
+- Custom Submission Queue (override_doctype_class): routes Employee IR,
+  Department IR, Product Certification, Stock Entry, and Main Slip submissions
+  to the `long` queue with an extended timeout. Treat any change here as
   high-risk: it affects every submit of those doctypes.
 - queued jobs, recurring jobs, retry logic.
 - jobs triggered from hooks / APIs / document events.
@@ -1365,6 +1380,57 @@ Reviewer self-check:
 - Stock Reservation Entry flow affected: Yes/No/Unclear
 - Tests or manual validation requested: Yes/No
 - Remaining uncertainty: list only real unknowns
+
+============================================================
+RECENT FEATURE WORK QUICK-REFERENCE (also see [repository_context] section 11)
+============================================================
+
+When a PR touches these areas, apply the rules summarised here. Section 11 of [repository_context].review_context contains the full text.
+
+- Make Receive Entry on Manufacturing Operation: dialog and server validation MUST source from active Stock Reservation Entry rows linked to manufacturing_work_order, NOT from `mop_balance_table`. Server re-fetches every SRE; client values are advisory. Authoritative remaining qty is `(reserved_qty - delivered_qty)` on the active SRE — do NOT also subtract historical Material Receive (WORK ORDER) qty (the partial-receive flow cancels and recreates the SRE so its remaining is already net of past receives). Tolerance = 10**-System Settings.float_precision.
+
+- Replacement SRE after partial receive: ERPNext's `Stock Reservation Entry.validate_mandatory` requires `available_qty` (label "Available Qty to Reserve"). Replacement MUST set:
+  available_qty = max(get_available_qty_to_reserve(item_code, warehouse, batch_no=...), reserved_qty)
+  has_batch_no / has_serial_no copied from Item master.
+  Use `insert(ignore_links=1)` then `submit()` (NOT `save()`).
+  Never submit an SRE with `reserved_qty <= tolerance`, with no positive `sb_entries` for Serial-and-Batch reservations, or with zero-qty batch children. The "Available Qty to Reserve is required" error is the canonical symptom of this contract being violated.
+  Do not work around with fake quantities (e.g. 0.001), `ignore_validate`, `ignore_mandatory`, or `ignore_permissions`.
+
+- Stock Entry idempotency: `custom_request_id` (Data, hidden, no_copy, read_only) on Stock Entry deduplicates Make Receive Entry double-clicks for the same Manufacturing Operation + stock_entry_type. Same request_id MUST return the existing SE without creating another.
+
+- Employee IR loss MOP Log: each Employee Loss Detail / Manually Book Loss Detail row produces a MOP Log row with:
+  qty_change                = -loss_weight (gram; carat * 0.2 first if stock_uom == "Carat")
+  qty_after_transaction*    = previous_balance - loss_weight (across overall, item-based, batch-based)
+  pcs_change / pcs_after_*  = preserved (loss is by weight)
+  is_synced                 = 1 (bridge — EOD must not re-materialize)
+  log_category              = "Loss Attribution"; loss_type / loss_weight / loss_percentage / loss_source_row populated.
+  `MOPLog.validate()` then writes `qty_after_transaction` to the Manufacturing Operation prefix bucket (M->net_wt, F->finding_wt, D->diamond_wt, G->gemstone_wt, O->other_wt). PRs that introduce `qty_change=0` for loss rows that must reduce the bucket should be flagged.
+
+- Balance helpers MUST include loss rows (because they post real qty_change deltas). Do NOT add a `log_category` filter that excludes Loss Attribution rows from `get_current_mop_balance_rows`, the manual-loss validator, or `_get_unsynced_mop_groups`. Existing `is_cancelled=0` (and `is_synced=0` for EOD) filters are sufficient.
+
+- Manual booked loss validation has TWO layers:
+  (a) per-row floor: `row.proportionally_loss <= MOP Log latest qty_after_transaction_batch_based for (item, batch)`.
+  (b) per-MWO total cap: `sum(manual loss for MWO, in grams) <= sum(gross_wt - received_gross_wt for MWO across employee_ir_operations)` — TRUE baseline, NOT `mop_loss_details_total` (which is already net of manual and would be circular).
+  Both layers must remain.
+
+- Loss item resolution comes from Manufacturer `custom_variant_loss_table` via `get_loss_item_from_manufacturer_mapping(item_code, manufacturer, loss_type="Loss")`. The mapping fields are `variant`, `loss_variant`, `loss_type`, parented to Manufacturer with `parentfield="custom_variant_loss_table"`. Expected mappings (read from Manufacturer; do NOT hardcode):
+  M+Loss->ML, F+Loss->FL, D+Loss->DL, D+Missing->DM, D+Burn->DB, D+Broken->DBK, G+Loss->GL, G+Broken->GB, O+Loss->OL.
+  For Diamond / Gemstone the loss_type is read from the `manually_book_loss_details` row.
+  Missing mapping or unresolvable target item must throw a clear configuration error pointing to "Manufacturer {0} -> Variant Loss Table" — error must NOT mention MOP Settings.
+
+- DO NOT add a `dust_item` field to MOP Settings. DO NOT add code that reads `MOP Settings.dust_item`. The current MOP Settings DocType has only `stock_entry_type_to_reservation` and `sync_mop_log` button; verify against the JSON before approving any addition.
+
+- The older helper `get_item_loss_item` is manufacturer-agnostic and falls through to the C3-buggy `create_loss_item` (always-throw debug leftover at `main_slip.py:804`). New code paths must use `get_loss_item_from_manufacturer_mapping`.
+
+- EOD sync `last_eod_sync_on` stamp is written ONLY on successful per-group sync (inside the savepoint release path). Failed/rolled-back groups MUST NOT stamp.
+
+- EOD SRE reconciliation `_reconcile_reservations_for_mwo` defaults to `dry_run=True` (logs only). PRs MUST NOT default-flip it to `dry_run=False`.
+
+- EOD continues to create `Material Transfer to Department` SE type and `Repack` for loss. Do NOT rename to `Material Transfer (WORK ORDER)` casually — custom field `depends_on`, reports, and downstream hooks key on the existing strings.
+
+- `book_metal_loss` reads MOP Log balance via the alias `qty_after_transaction_batch_based as qty` (gram-based). A historical bug aliased `pcs_after_transaction_batch_based as qty`; a PR that reverts to that alias (forensic C4) must be rejected.
+
+- Test infrastructure: authored unit tests live under `jewellery_erpnext/jewellery_erpnext/tests/` (with `__init__.py`). They are mock-heavy unit tests. The full-app `run-tests` may be blocked by an unrelated `india_compliance` `before_tests` fixture; document this and run modules directly via `python -m unittest` with `frappe.init` + `frappe.connect` if needed. Pre-existing failures in `test_mop_log.TestDepartmentIRIdempotency.*`, `test_main_slip_inject`, and `test_employee_ir.TestEmployeeIRReceiveLineageGuard.*` should not block PRs unless the PR touches those modules.
 '''
 
 
@@ -1483,6 +1549,19 @@ Before publishing a suggestion, verify:
 - It preserves stock/accounting/MOP/reservation semantics.
 - It does not rely on unverified assumptions.
 - It is small enough to apply safely.
+
+Highest-priority bug classes for /improve in this app (apply only when the diff touches related code; full rule text is in [repository_context] section 11):
+- Make Receive Entry sourcing rows from `mop_balance_table` instead of active Stock Reservation Entry rows linked to manufacturing_work_order.
+- Replacement Stock Reservation Entry submitted with no `available_qty`, with `reserved_qty` at zero/sub-precision, or with empty positive `sb_entries` for Serial-and-Batch reservations — the canonical symptom is "Available Qty to Reserve is required".
+- Replacement SRE that double-subtracts past Material Receive (WORK ORDER) qty from active SRE remaining (the partial-receive flow already cancels and recreates the SRE so its remaining is net of past receives).
+- Loss MOP Log writers using `qty_change=0` when the row is meant to reduce the Manufacturing Operation weight bucket. Loss must use negative `qty_change` and reduce `qty_after_transaction*` by the loss weight (gram-equivalent for D / G after `carat * 0.2`).
+- Adding a `log_category="Loss Attribution"` filter to balance helpers (`get_current_mop_balance_rows`, manual-loss validator, `_get_unsynced_mop_groups`) — loss rows post a real qty_change and must be included in balance calculations.
+- Any new `dust_item` field on MOP Settings or any `MOP Settings.dust_item` read. Loss/dust item resolution must come from `Manufacturer.custom_variant_loss_table` via `get_loss_item_from_manufacturer_mapping`. The older `get_item_loss_item` is manufacturer-agnostic and falls through to the C3-buggy `create_loss_item`; new code must not use it.
+- Hardcoded warehouse names, item codes, manufacturer names, customer names in loss / Repack / SRE / Make Receive Entry paths — these must resolve from Manufacturer / department / warehouse_type config.
+- Reverting `book_metal_loss` to `pcs_after_transaction_batch_based as qty` (forensic bug C4) — the correct alias is `qty_after_transaction_batch_based as qty`.
+- Default-flipping `_reconcile_reservations_for_mwo` to `dry_run=False`, or renaming EOD `Material Transfer to Department` / `Repack` SE types without coordinated migration.
+- Stock Entry idempotency: `custom_request_id` on Stock Entry must dedupe Make Receive Entry double-clicks; the same request_id must return the existing SE without creating another. Suggestions must not weaken this.
+- Working around ERPNext SRE validation with fake quantities (e.g. `0.001`), `ignore_validate`, `ignore_mandatory`, `ignore_permissions`, or raw SQL inserts — instead, fix the zero-qty source.
 '''
 
 
@@ -1498,4 +1577,337 @@ extra_instructions = '''
 Update changelog only for user-visible or developer-visible changes.
 Do not add changelog entries for pure formatting unless the repository convention requires it.
 Include the PR link when available.
+'''
+
+
+############################################################
+# Repository Context
+#
+# Durable, source-grounded review guidance for PR-Agent, derived from the
+# documentation under docs/ and the current repository files. This block is
+# orientation, not a snapshot. It deliberately avoids exact counts, line
+# numbers, hardcoded local site names, stale negative claims, and frozen bug
+# lists. The PR bot must read the diff and current source for truth; if
+# anything below contradicts the source, the source wins and this context
+# block should be flagged for refresh.
+############################################################
+
+[repository_context]
+
+source = "Generated from @docs/ and the current repository files. Use as PR review guidance, not as a frozen source of truth."
+purpose = "Durable review context for PR-Agent reviews of this Frappe v15 / ERPNext custom jewellery manufacturing app."
+
+review_context = '''
+============================================================
+1. REPOSITORY ORIENTATION
+============================================================
+
+The current source and docs/ indicate this is a Frappe v15 / ERPNext custom app for jewellery manufacturing. It is a thick customization layer on top of standard ERPNext, not a standalone product. modules.txt declares three Frappe modules:
+
+- A core manufacturing module covering planning, work orders, per-step manufacturing operations, a virtual MOP Log ledger that bridges into Stock Entry, refining, QC, metal / diamond / gemstone conversions, and certification flows.
+- A design pipeline module ("Gurukrupa Exports") covering sketch / CAD / design-order workflows that feed manufacturing, with per-customer Diamond / Gemstone / Making Charge price lists.
+- A subcontracting module ("Customer Subcontracting") implemented as doc_events handlers (no DocTypes) that rename parent and child batches at Stock Entry and Purchase Receipt before_submit using a customer-aware naming scheme.
+
+The current source includes hardcoded company, customer, supplier, and warehouse identifiers in several files. Treat the app as currently deployment-specific; multi-tenant rollout would require centralizing these identifiers.
+
+============================================================
+2. DOCUMENTED CORE WORKFLOWS
+============================================================
+
+- Make-to-order manufacturing chain: Sales Order -> Manufacturing Plan -> Parent Manufacturing Order -> Manufacturing Work Order -> Manufacturing Operation -> Department IR / Employee IR -> MOP Log -> Stock Entry (materialized by the daily MOP EOD sync). Treat changes anywhere in this chain as cross-cutting.
+
+- MOP Log dual-writer flow: virtual writers (Department IR / Employee IR submit, certain Manufacturing Operation paths) write rows that the EOD sync materializes; a bridge writer on Stock Entry submit writes rows already backed by the SE. Both paths must coexist without double-processing the same physical movement.
+
+- Stock Reservation Entry flow: reservations originate from MWO submit, EIR Receive, Stock Entry-derived flows, and Main Slip injection. Auto-created Stock Entries that should be reserved must carry the source marker the reservation lookup expects.
+
+- Main Slip Receive injection: a high-risk auto-create flow that walks Main Slip batch_details when a Receive shows extra returned metal and emits Material Transfer or Repack Stock Entries with an `employee_ir` header marker. Inventory-type priority order is documented as Regular Stock -> Customer Goods -> Pure Metal.
+
+- Customer-subcontracting batch rename: runs on Stock Entry and Purchase Receipt before_submit; renames parent and child batches using the documented `{customer}-{YearCode}{Month}-{item_code}-{serial}` scheme (YearCode mapping 0->J, 1->A, ..., 9->I). Touches batch identity and is high-impact for stock traceability.
+
+- Pricing and BOM: standard ERPNext BOM (with custom fields) coexists with a custom Tracking BOM bound to PMO. Customer-aware pricing branches between a customer-specific path and a standard path in multiple files.
+
+- Sketch / design pipeline: Sketch Order Form spawns Sketch Order(s) which walk through rough / final / CMO / HOD / Hold / Rejected stages driven by a fixture-defined workflow, eventually producing Item template(s).
+
+- Daily background processing: a scheduled MOP EOD sync materializes virtual MOP Log rows into Stock Entries. Other background-work sites exist for manual MOP sync, inter-branch JV reconciliation, bulk update, quotation pricing, and a subcontracting helper. When PRs change any of these, verify the current set against `hooks.py` and source `frappe.enqueue` call sites.
+
+- Custom Submission Queue routing: several heavy submittable doctypes (the IR documents, Product Certification, Stock Entry, Main Slip) are routed to the long queue with an extended timeout via an override of Frappe's Submission Queue.
+
+============================================================
+3. LOAD-BEARING INVARIANTS (PROTECT THESE)
+============================================================
+
+- The MOP Log idempotency key for active rows includes voucher_type, voucher_no, row_name, manufacturing_operation, item_code, batch_no, and is_cancelled=0. New writers must respect this key.
+
+- The is_synced flag is the dedup mechanism between virtual writers and the Stock Entry bridge writer. Virtual writers set is_synced=0 and the EOD sync flips it to 1; the SE bridge writer sets is_synced=1 directly because the SE already represents a physical movement. New writers must declare which side they are on.
+
+- Cancellation of MOP Log rows is done by marking is_cancelled=1, not by deletion — to preserve audit lineage.
+
+- Auto-created Stock Entries that should be reserved must carry the expected source marker on the SE header. Without it, reservation lookups silently miss the SE.
+
+- Main Slip Receive injection must preserve per-segment source warehouse, the documented inventory-type priority order, and the source marker on auto-created SEs.
+
+- Department IR Receive clones all Issue MOP Logs in ascending flow_index. Code in the relevant writer should preserve this ordering rather than reading only a max-tier snapshot.
+
+- Standard ERPNext Stock Entry / Stock Reconciliation / Stock Ledger Entry / Serial and Batch Bundle / Submission Queue controllers are overridden. PRs touching those override classes should preserve the parent-method chain where appropriate, and explicitly justify any case where super() is intentionally not called.
+
+- Several Frappe / ERPNext core whitelisted methods are intercepted via override_whitelisted_methods. Treat changes to those interceptors as upgrade-sensitive.
+
+- Payment Entry uses the same handler for on_submit and on_update_after_submit. Logic there must be idempotent.
+
+- The after_migrate hook re-applies every JSON file under custom_fields/ and property_setter/ on every bench migrate. Edits to those folders ship on the next deploy with no separate fixture step. Removed-but-still-applied fields are not auto-deleted; cleanup is manual.
+
+- Patches must be idempotent and safe to re-run on copied sites.
+
+- The Custom Submission Queue's long-queue routing for the listed heavy doctypes carries an extended timeout. Lowering it without checking actual submit times can break large submissions.
+
+============================================================
+4. HIGH-RISK REVIEW AREAS BY RESPONSIBILITY
+============================================================
+
+- Overridden ERPNext core controllers: bench-wide blast radius. Verify super() chaining, behavior on submit / cancel / resubmit, and SLE / batch / serial / SRE consistency.
+
+- Overridden core whitelisted methods: replacing core API endpoints affects every caller including standard ERPNext UI buttons. Verify response shape and behavior parity.
+
+- MOP Log writers and readers: verify the idempotency key, the is_synced direction, voucher-scoped source queries (no bare "latest by manufacturing_operation"), and cancellation behavior. Cross-check against the EOD sync expectations.
+
+- The MOP EOD sync background job: verify per-hop savepoint behavior, the loss-as-Repack-SE branch, and grouping keys.
+
+- Stock Reservation Entry creation, cancellation, and unreservation: verify per-source-voucher idempotency, marker presence on auto-created SEs, and cancel / resubmit symmetry.
+
+- Main Slip Receive injection: verify inventory-type priority, source-warehouse preservation, alloy-before-pure-metal preference, and the marker on auto-created SEs.
+
+- Department IR / Employee IR submit paths: multiple chained MOP Log writers, status transitions, and SE side effects. EIR carries nested helpers across several files; expect cross-file impact.
+
+- Manufacturing Operation controller: includes a very large finished-goods-BOM builder reachable from Serial Number Creator submit. Adding inline work in this path is a likely performance regression.
+
+- Tracking BOM and pricing helpers: customer-aware pricing branches exist; helpers resolve diamond, gemstone, making-charge, and gold rates from per-customer price-list masters. Pricing changes should be reviewed for customer isolation and parity between Quotation, Sales Order, Sales Invoice, and BOM rate computations.
+
+- Customer Subcontracting batch rename: touches batch identity. Verify customer scoping, naming-collision handling, and parent / child relationship integrity.
+
+- Whitelisted methods: when adding or changing a whitelisted method, verify permission enforcement, allowlists for dynamic doctype / field / method / filter / order_by arguments, and a minimal response payload. Explicitly check whether `allow_guest=True` was introduced. Avoid generic database-access patterns.
+
+- Background jobs / scheduler / Custom Submission Queue: verify retry safety, deduplication, timeout assumptions, transaction boundaries, and that enqueue is not happening from validate.
+
+- Migration patches and fixture / schema changes: verify idempotency and safe re-runs on copied sites. Coordinate JSON edits under custom_fields/ and property_setter/ with fixtures/custom_field.json and fixtures/property_setter.json so the two paths do not drift.
+
+- Workflow fixture changes (Sketch Order workflows): verify state names, transitions, and role assignments stay consistent with controller logic that branches on workflow_state.
+
+- Hardcoded company / customer / supplier / warehouse / item names: ask whether new branching should live in a Setting, Company-level flag, or Customer-level configuration.
+
+- Raw SQL / dynamic queries: parameterize values; allowlist dynamic identifiers.
+
+- External integrations: if a PR introduces external HTTP integrations, webhooks, website routes, portal pages, or `allow_guest=True` endpoints, require authentication, permission checks, error handling, logging, documentation, and operational guidance.
+
+- Client scripts (JS): JS must not be the sole enforcement path for any rule that affects stock, GL, manufacturing state, weight, loss, pricing, or permissions.
+
+============================================================
+5. DIRECT PR REVIEW RULES
+============================================================
+
+- When a PR touches MOP Log behavior, verify the idempotency key remains intact, the is_synced direction matches the writer role, and cancellation marks rather than deletes rows.
+
+- When a PR touches the EOD MOP sync, verify grouping keys, per-hop savepoint behavior, and the loss-as-Repack-SE emission branch.
+
+- When a PR touches Department IR or Employee IR, verify both Issue and Receive branches, MOP Log row generation, status transitions, and any auto-created SEs (markers, warehouses, batches). Receive must continue to clone all Issue logs in ascending flow_index.
+
+- When a PR touches Main Slip or its injection helpers, verify inventory-type priority, source-warehouse preservation, alloy-before-pure-metal preference, and SE marker presence.
+
+- When a PR touches an override of a Frappe / ERPNext core controller or whitelisted method, verify super() chaining (where appropriate) and behavior parity for both Desk UI and background flows.
+
+- When a PR touches Stock Reservation Entry creation or cancellation, verify duplicate prevention by source voucher, marker presence on auto-created SEs, and cancel / resubmit symmetry.
+
+- When a PR adds a whitelisted method, verify permission enforcement, allowlists for dynamic arguments, and a minimal response payload. Explicitly check whether `allow_guest=True` was introduced.
+
+- When a PR touches fixtures, workflows, custom_fields/, or property_setter/ JSON, verify they remain consistent with controller logic and with each other. Cross-reference any change to seeded Stock Entry Type names against client-side and server-side checks that filter by SE type name.
+
+- When a PR adds or modifies a patch, verify idempotency and safe re-runs.
+
+- When a PR adds or modifies a background job or `frappe.enqueue` site, verify retry safety, deduplication, timeout assumptions, transaction boundaries, and that enqueue is not happening from validate.
+
+- When a PR adds inline carat-to-gram conversion or M / F / D / G / O variant prefix branching, prefer the existing shared mapping rather than adding a new inline duplicate.
+
+- When a PR adds raw SQL, verify parameterization, identifier allowlisting, explicit SELECT columns, and bounded result sets.
+
+- When a PR touches Payment Entry on_submit or on_update_after_submit, verify the handler stays idempotent — both events use the same handler.
+
+- When a PR touches client-side pricing or weight logic, verify the same rule exists server-side.
+
+- When a PR re-enables any commented-out monkey-patch in hooks.py, call it out explicitly: those changes are bench-wide.
+
+- When a PR adds new hardcoded company / customer / supplier / warehouse identifiers, ask whether the change should instead live in a Setting, Company-level flag, or Customer-level configuration.
+
+- Always read the diff against current source. If this context block contradicts what the diff or source actually shows, trust the source and note that the context may need updating.
+
+============================================================
+6. TESTING EXPECTATIONS (BY CHANGE TYPE)
+============================================================
+
+- Lifecycle changes: request tests for the specific lifecycle event affected (validate, before_save, before_submit, on_submit, before_cancel, on_cancel, on_update_after_submit), and for submit / cancel / resubmit symmetry where stock, GL, MOP Log, or SRE are affected.
+- MOP Log changes: request tests that exercise the idempotency key, the is_synced behavior for the writer role, cancellation-by-marking, and the EOD sync interaction.
+- Stock Reservation Entry changes: request tests for marker presence, duplicate prevention by source voucher, and cancellation / unreservation symmetry on resubmit.
+- Patch changes: request idempotency / safe re-run verification.
+- Background jobs: request duplicate-execution and retry-safety verification.
+- Whitelisted methods: request both allowed-user and denied-user coverage. For methods that take dynamic doctype / field / method arguments, request input-validation tests.
+- Pricing / BOM changes: request affected-pricing-path coverage and parity checks across Quotation, Sales Order, Sales Invoice, and Tracking BOM.
+- Workflow fixture changes: request a path-through test of the affected state transitions.
+- Documentation-only changes: verify the docs match current source and avoid environment-specific commands.
+- Test asks should name the exact behavior, the affected role / user, the doctype / method, and the expected outcome — not generic "add tests" comments.
+- Test commands are bench-driven. Use placeholders such as `bench --site <site_name> run-tests --app <app_name>` and `bench --site <site_name> migrate` rather than hardcoding any specific local site name; any local default site mentioned in docs is environment-specific.
+
+============================================================
+7. DOCUMENTATION UPDATE EXPECTATIONS
+============================================================
+
+PRs should update the relevant docs in these cases:
+- Pipeline shape changes (new stage, new branch, new auto-create flow).
+- MOP Log invariant changes (writers, readers, idempotency key, is_synced semantics).
+- Override-class behavior changes (Stock Entry, SLE, SBB, Submission Queue, Stock Reconciliation).
+- New scheduler entries, new background-job sites, new Custom Submission Queue routings.
+- New whitelisted methods, especially ones that read or mutate sensitive data.
+- New custom_fields/ or property_setter/ JSON bundles, since these auto-deploy on the next bench migrate.
+- New site-specific assumptions (company, customer, supplier, warehouse, item).
+- Renamed or removed fields, especially those backed by patches.
+
+============================================================
+8. CONFIGURATION AND ENVIRONMENT GUIDANCE
+============================================================
+
+- All extension wiring lives in hooks.py. Re-enabling commented-out monkey-patch blocks (e.g. GST e-invoice, ERPNext core method swaps, auth_hooks) is bench-wide.
+- Single DocTypes drive runtime configuration (notably MOP Settings, which lists Stock Entry Types eligible for reservation and exposes a manual-sync entry point).
+- patches.txt controls which patches run on bench migrate. Patches that exist on disk but are not listed there should be assumed dead unless confirmed otherwise.
+- Fixtures cover workflows, workflow states, workflow action masters, a small role list, and a narrowly-filtered Custom Field set; broader Custom Field and Property Setter customization happens via JSON folders applied by after_migrate. Drift between the two paths is a recurring source of bugs.
+- Treat any documented local default site name as environment-specific. PR-Agent output should use `<site_name>` placeholders unless the target environment confirms the actual site.
+- If a PR introduces external secrets, API keys, or third-party integrations, require explicit documentation, secret-management guidance, error handling, and operational notes.
+
+============================================================
+9. DOCS MAP FOR REVIEWERS
+============================================================
+
+The forensic documentation under docs/ groups by purpose. Use the relevant group when a PR's scope is unclear:
+
+- Scope and evidence rules: defines what the docs cover and the rule that every claim is sourced from a file. Treat docs as orientation; if a doc claim conflicts with current source, prefer the source.
+- Architecture overview and final context summary: describe the manufacturing pipeline, the extension mechanisms, and the MOP Log dual-writer rule. Consult these when a PR touches multiple stages of the pipeline.
+- Hooks analysis: walks every entry in hooks.py — identity, asset includes, after_migrate, doctype_js, doctype_list_js, commented-out monkey-patches, doc_events with chained handlers, override_whitelisted_methods, override_doctype_class, scheduler_events, fixtures filter spec.
+- DocType deep dives: per-DocType walkthroughs covering files, fields, controller methods, doc events, relationships, and risks.
+- Python organization (doc-events index, big-file deep dives, root modules, patches): use these when a PR touches Python under doc_events/, customization/, root modules, or patches/.
+- JavaScript surface: maps the JS surface and the most-called backend methods.
+- API and whitelisted methods: describes the API surface, the overridden core whitelisted methods, and the highest-risk whitelisted methods.
+- Database / ER model: describes inferred relationships between custom and standard DocTypes.
+- End-to-end flows: traces concrete server-side paths for the major flows.
+- Dependency graph: cross-cutting tables for hooks, function call graphs, JS-to-backend call map, and scheduler targets.
+- Reports / pages / templates: lists custom reports, inline Jinja templates, and the website / portal surface state. One report is also imported and called from runtime code, so changes to its functions affect runtime behavior beyond the Reports UI.
+- Patches / fixtures / migration: describes how after_migrate re-applies all JSON under custom_fields/ and property_setter/ on every bench migrate, the patches.txt order, and the fixture-export filter.
+- Audits and bug register: describe risk themes, fragile patterns, and a confirmed-issues backlog. Reference these when a PR touches a related responsibility area; do not raise unrelated entries.
+- Generated catalogs: machine-extracted snapshots of source-file inventory, DocType fields, Python functions, JavaScript calls, API whitelists, hook targets, ER relationships, and risk occurrences. Treat them as "shape of the source as last regenerated"; verify against the diff if the source has changed.
+- README and current forensic report: navigation entry points.
+
+============================================================
+10. ANTI-HALLUCINATION RULE FOR THE PR BOT
+============================================================
+
+- The PR bot must read the diff and surrounding source files. This block is orientation, not truth.
+- If source and this context disagree, source wins. Note in the review that the repository context may need refreshing.
+- If docs and source disagree, source wins and the docs may need updating.
+- Do not raise risks from this block unless the PR actually touches the related code path.
+- Do not invent files, fields, DocTypes, hooks, fixtures, patches, commands, or workflows that are not visible in the current source.
+- When recommending commands, use placeholders such as `<site_name>` and `<app_name>` rather than hardcoded local values.
+- Only request tests relevant to the changed behavior; do not append generic "add tests" asks.
+
+============================================================
+11. RECENT FEATURE WORK INVARIANTS (verify against current source)
+============================================================
+
+The following rules reflect the most recent feature work on Make Receive Entry, Employee IR loss posting, EOD sync, and Manufacturer-driven loss item resolution. Apply these only when a PR touches the related areas. If the source has moved on, trust the source.
+
+11.1 Make Receive Entry on Manufacturing Operation
+- Source for the dialog and server-side validation MUST be active Stock Reservation Entry rows linked to the Manufacturing Operation's manufacturing_work_order. Active means docstatus=1 plus positive remaining qty (reserved_qty - delivered_qty for Qty-based; per-batch qty - delivered_qty for Serial-and-Batch). Do NOT hardcode SRE status string allowlists.
+- Authoritative remaining qty for an active SRE is `(reserved_qty - delivered_qty)`. Do NOT also subtract historical Material Receive (WORK ORDER) qty — partial-receive flow cancels and recreates the SRE so its remaining is already net of past receives. Double-subtracting is a regression source.
+- Server method MUST re-fetch every Stock Reservation Entry row from the database. Client-supplied warehouse / item / available_qty are advisory only.
+- Reject `qty <= 0`, `qty > available_qty + tolerance`, wrong-MWO SREs, and cancelled SREs. Tolerance is computed from System Settings `float_precision` (e.g. 10**-3 = 0.001).
+- Idempotency: a `custom_request_id` (Data, hidden, no_copy, read_only) field on Stock Entry deduplicates double-clicks for the same Manufacturing Operation + stock_entry_type. The same request_id must return the existing SE without creating another.
+- Material Receive (WORK ORDER) Stock Entry: source from SRE warehouse, target from `(department, warehouse_type="Raw Material")`. Reuse existing project pattern; do not hardcode warehouse names.
+- MOP Log writes for the SE happen via the existing `sync_mop_log_for_stock_entry` bridge (is_synced=1). The Make Receive Entry server method must NOT write MOP Log directly.
+
+11.2 Stock Reservation Entry replacement (cancel + recreate)
+- Full receive: cancel the original SRE and do NOT create a replacement.
+- Partial receive: cancel original; create replacement only if remaining qty is strictly greater than the float tolerance. For Serial-and-Batch SREs, also require at least one positive sb_entries row — otherwise return None and skip recreation.
+- Replacement SRE must set the ERPNext-mandatory field `available_qty` (label "Available Qty to Reserve"). Validation lives in ERPNext at `stock_reservation_entry.validate_mandatory`. Mirror the existing project convention from `stock_reservation_entry_for_mwo` in `doc_events/stock_entry.py`:
+  available_qty = max(get_available_qty_to_reserve(item_code, warehouse, batch_no=...), reserved_qty)
+  Resolve `has_batch_no` / `has_serial_no` from Item master; copy voucher_type / voucher_no / voucher_detail_no / voucher_qty / company / stock_uom / reservation_based_on / manufacturing_work_order / manufacturing_operation from the original SRE.
+- Persist with `insert(ignore_links=1)` then `submit()` to match the project's existing SRE pattern; do NOT use `save()` here.
+- Never submit an SRE with zero `reserved_qty`, zero per-batch `sb_entries.qty`, or no positive batch rows when `reservation_based_on != "Qty"`. The "Available Qty to Reserve is required" error is the canonical symptom of a missing/zero `available_qty` or empty positive batches.
+- Do not work around with fake quantities (0.001), `ignore_validate`, `ignore_mandatory`, or `ignore_permissions` to silence the validation; fix the zero-qty source.
+
+11.3 Employee IR loss MOP Log (qty_change rule)
+- For each Employee Loss Detail and Manually Book Loss Detail row, the loss is posted as a real MOP Log movement that REDUCES the Manufacturing Operation weight bucket. Concretely:
+  qty_change                       = -loss_weight_in_grams
+  qty_after_transaction            = previous_balance - loss_weight (across overall, item-based, and batch-based views)
+  pcs_change / pcs_after_*         = preserved at the prior values (loss is recorded by weight, not pieces)
+  flow_index                       = same as the latest movement (loss is not a transit hop)
+- `MOPLog.validate()` writes `qty_after_transaction` into the prefix bucket on Manufacturing Operation (M->net_wt, F->finding_wt, D->diamond_wt, G->gemstone_wt, O->other_wt) — so the post-loss weight is reflected automatically. Do not duplicate that update.
+- A previous design used `qty_change=0` and an audit-only `log_category="Loss Attribution"` filter. That convention is INCORRECT for MOP loss deltas: it left the MOP weight unchanged. PRs that introduce `qty_change=0` for loss rows that must reduce the bucket should be flagged.
+- Carat-denominated rows (typical for D / G items) are converted to grams via `carat * 0.2` BEFORE writing `qty_change` and `loss_weight`. The MOP balance is gram-based.
+- is_synced=1 on the loss row: the SE backing the receive already exists, EOD must not re-materialize the loss row.
+- Idempotency on `(voucher_type="Employee IR", voucher_no, manufacturing_operation, loss_source_row, loss_type, is_cancelled=0)`. The existing blanket EIR cancel path (set is_cancelled=1 for all MOP Log rows with that voucher_type/voucher_no) catches loss rows automatically.
+- The balance-helper queries (`get_current_mop_balance_rows`, the manual-loss validator, the EOD `_get_unsynced_mop_groups`) MUST include loss rows in the balance calculation because they post a real qty_change. Do NOT add a `log_category` filter that excludes them; the existing `is_cancelled=0` (and `is_synced=0` for EOD) filters are sufficient.
+
+11.4 Employee IR loss calculation (do not rewrite)
+- The proportional formula is: `loss_calculation = total_loss_weight * (item_weight / total_eligible_weight)`. Only items with prefixes M and F are eligible for auto-loss distribution. Same item across multiple batches stays row-wise (do not merge by item_code).
+- Diamond / Gemstone manual booked loss is converted carat -> gram (`carat * 0.2`) before validation against the available baseline.
+- `book_metal_loss` reads MOP Log balance via the alias `qty_after_transaction_batch_based as qty` (gram-based). A historical bug previously aliased pcs_after_transaction_batch_based as qty (forensic C4); the fix is in. PRs that revert to the pcs alias should be rejected.
+- Manual booked loss validation has TWO layers and both must remain:
+  (a) per-row floor: row.proportionally_loss <= MOP Log latest qty_after_transaction_batch_based for (item, batch).
+  (b) per-MWO total cap: sum(manual loss for MWO, in grams) <= sum(gross_wt - received_gross_wt for MWO across employee_ir_operations).
+  The second cap uses the TRUE baseline `(gwt - r_gwt)` per MWO, NOT `mop_loss_details_total` (which is already net of manual and would be circular).
+- Employee IR `9jbcvj1b85` was used as a debug reference for the loss-MOP-Log fix. It must NOT be hardcoded in code, fixtures, or tests.
+
+11.5 Manufacturer-driven loss item mapping (NO MOP Settings dust_item)
+- Loss / dust target item is resolved from the Manufacturer custom child table `custom_variant_loss_table` (DocType `Variant Loss Table`, fields `variant`, `loss_variant`, `loss_type`, with `parent`/`parenttype="Manufacturer"`/`parentfield="custom_variant_loss_table"`).
+- The new helper `get_loss_item_from_manufacturer_mapping(item_code, manufacturer, loss_type="Loss")` is manufacturer-scoped. The older `get_item_loss_item` is manufacturer-agnostic (queries the standalone Variant Loss Table) and falls through to the C3-buggy `create_loss_item` (always-throw debug leftover at line 804 of `main_slip.py`); use the new helper for any new loss-item resolution.
+- Expected mappings (read from Manufacturer; do not hardcode in code):
+  M + Loss -> ML
+  F + Loss -> FL
+  D + Loss -> DL ; D + Missing -> DM ; D + Burn -> DB ; D + Broken -> DBK
+  G + Loss -> GL ; G + Broken -> GB
+  O + Loss -> OL
+- For Diamond / Gemstone loss, the loss_type is read from the `manually_book_loss_details` row.
+- Missing mapping or unresolvable target loss item must throw a clear configuration error pointing to "Manufacturer {0} -> Variant Loss Table". The error must NOT mention MOP Settings.
+- DO NOT add a `dust_item` field to MOP Settings. DO NOT introduce any MOP-Settings-driven loss-item resolution. The existing MOP Settings DocType has only `stock_entry_type_to_reservation` and `sync_mop_log` button (verify against current JSON before reviewing).
+- EOD `_create_loss_entries` in `mop_eod_sync.py` calls the new helper. The error path propagates as a clear ValidationError; there is no silent skip / no MOP Settings fallback.
+
+11.6 EOD sync gap-fill (single sync; idempotent)
+- There is exactly one EOD sync: `mop_eod_sync.sync_mop_logs`, scheduled `daily_long` in `hooks.py`. Do not introduce a parallel sync.
+- Manufacturing Operation gets a `last_eod_sync_on` Datetime stamp ONLY after a successful per-group sync (inside the savepoint release path). Failed groups (rolled back) MUST NOT stamp.
+- SRE reconciliation is audit-first: `_reconcile_reservations_for_mwo(mwo, dry_run=True)` is called per processed MWO. Default `dry_run=True` only logs would-cancel decisions; destructive cancellation requires explicit operator action via console (`dry_run=False`). PRs MUST NOT default-flip this to destructive.
+- Reconciliation only cancels SREs whose latest MOP Log balance for `(item_code, to_warehouse=SRE.warehouse)` is zero. Ambiguous (positive but partial) balances are skipped.
+- EOD never duplicates main-slip-required behavior. `is_main_slip_required=1` flow is handled at Employee IR Receive submit by `inject_extra_metal_for_eir_receive` in `main_slip_inject.py`; those SEs surface to EOD as is_synced=1 rows.
+- EOD continues to create `Material Transfer to Department` SE type and `Repack` for loss. Do not rename to `Material Transfer (WORK ORDER)` casually — custom field `depends_on` clauses, reports, and downstream hooks key on the existing strings.
+- The audit doc lives at `docs/audits/eod_sync_audit.md`; cross-reference when reviewing EOD changes.
+
+11.7 New custom fields (re-applied on every bench migrate)
+- `Stock Entry.custom_request_id` (Data, len 36, read_only, no_copy, hidden, depends_on Material Receive (WORK ORDER)) — Make Receive Entry idempotency.
+- `MOP Log.log_category` (Select: blank | "Loss Attribution"), `loss_type` (Select: blank | "Auto Employee Loss" | "Manually Booked Loss"), `loss_weight` (Float, precision 3, gram), `loss_percentage` (Float, precision 4), `loss_source_row` (Data) — additive, do not break existing MOP Log validate.
+- `Manufacturing Operation.last_eod_sync_on` (Datetime, read_only, no_copy) — EOD observability stamp.
+- `MOP Settings` has NO `dust_item` field today (and must not gain one — see 11.5).
+- All four JSON files live under `jewellery_erpnext/custom_fields/` and are re-applied by `migrate.py` `after_migrate` on every bench migrate.
+
+11.8 Test infrastructure
+- Authored unit tests live at `jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry.py`, `test_employee_ir_loss_mop_log.py`, `test_eod_sync_gap_fill.py` (plus the pre-existing `test_stock_reservation_entry_mwo.py`). They are mock-heavy unit tests; no DB fixtures. The folder has an `__init__.py` so `unittest.discover` picks them up.
+- The full-app `bench --site <site_name> run-tests` may be blocked by an unrelated `india_compliance` `before_tests` fixture. As a workaround, run via `python -m unittest` with `frappe.init` + `frappe.connect` and load by fully-qualified module name.
+- Common pre-existing test failures unrelated to this feature work (do NOT block PRs unless the PR touches them):
+  - `test_mop_log.TestDepartmentIRIdempotency.*` and main-slip-required relaxations — outdated against commit 712ac8f (DIR Receive clones all Issue logs in ascending flow_index).
+  - `test_main_slip_inject` — module-level fixture issue.
+  - `test_employee_ir.TestEmployeeIRReceiveLineageGuard.test_receive_throws_when_issue_logs_miss_current_balance_component` — log_error call-count assertion against unchanged code.
+
+11.9 Anti-patterns to flag in PR review
+- Make Receive Entry sourcing rows from `mop_balance_table` instead of Stock Reservation Entry.
+- `_build_replacement_sre` with no `available_qty` set, or saving/submitting an SRE with `reserved_qty <= tolerance` or empty positive `sb_entries`.
+- A loss MOP Log writer with `qty_change=0` when the row is supposed to reduce the Manufacturing Operation weight bucket.
+- A `log_category="Loss Attribution"` filter added to `get_current_mop_balance_rows`, `validate_manually_book_loss_details` per-row balance check, or `_get_unsynced_mop_groups` — these break the post-loss balance.
+- A new `dust_item` field on MOP Settings or any code path reading `MOP Settings.dust_item`.
+- `get_item_loss_item` used for new code paths (manufacturer-agnostic; falls through to C3-buggy `create_loss_item`). New code should use `get_loss_item_from_manufacturer_mapping`.
+- EOD sync renaming `Material Transfer to Department` to anything else without explicit migration coverage.
+- `_reconcile_reservations_for_mwo` defaulted to `dry_run=False`.
+- Hardcoded warehouse names, item codes, manufacturer names, customer names in code paths that should resolve from Manufacturer / department / warehouse_type config.
+- Reverting `book_metal_loss` to alias `pcs_after_transaction_batch_based as qty` (forensic bug C4).
 '''

--- a/jewellery_erpnext/hooks.py
+++ b/jewellery_erpnext/hooks.py
@@ -1,5 +1,3 @@
-from . import __version__ as app_version
-
 app_name = "jewellery_erpnext"
 app_title = "Jewellery Erpnext"
 app_publisher = "Nirali"
@@ -186,6 +184,7 @@ override_doctype_class = {
 	"Stock Entry": "jewellery_erpnext.jewellery_erpnext.customization.stock_entry.stock_entry.CustomStockEntry",
 	"Stock Reconciliation": "jewellery_erpnext.jewellery_erpnext.doctype.stock_reconciliation_template.stock_reconciliation_template_utils.CustomStockReconciliation",
 	"Stock Ledger Entry": "jewellery_erpnext.jewellery_erpnext.customization.stock_ledger_entry.stock_ledger_entry.CustomStockLedgerEntry",
+	"Stock Reservation Entry": "jewellery_erpnext.jewellery_erpnext.customization.stock_reservation_entry.stock_reservation_entry.CustomStockReservationEntry",
 	"Serial and Batch Bundle": "jewellery_erpnext.jewellery_erpnext.customization.serial_and_batch_bundle.serial_and_batch_bundle.CustomSerialandBatchBundle",
 	"Submission Queue": "jewellery_erpnext.jewellery_erpnext.customization.submission_queue.submission_queue.CustomSubmissionQueue",
 	# "Purchase Receipt": "jewellery_erpnext.jewellery_erpnext.doc_events.purchase_receipt.CustomPurchaseReceipt",

--- a/jewellery_erpnext/jewellery_erpnext/custom_fields/manufacturing_operation.json
+++ b/jewellery_erpnext/jewellery_erpnext/custom_fields/manufacturing_operation.json
@@ -1,0 +1,15 @@
+{
+ "Manufacturing Operation": [
+  {
+   "dt": "Manufacturing Operation",
+   "fieldname": "last_eod_sync_on",
+   "fieldtype": "Datetime",
+   "insert_after": "is_received_gross_greater_than",
+   "is_system_generated": 1,
+   "label": "Last EOD Sync On",
+   "no_copy": 1,
+   "read_only": 1,
+   "module": "Jewellery Erpnext"
+  }
+ ]
+}

--- a/jewellery_erpnext/jewellery_erpnext/custom_fields/mop_log.json
+++ b/jewellery_erpnext/jewellery_erpnext/custom_fields/mop_log.json
@@ -1,0 +1,64 @@
+{
+ "MOP Log": [
+  {
+   "dt": "MOP Log",
+   "fieldname": "log_category",
+   "fieldtype": "Select",
+   "options": "\nLoss Attribution",
+   "default": "",
+   "insert_after": "is_synced",
+   "is_system_generated": 1,
+   "label": "Log Category",
+   "read_only": 1,
+   "module": "Jewellery Erpnext"
+  },
+  {
+   "dt": "MOP Log",
+   "fieldname": "loss_type",
+   "fieldtype": "Select",
+   "options": "\nAuto Employee Loss\nManually Booked Loss",
+   "default": "",
+   "depends_on": "eval:doc.log_category==\"Loss Attribution\"",
+   "insert_after": "log_category",
+   "is_system_generated": 1,
+   "label": "Loss Type",
+   "read_only": 1,
+   "module": "Jewellery Erpnext"
+  },
+  {
+   "dt": "MOP Log",
+   "fieldname": "loss_weight",
+   "fieldtype": "Float",
+   "precision": "3",
+   "depends_on": "eval:doc.log_category==\"Loss Attribution\"",
+   "insert_after": "loss_type",
+   "is_system_generated": 1,
+   "label": "Loss Weight (g)",
+   "read_only": 1,
+   "module": "Jewellery Erpnext"
+  },
+  {
+   "dt": "MOP Log",
+   "fieldname": "loss_percentage",
+   "fieldtype": "Float",
+   "precision": "4",
+   "depends_on": "eval:doc.log_category==\"Loss Attribution\"",
+   "insert_after": "loss_weight",
+   "is_system_generated": 1,
+   "label": "Loss Percentage",
+   "read_only": 1,
+   "module": "Jewellery Erpnext"
+  },
+  {
+   "dt": "MOP Log",
+   "fieldname": "loss_source_row",
+   "fieldtype": "Data",
+   "depends_on": "eval:doc.log_category==\"Loss Attribution\"",
+   "insert_after": "loss_percentage",
+   "is_system_generated": 1,
+   "label": "Loss Source Row",
+   "read_only": 1,
+   "module": "Jewellery Erpnext"
+  }
+ ]
+}

--- a/jewellery_erpnext/jewellery_erpnext/custom_fields/stock_entry.json
+++ b/jewellery_erpnext/jewellery_erpnext/custom_fields/stock_entry.json
@@ -1005,6 +1005,21 @@
     "hidden": 1,
     "search_index": 1,
     "module": "Jewellery Erpnext"
+   },
+  {
+    "dt": "Stock Entry",
+    "fieldname": "custom_request_id",
+    "fieldtype": "Data",
+    "length": 36,
+    "depends_on": "eval:doc.stock_entry_type==\"Material Receive (WORK ORDER)\"",
+    "insert_after": "to_rename",
+    "is_system_generated": 1,
+    "label": "Make Receive Entry Request ID",
+    "no_copy": 1,
+    "read_only": 1,
+    "hidden": 1,
+    "search_index": 1,
+    "module": "Jewellery Erpnext"
    }
  ]
 }

--- a/jewellery_erpnext/jewellery_erpnext/customization/stock_reservation_entry/stock_reservation_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/customization/stock_reservation_entry/stock_reservation_entry.py
@@ -1,0 +1,21 @@
+from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+	StockReservationEntry,
+)
+
+
+class CustomStockReservationEntry(StockReservationEntry):
+	def auto_reserve_serial_and_batch(self, based_on: str | None = None) -> None:
+		# MWO + MOP flow pre-populates sb_entries with the exact operator-picked
+		# batch in stock_reservation_entry_for_mwo (doc_events/stock_entry.py).
+		# ERPNext's auto-pick would clear and re-FIFO those rows, breaking
+		# per-operation batch lineage downstream in MOP Log / EOD sync.
+		if (
+			self.get("manufacturing_work_order")
+			and self.get("manufacturing_operation")
+			and self.get("sb_entries")
+			and self.get("reservation_based_on")
+			and self.get("reservation_based_on") == "Serial and Batch"
+		):
+			return
+
+		super().auto_reserve_serial_and_batch(based_on)

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/quotation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/quotation.py
@@ -52,6 +52,13 @@ def create_bom_scientifically(self):
 	create_tracking_bom_directly(self)
 
 
+# Backward-compat alias. test_quotation.py imports `create_new_bom` by name;
+# the implementation was renamed to `create_bom_scientifically` in PR #506.
+# Without the alias the full `bench run-tests --app jewellery_erpnext`
+# invocation crashes at module-load time when test_quotation imports.
+create_new_bom = create_bom_scientifically
+
+
 @frappe.whitelist()
 def generate_bom(name):
 	self = frappe.get_doc("Quotation", name)

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/stock_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/stock_entry.py
@@ -661,6 +661,9 @@ def stock_reservation_entry_for_mwo(self):
 			)
 
 	for row in self.items:
+		if self.stock_entry_type == "Material Receive (WORK ORDER)":
+			create_mop_log(self, row, is_synced=True)
+			continue
 		# Repack / issue rows only have s_warehouse; reserve against inbound stock only.
 		if not row.get("t_warehouse"):
 			continue
@@ -681,7 +684,9 @@ def stock_reservation_entry_for_mwo(self):
 		qty_to_be_reserved = flt(qty_to_be_reserved)
 		# Employee IR extra-metal injection: stock just landed; availability checks can lag
 		# the same transaction. Reserve the inbound line qty when this SE is tied to an EIR.
-		if qty_to_be_reserved <= 0 and flt(row.qty) > 0:
+		# Gate on is_eir_injection — without the gate, regular Repack/Manufacture SEs would
+		# create SREs with no reservable qty, regressing test_skips_when_no_reservable_qty.
+		if is_eir_injection and qty_to_be_reserved <= 0 and flt(row.qty) > 0:
 			qty_to_be_reserved = flt(row.qty)
 		if qty_to_be_reserved <= 0:
 			continue

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/department_ir.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/department_ir.py
@@ -189,6 +189,19 @@ class DepartmentIR(Document):
 			},
 		)
 		if cancel:
+			# Bulk db.set_value bypasses MOPLog.validate, so capture the affected
+			# MOPs first and replay the central recompute after the flip.
+			affected_mops_recv = [
+				r[0]
+				for r in frappe.db.sql(
+					"""
+					SELECT DISTINCT manufacturing_operation FROM `tabMOP Log`
+					WHERE voucher_type = %s AND voucher_no = %s AND is_cancelled = 0
+					  AND manufacturing_operation IS NOT NULL
+					""",
+					(self.doctype, self.name),
+				)
+			]
 			frappe.db.set_value(
 				"MOP Log",
 				{
@@ -199,6 +212,12 @@ class DepartmentIR(Document):
 				"is_cancelled",
 				1,
 			)
+			from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+				recalculate_manufacturing_operation_weights,
+			)
+
+			for mop_name in affected_mops_recv:
+				recalculate_manufacturing_operation_weights(mop_name)
 			values.update(
 				{
 					"department_receive_id": None,
@@ -309,6 +328,19 @@ class DepartmentIR(Document):
 					).format(self.next_department)
 				)
 		else:
+			# Bulk db.set_value bypasses MOPLog.validate; replay the recompute
+			# after the flip so prefix buckets shed the just-cancelled rows.
+			affected_mops_iss = [
+				r[0]
+				for r in frappe.db.sql(
+					"""
+					SELECT DISTINCT manufacturing_operation FROM `tabMOP Log`
+					WHERE voucher_type = %s AND voucher_no = %s AND is_cancelled = 0
+					  AND manufacturing_operation IS NOT NULL
+					""",
+					(self.doctype, self.name),
+				)
+			]
 			frappe.db.set_value(
 				"MOP Log",
 				{
@@ -319,6 +351,12 @@ class DepartmentIR(Document):
 				"is_cancelled",
 				1,
 			)
+			from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+				recalculate_manufacturing_operation_weights,
+			)
+
+			for mop_name in affected_mops_iss:
+				recalculate_manufacturing_operation_weights(mop_name)
 		for row in self.department_ir_operation:
 			if cancel:
 				new_operation = frappe.db.get_value(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/filters.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/filters.py
@@ -4,16 +4,29 @@ import frappe
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_batch_details(doctype, txt, searchfield, start, page_len, filters):
+	# Returns batch_no candidates for Manually Book Loss Details. Filters by
+	# item_code (always required) plus manufacturing_operation and
+	# manufacturing_work_order when the row supplies them; missing filters are
+	# treated as wildcards rather than literal NULL matches so the dropdown
+	# isn't silently empty when only one of the two MOP keys is set.
 	searchfield = "batch_no"
 	ML = frappe.qb.DocType("MOP Log")
 
-	query = frappe.qb.from_(ML).select(ML.batch_no).distinct()
-
-	query = query.where(
-		(ML.item_code == filters.get("item_code"))
-		& (ML.manufacturing_operation == filters.get("manufacturing_operation"))
-		& (ML.is_cancelled == 0)
+	query = (
+		frappe.qb.from_(ML)
+		.select(ML.batch_no)
+		.distinct()
+		.where((ML.item_code == filters.get("item_code")) & (ML.is_cancelled == 0))
 	)
+
+	if filters.get("manufacturing_operation"):
+		query = query.where(
+			ML.manufacturing_operation == filters.get("manufacturing_operation")
+		)
+	if filters.get("manufacturing_work_order"):
+		query = query.where(
+			ML.manufacturing_work_order == filters.get("manufacturing_work_order")
+		)
 
 	query = (
 		query.where((ML[searchfield].like(f"%{txt}%")))

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/main_slip_inject.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/main_slip_inject.py
@@ -331,8 +331,7 @@ def _resolve_fallback_inject_segments(eir, mwo_name, total_extra, dept_wh):
 		if not alloy_item:
 			frappe.throw(
 				_(
-					"Main Slip injection: cannot resolve metal Item for "
-					"{0}/{1}/{2}/{3}"
+					"Main Slip injection: cannot resolve metal Item for {0}/{1}/{2}/{3}"
 				).format(
 					mwo["metal_type"],
 					mwo["metal_touch"],
@@ -823,8 +822,7 @@ def _resolve_inject_metal_items(mwo_name, total_extra):
 		if not item_code:
 			frappe.throw(
 				_(
-					"Main Slip injection: cannot resolve metal Item for "
-					"{0}/{1}/{2}/{3}"
+					"Main Slip injection: cannot resolve metal Item for {0}/{1}/{2}/{3}"
 				).format(
 					mwo["metal_type"],
 					mwo["metal_touch"],
@@ -834,6 +832,10 @@ def _resolve_inject_metal_items(mwo_name, total_extra):
 			)
 		items.append({"item_code": item_code, "qty": per_colour_qty, "batch_no": None})
 	return items
+
+
+def _resolve_source_warehouse(eir):
+	return _resolve_source_warehouse_raw_material(eir)
 
 
 def _resolve_source_warehouse_raw_material(eir):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/validation_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/validation_utils.py
@@ -3,6 +3,23 @@ from frappe import _
 from frappe.utils import cint, flt
 
 
+def get_loss_qty_in_grams(item_code: str | None, qty) -> float:
+	# Normalize a loss qty to grams. D/G item codes carry carat-denominated
+	# quantities; the rest of the loss pipeline (MOP Log, MOP weight buckets)
+	# is gram-based, so callers summing across mixed prefixes need conversion
+	# applied uniformly.
+	#
+	# 1 carat = 0.2 g. Item-code prefix is the load-bearing signal here
+	# because variant_of, stock_uom, and prefix all agree in this codebase
+	# today, and prefix is the only one available without a DB lookup.
+	q = flt(qty, 3)
+	if not item_code:
+		return q
+	if item_code[0] in ("D", "G"):
+		return flt(q * 0.2, 3)
+	return q
+
+
 def validate_duplication_and_gr_wt(self):
 	# if self.main_slip and frappe.db.get_value("Main Slip", self.main_slip, "workflow_state") != "In Use":
 	# 	self.main_slip = None
@@ -120,10 +137,17 @@ def update_mop_balance(mop_name):
 def validate_manually_book_loss_details(self):
 	if self.docstatus != 0:
 		return
+	# Stricter floor: per-row balance must cover the manual loss qty. Pre-submit
+	# the latest balance already reflects any prior submitted losses (loss MOP
+	# Log rows post a real negative qty_change), so no log_category filter is
+	# needed here.
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+		get_available_qty_pcs_for_mop_item,
+	)
+
 	for row in self.manually_book_loss_details:
 		if not row.manufacturing_operation:
 			continue
-		# Query MOP Log for latest balance instead of MOP Balance Table
 		balance_qty = (
 			frappe.db.get_value(
 				"MOP Log",
@@ -143,6 +167,74 @@ def validate_manually_book_loss_details(self):
 				_(
 					"Row #{0}: <b>{1}</b> Proportionally Loss {2} cannot be greater than Balance Qty {3}"
 				).format(row.idx, row.item_code, row.proportionally_loss, balance_qty)
+			)
+
+		# D/G PCS reconciliation: manual loss PCS must not drive the MOP
+		# diamond_pcs/gemstone_pcs negative. Only D/G items carry meaningful
+		# PCS in MOP Log; for M/F/O the loss MOP Log emits pcs_change=0 so we
+		# skip this branch entirely. A pcs=0 (or missing/non-numeric) row
+		# never reduces balance, so we also skip the helper query.
+		if row.item_code and row.item_code[0] in ("D", "G"):
+			raw_pcs = getattr(row, "pcs", 0)
+			try:
+				pcs_to_book = int(float(raw_pcs)) if raw_pcs not in (None, "") else 0
+			except (TypeError, ValueError):
+				pcs_to_book = 0
+			if pcs_to_book < 0:
+				frappe.throw(_("Row #{0}: PCS must be >= 0").format(row.idx))
+			if pcs_to_book > 0:
+				ctx = get_available_qty_pcs_for_mop_item(
+					manufacturing_operation=row.manufacturing_operation,
+					item_code=row.item_code,
+					batch_no=row.batch_no,
+				)
+				if ctx["available_pcs"] and pcs_to_book > ctx["available_pcs"]:
+					frappe.throw(
+						_(
+							"Row #{0} <b>{1}</b> batch {2}: PCS to book ({3}) "
+							"exceeds available PCS in MOP balance ({4})"
+						).format(
+							row.idx,
+							row.item_code,
+							row.batch_no,
+							pcs_to_book,
+							ctx["available_pcs"],
+						)
+					)
+
+	# Additional cap: total manual loss for a MWO cannot exceed the true
+	# available baseline (gross_wt - received_gross_wt) for that MWO.
+	# Carat manual loss converted to grams for comparison.
+	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
+
+	baseline_by_mwo = {}
+	for op in self.employee_ir_operations:
+		if not op.received_gross_wt:
+			continue
+		baseline = max(
+			0.0, flt(op.gross_wt, precision) - flt(op.received_gross_wt, precision)
+		)
+		baseline_by_mwo.setdefault(op.manufacturing_work_order, 0.0)
+		baseline_by_mwo[op.manufacturing_work_order] += baseline
+
+	manual_by_mwo = {}
+	for row in self.manually_book_loss_details:
+		qty = flt(row.proportionally_loss)
+		stock_uom = frappe.get_cached_value("Item", row.item_code, "stock_uom")
+		if stock_uom == "Carat":
+			qty = qty * 0.2
+		manual_by_mwo.setdefault(row.manufacturing_work_order, 0.0)
+		manual_by_mwo[row.manufacturing_work_order] += qty
+
+	for mwo, manual_total in manual_by_mwo.items():
+		available = baseline_by_mwo.get(mwo, 0.0)
+		if manual_total > available:
+			frappe.throw(
+				_(
+					"Total Manually Booked Loss for Manufacturing Work Order {0} "
+					"({1} g) cannot exceed available loss baseline ({2} g = "
+					"Gross Wt - Received Gross Wt)."
+				).format(mwo, flt(manual_total, 3), flt(available, 3))
 			)
 
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.js
@@ -139,13 +139,13 @@ frappe.ui.form.on("Employee IR", {
 					"gemstone_wt",
 					"gemstone_pcs",
 				])
-					.then((r) => {
-						let values = r.message;
+				.then((r) => {
+					let values = r.message;
 
-						if (values.manufacturing_work_order) {
-							frappe.db.get_value(
-								"QC",
-								{
+					if (values.manufacturing_work_order) {
+						frappe.db.get_value(
+							"QC",
+							{
 								manufacturing_work_order: values.manufacturing_work_order,
 								manufacturing_operation: values.name,
 								status: ["!=", "Rejected"],
@@ -345,7 +345,6 @@ frappe.ui.form.on("Employee IR Operation", {
 			var gwt = child.gross_wt || 0;
 			var opt = child.manufacturing_operation;
 			var r_gwt = child.received_gross_wt;
-			book_loss_details(frm, mwo, opt, gwt, r_gwt);
 			// frappe.db.get_value("Manufacturing Work Order", mwo, ['multicolour','allowed_colours'])
 			// 	.then(r => {
 			// 		console.log(r.message);
@@ -492,6 +491,7 @@ function set_child_table_batch_filter(frm) {
 			query: "jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.filters.get_batch_details",
 			filters: {
 				item_code: d.item_code,
+				manufacturing_operation: d.manufacturing_operation,
 				manufacturing_work_order: d.manufacturing_work_order,
 			},
 		};

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.py
@@ -46,6 +46,7 @@ from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufac
 	update_new_mop_wtg,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+	create_mop_log_for_employee_ir_loss,
 	create_mop_log_for_employee_ir_receive,
 	creste_mop_log_for_employee_ir,
 )
@@ -127,6 +128,17 @@ class EmployeeIR(Document):
 		# 	mop_data = json.loads(self.mop_data)
 		# 	return create_single_se_entry(self, mop_data)
 		if cancel:
+			affected_mops_issue = [
+				r[0]
+				for r in frappe.db.sql(
+					"""
+					SELECT DISTINCT manufacturing_operation FROM `tabMOP Log`
+					WHERE voucher_type = %s AND voucher_no = %s AND is_cancelled = 0
+					  AND manufacturing_operation IS NOT NULL
+					""",
+					(self.doctype, self.name),
+				)
+			]
 			frappe.db.set_value(
 				"MOP Log",
 				{
@@ -137,6 +149,12 @@ class EmployeeIR(Document):
 				"is_cancelled",
 				1,
 			)
+			from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+				recalculate_manufacturing_operation_weights,
+			)
+
+			for mop_name in affected_mops_issue:
+				recalculate_manufacturing_operation_weights(mop_name)
 		# Set initial values based on cancel flag
 		employee = None if cancel else self.employee
 		operation = None if cancel else self.operation
@@ -259,6 +277,20 @@ class EmployeeIR(Document):
 		curr_time = frappe.utils.now()
 
 		if cancel:
+			# Capture which Manufacturing Operations need bucket recompute BEFORE
+			# the bulk is_cancelled flip — afterwards the rows are filtered out
+			# by the `is_cancelled = 0` clause the recompute uses.
+			affected_mops = [
+				r[0]
+				for r in frappe.db.sql(
+					"""
+					SELECT DISTINCT manufacturing_operation FROM `tabMOP Log`
+					WHERE voucher_type = %s AND voucher_no = %s AND is_cancelled = 0
+					  AND manufacturing_operation IS NOT NULL
+					""",
+					(self.doctype, self.name),
+				)
+			]
 			frappe.db.set_value(
 				"MOP Log",
 				{
@@ -272,6 +304,16 @@ class EmployeeIR(Document):
 			# Cancel any auto-created Main Slip Repack SEs; their on_cancel hook
 			# flips the matching MOP Log rows to is_cancelled=1 via the bridge.
 			cancel_injections_for_eir(self.name)
+			# Bulk db.set_value above bypasses MOPLog.validate, so the prefix
+			# buckets stay stale showing pre-cancel balances. Re-run the central
+			# aggregator on each affected MOP so gross_wt restores to the
+			# remaining-active-rows balance.
+			from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+				recalculate_manufacturing_operation_weights,
+			)
+
+			for mop_name in affected_mops:
+				recalculate_manufacturing_operation_weights(mop_name)
 
 		for row in self.employee_ir_operations:
 			if is_mould_operation and not cancel:
@@ -329,6 +371,35 @@ class EmployeeIR(Document):
 				create_mop_log_for_employee_ir_receive(
 					self, row, actor_wh, department_wh, stock_entry_name
 				)
+
+				# Loss attribution bridge writes (is_synced=1, qty_change=0).
+				# Per-MWO total loss = sum of proportional + manual already
+				# accumulated in mwo_loss_dict above. Helper is idempotent on
+				# (voucher_type, voucher_no, mop, loss_source_row, loss_type).
+				total_loss_for_mwo = (
+					mwo_loss_dict.get(row.manufacturing_work_order) or 0
+				)
+				for lr in self.employee_loss_details:
+					if lr.manufacturing_work_order == row.manufacturing_work_order:
+						create_mop_log_for_employee_ir_loss(
+							self,
+							lr,
+							"Auto Employee Loss",
+							total_loss_for_mwo,
+							from_wh=actor_wh,
+							to_wh=department_wh,
+						)
+				for lr in self.manually_book_loss_details:
+					if lr.manufacturing_work_order == row.manufacturing_work_order:
+						create_mop_log_for_employee_ir_loss(
+							self,
+							lr,
+							"Manually Booked Loss",
+							total_loss_for_mwo,
+							from_wh=actor_wh,
+							to_wh=department_wh,
+						)
+
 				update_new_mop_wtg(new_operation)
 			else:
 				for sre in frappe.db.get_all(
@@ -481,7 +552,7 @@ class EmployeeIR(Document):
 	def validate_process_loss(self):
 		if (self.docstatus != 0) or self.type == "Issue":
 			return
-		allowed_loss_percentage = frappe.get_value(
+		allowed_loss_percentage = frappe.get_cached_value(
 			"Department Operation",
 			{"company": self.company, "department": self.department},
 			"allowed_loss_percentage",
@@ -498,7 +569,6 @@ class EmployeeIR(Document):
 				)
 
 		self.employee_loss_details = []
-		proportionally_loss_sum = 0
 		for row in rows_to_append:
 			proportionally_loss = flt(row["proportionally_loss"], 3)
 			if proportionally_loss > 0:
@@ -520,8 +590,17 @@ class EmployeeIR(Document):
 						"customer": row.get("customer"),
 					},
 				)
-				proportionally_loss_sum += proportionally_loss
-		self.mop_loss_details_total = proportionally_loss_sum
+
+		# Pre-deduction MOP baseline: total loss available from the operations
+		# before any manual deduction. Drives downstream caps and serves as the
+		# reference for `remaining_loss = baseline - sum(manually_book_loss)`.
+		mop_baseline = 0.0
+		for child in self.employee_ir_operations:
+			if child.received_gross_wt and flt(child.gross_wt) > flt(
+				child.received_gross_wt
+			):
+				mop_baseline += flt(child.gross_wt) - flt(child.received_gross_wt)
+		self.mop_loss_details_total = flt(mop_baseline, 3)
 
 	@frappe.whitelist()
 	def book_metal_loss(self, mwo, opt, gwt, r_gwt, allowed_loss_percentage=None):
@@ -538,31 +617,36 @@ class EmployeeIR(Document):
 		data = []  # for final data list
 		# Fetching Stock Entry based on MNF Work Order
 		if gwt != r_gwt:
-			mop_balance_table = []
+			# Forensic C4 fix: previously aliased pcs_after_transaction_batch_based
+			# to BOTH qty and pcs, making the proportional loss formula run on
+			# PCS counts instead of grams. Use the weight column for qty so
+			# downstream `stock_loss = (entry["qty"] * loss) / total_qty` produces
+			# gram-based outputs matching the spec examples.
 			fields = [
 				"item_code",
 				"batch_no",
-				"pcs_after_transaction_batch_based as qty",
+				"qty_after_transaction_batch_based as qty",
 				"pcs_after_transaction_batch_based as pcs",
 			]
-			for row in frappe.db.get_all(
-				"MOP Log",
-				{
-					"manufacturing_work_order": mwo,
-					"manufacturing_operation": opt,
-					"is_cancelled": 0,
-					"voucher_type": "Employee IR",
-				},
-				fields,
-			):
-				mop_balance_table.append(row)
+			mop_balance_table = (
+				frappe.db.get_all(
+					"MOP Log",
+					{
+						"manufacturing_work_order": mwo,
+						"manufacturing_operation": opt,
+						"is_cancelled": 0,
+					},
+					fields,
+				)
+				or []
+			)
 			# Declaration & fetch required value
 			metal_item = []  # for check metal or not list
 			unique = set()  # for Unique Item_Code
 			sum_qty = {}  # for sum of qty matched item
 
 			# getting Metal property from MNF Work Order
-			mwo_metal_property = frappe.db.get_value(
+			mwo_metal_property = frappe.get_cached_value(
 				"Manufacturing Work Order",
 				mwo,
 				[
@@ -647,6 +731,35 @@ class EmployeeIR(Document):
 						entry["proportionally_loss"] = 0
 						entry["received_gross_weight"] = 0
 						entry["main_slip_consumption"] = ms_consum_book
+
+			# Precision-3 reconciliation: independently rounding each row's
+			# proportionally_loss can leave the sum drifting from flt(loss, 3),
+			# which trips validate_loss_qty's per-MWO equality check. Round
+			# each row first, then anchor the residual on the largest-loss
+			# row so the sum matches flt(loss, 3) exactly.
+			if loss > 0 and total_qty != 0:
+				positive = [e for e in data if flt(e["proportionally_loss"]) > 0]
+				if positive:
+					for entry in positive:
+						entry["proportionally_loss"] = flt(
+							entry["proportionally_loss"], 3
+						)
+						entry["received_gross_weight"] = flt(
+							entry["qty"] - entry["proportionally_loss"], 3
+						)
+					target = flt(loss, 3)
+					distributed = flt(
+						sum(e["proportionally_loss"] for e in positive), 3
+					)
+					residual = flt(target - distributed, 3)
+					if residual:
+						anchor = max(positive, key=lambda e: e["proportionally_loss"])
+						anchor["proportionally_loss"] = flt(
+							anchor["proportionally_loss"] + residual, 3
+						)
+						anchor["received_gross_weight"] = flt(
+							anchor["qty"] - anchor["proportionally_loss"], 3
+						)
 			# -------------------------------------------------------------------------
 		return data
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/main_slip/main_slip.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/main_slip/main_slip.py
@@ -27,14 +27,13 @@ class MainSlip(Document):
 			self.color_abbr = None
 
 	def validate(self):
-		
 		dynamic_field = "subcontractor"
 		dynamic_value = self.subcontractor
 		if not self.for_subcontracting:
 			dynamic_field = "employee"
 			dynamic_value = self.employee
 			self.validate_metal_properties()
-		
+
 		if self.flags.ignore_validations:
 			return
 
@@ -78,7 +77,9 @@ class MainSlip(Document):
 			# 	"Manufacturing Setting", {"company": self.company}, field_map.get(self.metal_touch)
 			# )
 			ratio = frappe.db.get_value(
-				"Manufacturing Setting", {"manufacturer": self.manufacturer}, field_map.get(self.metal_touch)
+				"Manufacturing Setting",
+				{"manufacturer": self.manufacturer},
+				field_map.get(self.metal_touch),
 			)
 			self.computed_gold_wt = flt(self.tree_wax_wt) * flt(ratio)
 		if (
@@ -137,7 +138,9 @@ class MainSlip(Document):
 
 			batch_entry = batch_details[key]
 			self.issue_metal += batch_entry["qty"]
-			self.receive_metal += batch_entry["consume_qty"] + batch_entry["employee_qty"]
+			self.receive_metal += (
+				batch_entry["consume_qty"] + batch_entry["employee_qty"]
+			)
 			self.operation_issue += batch_entry["mop_qty"]
 			self.operation_receive += batch_entry["mop_consume_qty"]
 
@@ -159,7 +162,10 @@ class MainSlip(Document):
 				row.mop_consume_qty = batch_entry["mop_consume_qty"]
 
 			loss_details[key[0]] = loss_details.get(key[0], 0) + (
-				(batch_entry["qty"] - (batch_entry["consume_qty"] + batch_entry["employee_qty"]))
+				(
+					batch_entry["qty"]
+					- (batch_entry["consume_qty"] + batch_entry["employee_qty"])
+				)
 				+ batch_entry["mop_qty"]
 				- batch_entry["mop_consume_qty"]
 			)
@@ -192,7 +198,10 @@ class MainSlip(Document):
 			)
 
 			loss_details[row[0]] = loss_details.get(row[0], 0) + (
-				(batch_entry["qty"] - (batch_entry["consume_qty"] + batch_entry["employee_qty"]))
+				(
+					batch_entry["qty"]
+					- (batch_entry["consume_qty"] + batch_entry["employee_qty"])
+				)
 				+ batch_entry["mop_qty"]
 				- batch_entry["mop_consume_qty"]
 			)
@@ -304,7 +313,9 @@ class MainSlip(Document):
 		not_finished_mop = []
 		for row in self.main_slip_operation:
 			if (
-				frappe.db.get_value("Manufacturing Operation", row.manufacturing_operation, "status")
+				frappe.db.get_value(
+					"Manufacturing Operation", row.manufacturing_operation, "status"
+				)
 				!= "Finished"
 			):
 				if row.manufacturing_work_order not in not_finished_mop:
@@ -312,14 +323,18 @@ class MainSlip(Document):
 
 		if not_finished_mop:
 			frappe.throw(
-				_("Below mentioned Manufacturing Operations are not finished yet.<br> {0}").format(
-					",".join(not_finished_mop)
-				)
+				_(
+					"Below mentioned Manufacturing Operations are not finished yet.<br> {0}"
+				).format(",".join(not_finished_mop))
 			)
 		frappe.db.MAX_WRITES_PER_TRANSACTION *= 16
 		for row in self.loss_details:
 			create_loss_stock_entries(
-				self, row.item_code, row.variant_of, row.received_qty, (row.msl_qty - row.received_qty)
+				self,
+				row.item_code,
+				row.variant_of,
+				row.received_qty,
+				(row.msl_qty - row.received_qty),
 			)
 
 	def validate_metal_properties(self):
@@ -413,7 +428,13 @@ def create_tree_number(self):
 
 @frappe.whitelist()
 def create_stock_entries(
-	main_slip, actual_qty, metal_loss, metal_type, metal_touch, metal_purity, metal_colour=None
+	main_slip,
+	actual_qty,
+	metal_loss,
+	metal_type,
+	metal_touch,
+	metal_purity,
+	metal_colour=None,
 ):
 	item = get_item_from_attribute(metal_type, metal_touch, metal_purity, metal_colour)
 	if not item:
@@ -468,7 +489,6 @@ def create_stock_entries(
 
 
 def create_loss_stock_entries(self, item, variant_of, actual_qty, metal_loss):
-
 	if not item:
 		frappe.throw(_("No Item found for selected atrributes in main slip"))
 	if flt(actual_qty) <= 0 and metal_loss == 0:
@@ -480,7 +500,7 @@ def create_loss_stock_entries(self, item, variant_of, actual_qty, metal_loss):
 			batch_data.append(
 				{
 					"batch_no": row.batch_no,
-					"qty":flt(row.qty - row.employee_qty, 3),
+					"qty": flt(row.qty - row.employee_qty, 3),
 					"inventory_type": row.inventory_type,
 				}
 			)
@@ -555,11 +575,17 @@ def create_loss_stock_entries(self, item, variant_of, actual_qty, metal_loss):
 
 @frappe.whitelist()
 def create_process_loss(
-	main_slip, mop, item, qty, consume_qty, metal_loss, batch_no, inventory_type, customer=None
+	main_slip,
+	mop,
+	item,
+	qty,
+	consume_qty,
+	metal_loss,
+	batch_no,
+	inventory_type,
+	customer=None,
 ):
-
 	qty = flt(qty, 3)
-	consume_qty = flt(qty, 3)
 	metal_loss = flt(metal_loss, 3)
 
 	doc = frappe.get_doc("Main Slip", main_slip)
@@ -593,9 +619,9 @@ def create_process_loss(
 		if variant_loss_details.get("loss_warehouse"):
 			loss_warehouse = variant_loss_details.get("loss_warehouse")
 
-		elif variant_loss_details.get("consider_department_warehouse") and variant_loss_details.get(
-			"warehouse_type"
-		):
+		elif variant_loss_details.get(
+			"consider_department_warehouse"
+		) and variant_loss_details.get("warehouse_type"):
 			loss_warehouse = frappe.db.get_value(
 				"Warehouse",
 				{
@@ -633,7 +659,9 @@ def create_process_loss(
 		},
 	)
 	if frappe.db.get_value("Item", dust_item, "valuation_rate") == 0:
-		frappe.db.set_value("Item", dust_item, "valuation_rate", se_doc.items[0].get("basic_rate") or 1)
+		frappe.db.set_value(
+			"Item", dust_item, "valuation_rate", se_doc.items[0].get("basic_rate") or 1
+		)
 	se_doc.append(
 		"items",
 		{
@@ -674,9 +702,9 @@ def create_metal_loss(doc, item, variant_of, metal_loss, batch_data, mop=None):
 	if variant_loss_details and variant_loss_details.get("loss_warehouse"):
 		loss_warehouse = variant_loss_details.get("loss_warehouse")
 
-	elif variant_loss_details.get("consider_department_warehouse") and variant_loss_details.get(
-		"warehouse_type"
-	):
+	elif variant_loss_details.get(
+		"consider_department_warehouse"
+	) and variant_loss_details.get("warehouse_type"):
 		loss_warehouse = frappe.db.get_value(
 			"Warehouse",
 			{
@@ -695,7 +723,9 @@ def create_metal_loss(doc, item, variant_of, metal_loss, batch_data, mop=None):
 
 	if not item:
 		frappe.msgprint(
-			_("Please set item for metal loss in Manufacturing Setting for selected company")
+			_(
+				"Please set item for metal loss in Manufacturing Setting for selected company"
+			)
 		)
 		return
 	se = frappe.new_doc("Stock Entry")
@@ -753,13 +783,16 @@ def create_metal_loss(doc, item, variant_of, metal_loss, batch_data, mop=None):
 
 
 def get_item_loss_item(company, item, variant_of="M", loss_type=None):
-
 	if loss_type:
 		variant_name = frappe.db.get_value(
-			"Variant Loss Table", {"variant": variant_of, "loss_type": loss_type}, "loss_variant"
+			"Variant Loss Table",
+			{"variant": variant_of, "loss_type": loss_type},
+			"loss_variant",
 		)
 	else:
-		variant_name = frappe.db.get_value("Variant Loss Table", {"variant": variant_of}, "loss_variant")
+		variant_name = frappe.db.get_value(
+			"Variant Loss Table", {"variant": variant_of}, "loss_variant"
+		)
 
 	item_attr_dict = {}
 	for row in frappe.db.get_all(
@@ -772,15 +805,19 @@ def get_item_loss_item(company, item, variant_of="M", loss_type=None):
 	loss_item = set_items_from_attribute(
 		variant_name,
 		frappe.db.get_all(
-			"Item Variant Attribute", {"parent": item}, ["attribute as item_attribute", "attribute_value"]
+			"Item Variant Attribute",
+			{"parent": item},
+			["attribute as item_attribute", "attribute_value"],
 		),
 	)
 
 	if loss_item:
-		#loss_item.has_variants = 0
-		#loss_item.is_stock_item = 1
-		#loss_item.save()
-		frappe.db.set_value("Item",loss_item.name,{"has_variants":0,"is_stock_item":1})
+		# loss_item.has_variants = 0
+		# loss_item.is_stock_item = 1
+		# loss_item.save()
+		frappe.db.set_value(
+			"Item", loss_item.name, {"has_variants": 0, "is_stock_item": 1}
+		)
 		return loss_item.name
 	else:
 		return create_loss_item(variant_name, item_attr_dict)
@@ -788,9 +825,14 @@ def get_item_loss_item(company, item, variant_of="M", loss_type=None):
 
 def get_main_slip_item(main_slip):
 	ms = frappe.db.get_value(
-		"Main Slip", main_slip, ["metal_type", "metal_touch", "metal_purity", "metal_colour"], as_dict=1
+		"Main Slip",
+		main_slip,
+		["metal_type", "metal_touch", "metal_purity", "metal_colour"],
+		as_dict=1,
 	)
-	item = get_item_from_attribute(ms.metal_type, ms.metal_touch, ms.metal_purity, ms.metal_colour)
+	item = get_item_from_attribute(
+		ms.metal_type, ms.metal_touch, ms.metal_purity, ms.metal_colour
+	)
 	return item
 
 
@@ -816,11 +858,15 @@ def get_any_item_from_attribute(variant_of, attributes):
 		table_name = frappe.scrub(row)
 		alias = ItemVariantAttribute.as_(table_name)
 		join_tables.append(alias)
-		conditions.append((alias.attribute == row) & (alias.attribute_value == attributes[row]))
+		conditions.append(
+			(alias.attribute == row) & (alias.attribute_value == attributes[row])
+		)
 
 	# Construct the main query
 	query = (
-		frappe.qb.from_(Item).select(Item.name.as_("item_code")).where(Item.variant_of == variant_of)
+		frappe.qb.from_(Item)
+		.select(Item.name.as_("item_code"))
+		.where(Item.variant_of == variant_of)
 	)
 	# Add joins
 	for alias in join_tables:
@@ -837,3 +883,69 @@ def get_any_item_from_attribute(variant_of, attributes):
 	if data:
 		return data[0][0]
 	return None
+
+
+def get_loss_item_from_manufacturer_mapping(item_code, manufacturer, loss_type="Loss"):
+	"""Resolve a loss item from the per-Manufacturer Variant Loss Table.
+
+	The Manufacturer DocType has a custom child table `custom_variant_loss_table`
+	(of type `Variant Loss Table`) with rows keyed by (variant, loss_type) ->
+	loss_variant. This helper is manufacturer-scoped — unlike the older
+	`get_item_loss_item` which queries the standalone Variant Loss Table and
+	returns the first row from any Manufacturer.
+
+	Throws a clear configuration error pointing the user to the Manufacturer
+	form when the mapping is missing. Does NOT call `create_loss_item` because
+	that function carries forensic bug C3 (always-throw debug leftover).
+	"""
+	if not manufacturer:
+		frappe.throw(
+			_("Manufacturer is required to resolve loss item for {0}").format(item_code)
+		)
+
+	variant_of = frappe.db.get_value("Item", item_code, "variant_of")
+	if not variant_of:
+		frappe.throw(
+			_(
+				"Item {0} has no Variant Of template; cannot resolve loss variant"
+			).format(item_code)
+		)
+
+	loss_variant = frappe.db.get_value(
+		"Variant Loss Table",
+		{
+			"parenttype": "Manufacturer",
+			"parent": manufacturer,
+			"parentfield": "custom_variant_loss_table",
+			"variant": variant_of,
+			"loss_type": loss_type,
+		},
+		"loss_variant",
+	)
+	if not loss_variant:
+		frappe.throw(
+			_(
+				"Loss Item could not be resolved for Item {0}. Configure "
+				"Manufacturer {1} -> Variant Loss Table for Variant {2} "
+				"and Loss Type {3}."
+			).format(item_code, manufacturer, variant_of, loss_type)
+		)
+
+	from jewellery_erpnext.utils import set_items_from_attribute
+
+	item_attrs = frappe.db.get_all(
+		"Item Variant Attribute",
+		{"parent": item_code},
+		["attribute as item_attribute", "attribute_value"],
+	)
+	loss_item = set_items_from_attribute(loss_variant, item_attrs)
+	if not loss_item:
+		frappe.throw(
+			_(
+				"Loss Item variant for template {0} (mapped from {1}) does not "
+				"exist. Create the variant manually before running this flow."
+			).format(loss_variant, item_code)
+		)
+
+	frappe.db.set_value("Item", loss_item.name, {"has_variants": 0, "is_stock_item": 1})
+	return loss_item.name

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.js
@@ -10,11 +10,7 @@ frappe.ui.form.on("Manufacturing Operation", {
 			frm.set_df_property("employee_source_table", "hidden", 1);
 		}
 		set_html(frm);
-		if (
-			frm.doc.is_last_operation &&
-			frm.doc.for_fg &&
-			["Not Started", "WIP"].includes(frm.doc.status)
-		) {
+		if (frm.doc.is_last_operation && frm.doc.for_fg && ["Not Started", "WIP"].includes(frm.doc.status)) {
 			frm.add_custom_button(__("Finish"), async () => {
 				await frappe.call({
 					method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.get_linked_stock_entries_for_serial_number_creator",
@@ -22,7 +18,7 @@ frappe.ui.form.on("Manufacturing Operation", {
 						mwo: frm.doc.manufacturing_work_order,
 						department: frm.doc.department,
 						design_id_bom: frm.doc.design_id_bom,
-						qty: frm.doc.qty
+						qty: frm.doc.qty,
 					},
 					callback: function (r) {
 						frappe.call({
@@ -50,10 +46,10 @@ frappe.ui.form.on("Manufacturing Operation", {
 		// if (in_list(["Not Started", "WIP"], frm.doc.status)) {
 		if (["Not Started", "WIP"].includes(frm.doc.status)) {
 			frm.add_custom_button(__("Swap Metal"), () => {
-			let source_warehouse = "";
-			if (frm.doc.mop_balance_table && frm.doc.mop_balance_table.length > 0) {
-				source_warehouse = frm.doc.mop_balance_table[0].s_warehouse || "";
-			}
+				let source_warehouse = "";
+				if (frm.doc.mop_balance_table && frm.doc.mop_balance_table.length > 0) {
+					source_warehouse = frm.doc.mop_balance_table[0].s_warehouse || "";
+				}
 				// const serializedMopBalanceTable = JSON.stringify(frm.doc.mop_balance_table);
 				frappe.route_options = {
 					department: frm.doc.department,
@@ -63,8 +59,7 @@ frappe.ui.form.on("Manufacturing Operation", {
 					operation: frm.doc.name,
 					employee: frm.doc.employee,
 					source_warehouse: source_warehouse,
-					target_warehouse:source_warehouse,
-
+					target_warehouse: source_warehouse,
 				};
 				frappe.set_route("Form", "Swap Metal", "new-swap-metal");
 			}).addClass("btn-primary");
@@ -112,8 +107,8 @@ frappe.ui.form.on("Manufacturing Operation", {
 			// }
 		}
 
-		if (["Draft", "WIP", "Not Started"].includes(frm.doc.status)) {
-			frm.trigger("setup_buttons")
+		if (["Draft", "WIP", "Not Started"].includes(frm.doc.status) && frm.doc.manufacturing_work_order) {
+			frm.trigger("setup_buttons");
 		}
 	},
 	setup(frm) {
@@ -309,199 +304,321 @@ frappe.ui.form.on("Manufacturing Operation", {
 	},
 	setup_buttons: (frm) => {
 		frm.add_custom_button(__("Make Receive Entry"), () => {
-			this.data = frm.doc.mop_balance_table.map((e) => {
-				return {
-					"item_code": e.item_code,
-					"qty": e.qty,
-					"pcs": e.pcs,
-					"s_warehouse": e.s_warehouse,
-					"batch_no": e.batch_no,
-					"inventory_type": e.inventory_type,
-					"department": e.department,
-					"to_department": e.to_department,
-					"customer":e.customer
-				}
-			})
-
-			let d = new frappe.ui.Dialog({
-				title: __("Create Material Receive WO"),
-				size: "extra-large",
-				fields: [
-					{
-						fieldname: "receive_entries",
-						label: __("Receive Entry Details"),
-						fieldtype: "Table",
-						cannot_add_rows: 1,
-						cannot_delete_rows: 1,
-						data: this.data,
-							get_data: () => {
-								return this.data;
-							},
-							fields: [
-								{
-									"label": __("Item Code"),
-									"fieldtype": "Link",
-									"fieldname": "item_code",
-									"options": "Item",
-									"in_list_view": 1,
-									"read_only": 1,
-								},
-								{
-									"label": __("Source Warehouse"),
-									"fieldtype": "Link",
-									"fieldname": "s_warehouse",
-									"in_list_view": 1,
-									"read_only": 1
-								},
-								{
-									"label": __("Qty"),
-									"fieldtype": "Float",
-									"fieldname": "qty",
-									"in_list_view": 1,
-									"read_only": 1,
-									"columns": 1,
-									"default": flt()
-
-								},
-								{
-									"label": __("Pcs"),
-									"fieldtype": "Float",
-									"fieldname": "pcs",
-									"in_list_view": 1,
-									"read_only": 1,
-									"columns": 1,
-									"default": flt()
-								},
-								{
-									"label": __("Receive Quantity"),
-									"fieldtype": "Float",
-									"fieldname": "receive_qty",
-									"in_list_view": 1,
-									"reqd": 1,
-									"default": flt(),
-								},
-								{
-									"label": __("Receive Pcs"),
-									"fieldtype": "Float",
-									"fieldname": "receive_pcs",
-									"in_list_view": 1,
-									// "reqd": 1,
-									"default": flt()
-								},
-								{
-									"label": __("Batch No"),
-									"fieldtype": "Link",
-									"options": "Batch",
-									"fieldname": "batch_no",
-									"read_only": 1,
-								},
-								{
-									"label": __("Inventory Type"),
-									"fieldtype": "Link",
-									"options": "Inventory Type",
-									"fieldname": "inventory_type",
-									"read_only": 1,
-								},
-								{
-									"label": __("Customer"),
-									"fieldtype": "Link",
-									"options": "Customer",
-									"fieldname": "customer",
-									"read_only": 1,
-								},
-								{
-									"label": __("Department"),
-									"fieldtype": "Link",
-									"options": "Department",
-									"fieldname": "department",
-									"read_only": 1,
-								},
-																{
-									"label": __("To Department"),
-									"fieldtype": "Link",
-									"options": "Department",
-									"fieldname": "to_department",
-									"read_only": 1,
-								}
-							]
-						}
-				],
-				primary_action_label: __("Create Material Receive Entry"),
-				primary_action: (r) => {
-					let receive_items = []
-					r.receive_entries.forEach(e => {
-						if (e.receive_qty > e.qty) {
-							frappe.throw(__("Row <b>{0}</b> Item <b>{1}</b> : Receive Qty <b>{2}</b> should not be greater than Balance Qty <b>{3}</b>", [e.idx, e.item_code, e.receive_qty, e.qty]))
-						}
-						if (e.receive_pcs > e.pcs && e.pcs>0) {
-							frappe.throw(__("Row <b>{0}</b> Item <b>{1}</b> : Receive Pcs <b>{2}</b> should not be greater than Balance Pcs <b>{3}</b>", [e.idx, e.item_code, e.receive_pcs, e.pcs]))
-						}
-						// if ((e.receive_pcs == e.pcs && e.receive_qty != e.qty) || (e.receive_qty == e.qty && e.receive_pcs != e.pcs)) {
-						// 	frappe.throw(__("Row <b>{0}</b> Item <b>{1}</b> : Receive Qty and Pcs should be same if receiving all qty or pcs", [e.idx, e.item_code]))
-						// }
-
-						if (e.receive_qty || e.receive_pcs) {
-							receive_items.push({
-								idx: e.idx,
-								item_code: e.item_code,
-								s_warehouse: e.s_warehouse,
-								qty: e.receive_qty,
-								pcs: e.receive_pcs,
-								batch_no: e.batch_no,
-								inventory_type: e.inventory_type,
-								department: e.department,
-								to_department: e.to_department,
-								customer: e.customer
-							})
-						}
-					});
-
-					if (receive_items.length === 0) {
-						frappe.msgprint(__("No Receive Items found for Material Receive stock entry creation"))
+			frappe.call({
+				method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.get_make_receive_entry_rows",
+				args: { manufacturing_operation: frm.doc.name },
+				freeze: true,
+				freeze_message: __("Loading Stock Reservation Entries..."),
+				callback: (r) => {
+					const rows = (r && r.message) || [];
+					if (!rows.length) {
+						frappe.msgprint(
+							__("No active Stock Reservation Entries found for this Manufacturing Work Order.")
+						);
+						return;
 					}
 
-					frappe.call({
-						method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.create_mr_wo_stock_entry",
-						args: {
-							se_data: {
-								manufacturing_work_order: frm.doc.manufacturing_work_order,
-								manufacturing_operation: frm.doc.name,
-								manufacturing_order: frm.doc.manufacturing_order,
-								department: frm.doc.department,
-								receive_items: receive_items
+					// Per-dialog request id — stamped on the resulting Stock Entry to
+					// short-circuit double-clicks and resubmits server-side.
+					// Frappe JS exposes `get_random(N)`, not `get_random_string`.
+					const request_id = frappe.utils.get_random(36);
+
+					// Spec field names: reserved_* / mop_available_* / available_to_receive_*.
+					// Server endpoint emits these directly; the JS just forwards them
+					// into the dialog and surfaces `qty_to_receive` / `pcs_to_receive`
+					// as the editable inputs.
+					const dialog_data = rows.map((e) => ({
+						stock_reservation_entry: e.stock_reservation_entry,
+						stock_reservation_entry_detail: e.stock_reservation_entry_detail,
+						item_code: e.item_code,
+						s_warehouse: e.s_warehouse,
+						t_warehouse: e.t_warehouse,
+						batch_no: e.batch_no,
+						reserved_qty: e.reserved_qty,
+						reserved_pcs: e.reserved_pcs || 0,
+						delivered_qty: e.delivered_qty,
+						already_received_qty: e.already_received_qty,
+						already_received_pcs: e.already_received_pcs || 0,
+						mop_available_qty: e.mop_available_qty || 0,
+						mop_available_pcs: e.mop_available_pcs || 0,
+						available_to_receive_qty: e.available_to_receive_qty,
+						available_to_receive_pcs: e.available_to_receive_pcs || 0,
+						is_pcs_item: e.is_pcs_item ? 1 : 0,
+						mop_log_reference: e.mop_log_reference || "",
+						qty_to_receive: 0,
+						pcs_to_receive: 0,
+						stock_uom: e.stock_uom,
+					}));
+
+					const d = new frappe.ui.Dialog({
+						title: __("Create Material Receive (WORK ORDER)"),
+						size: "extra-large",
+						fields: [
+							{
+								fieldname: "receive_entries",
+								label: __("Receive Entry Details"),
+								fieldtype: "Table",
+								cannot_add_rows: 1,
+								cannot_delete_rows: 1,
+								data: dialog_data,
+								get_data: () => dialog_data,
+								fields: [
+									{
+										label: __("SRE"),
+										fieldtype: "Link",
+										fieldname: "stock_reservation_entry",
+										options: "Stock Reservation Entry",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("Item Code"),
+										fieldtype: "Link",
+										fieldname: "item_code",
+										options: "Item",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("Source Warehouse"),
+										fieldtype: "Link",
+										fieldname: "s_warehouse",
+										options: "Warehouse",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("Target Warehouse"),
+										fieldtype: "Link",
+										fieldname: "t_warehouse",
+										options: "Warehouse",
+										read_only: 1,
+									},
+									{
+										label: __("Batch No"),
+										fieldtype: "Link",
+										fieldname: "batch_no",
+										options: "Batch",
+										read_only: 1,
+									},
+									{
+										label: __("Reserved Qty"),
+										fieldtype: "Float",
+										fieldname: "reserved_qty",
+										read_only: 1,
+									},
+									{
+										label: __("Reserved PCS"),
+										fieldtype: "Float",
+										fieldname: "reserved_pcs",
+										read_only: 1,
+									},
+									{
+										label: __("Delivered Qty"),
+										fieldtype: "Float",
+										fieldname: "delivered_qty",
+										read_only: 1,
+									},
+									{
+										label: __("MOP Available Qty"),
+										fieldtype: "Float",
+										fieldname: "mop_available_qty",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("MOP Available PCS"),
+										fieldtype: "Float",
+										fieldname: "mop_available_pcs",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("Already Received"),
+										fieldtype: "Float",
+										fieldname: "already_received_qty",
+										read_only: 1,
+									},
+									{
+										label: __("Already Received PCS"),
+										fieldtype: "Float",
+										fieldname: "already_received_pcs",
+										read_only: 1,
+									},
+									{
+										label: __("Available to Receive Qty"),
+										fieldtype: "Float",
+										fieldname: "available_to_receive_qty",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("Available to Receive PCS"),
+										fieldtype: "Float",
+										fieldname: "available_to_receive_pcs",
+										in_list_view: 1,
+										read_only: 1,
+									},
+									{
+										label: __("Qty to Receive"),
+										fieldtype: "Float",
+										fieldname: "qty_to_receive",
+										in_list_view: 1,
+										default: 0,
+									},
+									{
+										label: __("PCS to Receive"),
+										fieldtype: "Float",
+										fieldname: "pcs_to_receive",
+										in_list_view: 1,
+										default: 0,
+										// Read-only for non-D/G rows. Frappe Table fields
+										// don't support per-row hidden cells, so we use
+										// read_only_depends_on; server still force-zeros
+										// PCS for non-D/G regardless of dialog value.
+										read_only_depends_on: "eval:!doc.is_pcs_item",
+									},
+									{
+										label: __("PCS Item"),
+										fieldtype: "Check",
+										fieldname: "is_pcs_item",
+										hidden: 1,
+										read_only: 1,
+									},
+									{
+										label: __("MOP Log Reference"),
+										fieldtype: "Link",
+										fieldname: "mop_log_reference",
+										options: "MOP Log",
+										read_only: 1,
+									},
+									{
+										label: __("Stock UOM"),
+										fieldtype: "Link",
+										fieldname: "stock_uom",
+										options: "UOM",
+										read_only: 1,
+									},
+								],
+							},
+						],
+						primary_action_label: __("Create Material Receive Entry"),
+						primary_action: (r_) => {
+							const receive_items = [];
+							r_.receive_entries.forEach((e) => {
+								// Qty must be capped by min(SRE remaining, MOP balance);
+								// the server endpoint surfaces that as available_to_receive_qty.
+								if (e.qty_to_receive > e.available_to_receive_qty) {
+									frappe.throw(
+										__(
+											"Row <b>{0}</b> Item <b>{1}</b>: Qty to Receive <b>{2}</b> exceeds Available to Receive Qty <b>{3}</b>",
+											[e.idx, e.item_code, e.qty_to_receive, e.available_to_receive_qty]
+										)
+									);
+								}
+								// PCS validation: D/G rows must respect Available to
+								// Receive PCS; non-D/G rows are force-zeroed regardless
+								// of dialog value. Server revalidates either way.
+								let pcs_to_receive = 0;
+								if (e.is_pcs_item) {
+									pcs_to_receive = e.pcs_to_receive || 0;
+									if (pcs_to_receive < 0) {
+										frappe.throw(
+											__(
+												"Row <b>{0}</b> Item <b>{1}</b>: PCS to Receive must be >= 0",
+												[e.idx, e.item_code]
+											)
+										);
+									}
+									if (
+										e.available_to_receive_pcs &&
+										pcs_to_receive > e.available_to_receive_pcs
+									) {
+										frappe.throw(
+											__(
+												"Row <b>{0}</b> Item <b>{1}</b>: PCS to Receive <b>{2}</b> exceeds Available to Receive PCS <b>{3}</b>",
+												[
+													e.idx,
+													e.item_code,
+													pcs_to_receive,
+													e.available_to_receive_pcs,
+												]
+											)
+										);
+									}
+								}
+								if (e.qty_to_receive && e.qty_to_receive > 0) {
+									receive_items.push({
+										idx: e.idx,
+										stock_reservation_entry: e.stock_reservation_entry,
+										stock_reservation_entry_detail: e.stock_reservation_entry_detail,
+										item_code: e.item_code,
+										s_warehouse: e.s_warehouse,
+										// Server still consumes `qty` and `pcs` keys for
+										// receive_items — the dialog field rename is
+										// cosmetic only.
+										qty: e.qty_to_receive,
+										pcs: pcs_to_receive,
+										batch_no: e.batch_no,
+									});
+								}
+							});
+
+							if (!receive_items.length) {
+								frappe.msgprint(
+									__("No Receive Items selected for Material Receive Stock Entry")
+								);
+								return;
 							}
+
+							d.disable_primary_action();
+							frappe.call({
+								method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.create_mr_wo_stock_entry",
+								args: {
+									se_data: {
+										manufacturing_work_order: frm.doc.manufacturing_work_order,
+										manufacturing_operation: frm.doc.name,
+										manufacturing_order: frm.doc.manufacturing_order,
+										department: frm.doc.department,
+										receive_items: receive_items,
+									},
+									request_id: request_id,
+								},
+								freeze: true,
+								freeze_message: __("Creating Material Receive Entry..."),
+								callback: (resp) => {
+									if (resp && resp.message) {
+										const se_link = frappe.utils.get_form_link(
+											resp.message.doctype,
+											resp.message.docname,
+											true
+										);
+										const title = resp.message.idempotent
+											? __("Existing Material Receive Stock Entry")
+											: __("Material Receive Stock Entry Created");
+										frappe.msgprint({
+											message: __("Material Receive Entry: {0}", [se_link]),
+											title: title,
+											indicator: "green",
+										});
+										frm.reload_doc();
+									}
+								},
+								error: () => {
+									d.enable_primary_action();
+								},
+							});
+
+							d.hide();
 						},
-						freeze: true,
-						freeze_message: __("Creating Material Receive Entry...."),
-						callback: (r) => {
-							if (!r.exec) {
-								let se_link = frappe.utils.get_form_link(
-									r.message.doctype,
-									r.message.docname,
-									true
-								)
-								frappe.msgprint({
-									message: __("Material Receive Entry has been created successfully {0}", [se_link]),
-									title: __("Material Receive Stock Entry Created"),
-									indicator: "green"
-								})
+					});
 
-								frm.reload_doc()
-								frm.refresh();
-							}
-						}
-					})
-
-					d.hide()
-				}
-			})
-
-			d.get_field("receive_entries").grid.wrapper.find(".grid-row-check").hide();
-			d.show()
-
-		}).addClass("btn-primary")
-
-	}
+					d.get_field("receive_entries").grid.wrapper.find(".grid-row-check").hide();
+					d.show();
+				},
+			});
+		}).addClass("btn-primary");
+	},
 });
 function initialiseTimer(section, currentIncrement) {
 	const interval = setInterval(function () {
@@ -538,7 +655,7 @@ function set_html(frm) {
 			method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.get_linked_stock_entries",
 			args: {
 				mwo: frm.doc.manufacturing_work_order,
-				department: frm.doc.department
+				department: frm.doc.department,
 			},
 			callback: function (r) {
 				frm.get_field("stock_entry_details").$wrapper.html(r.message);

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -10,6 +10,7 @@ from frappe.model.naming import make_autoname
 from frappe.query_builder import Criterion, CustomFunction
 from frappe.query_builder.functions import Avg, IfNull, Max, Sum
 from frappe.utils import (
+	cint,
 	flt,
 	get_datetime,
 	now,
@@ -19,6 +20,7 @@ from frappe.utils import (
 )
 
 from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+	get_available_qty_pcs_for_mop_item,
 	get_current_mop_balance_rows,
 	get_last_mop_index,
 )
@@ -1274,7 +1276,7 @@ def genrate_serial_no(doc, diamond_grade_data):
 			dg_abbr = "0"
 		# diamond_grade = max(diamond_grade_data, key=diamond_grade_data.get)
 		# dg_abbr = frappe.db.get_value("Attribute Value", diamond_grade, ["abbreviation"])
-		date = f"{posting_date.year %100:02d}"
+		date = f"{posting_date.year % 100:02d}"
 		date_to_letter = {
 			0: "J",
 			1: "A",
@@ -3634,78 +3636,775 @@ def get_linked_stock_entries(mwo, department):
 
 
 @frappe.whitelist()
-def create_mr_wo_stock_entry(se_data):
+def get_make_receive_entry_rows(manufacturing_operation):
+	"""Return rows for the Make Receive Entry dialog, sourced from active
+	Stock Reservation Entry rows linked to the MOP's Manufacturing Work Order.
+
+	Each returned row carries the SRE name (and per-batch sb_entries name when
+	the SRE is batch-based). Available qty is the SRE's own remaining
+	(reserved_qty - delivered_qty); we do NOT subtract previous Material Receive
+	Stock Entries because partial receives are handled by cancel-and-recreate
+	of the SRE — the active SRE already reflects the remaining stock.
+	"""
+	mo = frappe.get_doc("Manufacturing Operation", manufacturing_operation)
+
+	if not mo.manufacturing_work_order:
+		frappe.throw(_("Manufacturing Work Order is required for Make Receive Entry"))
+
+	t_warehouse = frappe.db.get_value(
+		"Warehouse",
+		{"warehouse_type": "Raw Material", "department": mo.department},
+		"name",
+	)
+	if not t_warehouse:
+		frappe.throw(_("No warehouse found for warehouse type Raw Material"))
+
+	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
+	tolerance = _float_tolerance(precision)
+
+	sres = frappe.db.get_all(
+		"Stock Reservation Entry",
+		filters={
+			"manufacturing_work_order": mo.manufacturing_work_order,
+			"docstatus": 1,
+		},
+		fields=[
+			"name",
+			"item_code",
+			"warehouse",
+			"reserved_qty",
+			"delivered_qty",
+			"stock_uom",
+			"voucher_type",
+			"voucher_no",
+			"voucher_detail_no",
+			"has_serial_no",
+			"has_batch_no",
+			"reservation_based_on",
+			"manufacturing_work_order",
+			"manufacturing_operation",
+		],
+	)
+
+	# Pre-compute MOP Log balance map once for this MOP — the helper picks
+	# the matching (item_code, batch_no) row out of this map per popup row.
+	mop_balance_rows = get_current_mop_balance_rows(mo.name)
+	mop_log_balance_map = {
+		(row.get("item_code"), row.get("batch_no")): row for row in mop_balance_rows
+	}
+
+	# Batch the already-received aggregations: ONE SQL per metric covering
+	# every (item_code, s_warehouse) referenced by the SREs, instead of
+	# 2 SQLs per SRE row. Saves N-1 round-trips per popup open. Numbers
+	# remain informational only — never subtracted from active SRE remaining.
+	already_received_qty_map = {}
+	already_received_pcs_map = {}
+	if sres:
+		# DISTINCT (item_code, warehouse) pairs minimise the IN-list size.
+		distinct_pairs = sorted({(s.item_code, s.warehouse) for s in sres})
+		item_codes = sorted({pair[0] for pair in distinct_pairs})
+		warehouses = sorted({pair[1] for pair in distinct_pairs})
+		# Build positional placeholders so MariaDB can index-scan; use single
+		# IN-list per axis and filter post-fetch by exact (item, warehouse)
+		# pair to keep results minimal.
+		item_ph = ", ".join(["%s"] * len(item_codes))
+		wh_ph = ", ".join(["%s"] * len(warehouses))
+		params = (
+			mo.manufacturing_work_order,
+			*item_codes,
+			*warehouses,
+		)
+		agg_rows = frappe.db.sql(
+			f"""
+			SELECT
+			    sed.item_code,
+			    sed.s_warehouse,
+			    COALESCE(SUM(sed.qty), 0) AS sum_qty,
+			    COALESCE(SUM(CAST(NULLIF(sed.pcs, '') AS UNSIGNED)), 0) AS sum_pcs
+			FROM `tabStock Entry Detail` sed
+			INNER JOIN `tabStock Entry` se ON se.name = sed.parent
+			WHERE se.docstatus = 1
+			  AND se.stock_entry_type = 'Material Receive (WORK ORDER)'
+			  AND se.manufacturing_work_order = %s
+			  AND sed.item_code IN ({item_ph})
+			  AND sed.s_warehouse IN ({wh_ph})
+			GROUP BY sed.item_code, sed.s_warehouse
+			""",
+			params,
+		)
+		# agg_rows tuples: (item_code, s_warehouse, sum_qty, sum_pcs).
+		# Defensive against mocked test returns of shape [(0,)] — only
+		# index when the row has at least 4 columns; otherwise there is
+		# no aggregate available and we fall back to the .get(key, 0)
+		# defaults below.
+		for r in agg_rows:
+			if not isinstance(r, (list, tuple)) or len(r) < 4:
+				continue
+			key = (r[0], r[1])
+			already_received_qty_map[key] = flt(r[2] or 0)
+			already_received_pcs_map[key] = cint(r[3] or 0)
+
+	# Batch fetch all sb_entries rows for all batch-based SREs — one query
+	# instead of one per SRE.
+	sb_entries_by_sre = {}
+	batch_sre_names = [
+		s.name for s in sres if cint(s.has_batch_no) and s.reservation_based_on != "Qty"
+	]
+	if batch_sre_names:
+		all_sb = frappe.db.get_all(
+			"Serial and Batch Entry",
+			filters={"parent": ["in", batch_sre_names]},
+			fields=["name", "parent", "batch_no", "qty", "delivered_qty"],
+		)
+		for sb in all_sb:
+			sb_entries_by_sre.setdefault(sb["parent"], []).append(sb)
+
+	rows = []
+	for sre in sres:
+		batch_based = cint(sre.has_batch_no) and sre.reservation_based_on != "Qty"
+		key = (sre.item_code, sre.warehouse)
+		already_received_for_item = already_received_qty_map.get(key, 0)
+		already_received_pcs_for_item = already_received_pcs_map.get(key, 0)
+
+		if batch_based:
+			sb_entries = sb_entries_by_sre.get(sre.name, [])
+			for sb in sb_entries:
+				# SRE remaining for this batch row.
+				sre_remaining = flt(sb.qty) - flt(sb.delivered_qty)
+				if sre_remaining <= tolerance:
+					# Nothing left in the SRE for this batch — no row to show.
+					continue
+				ctx = get_available_qty_pcs_for_mop_item(
+					manufacturing_operation=mo.name,
+					item_code=sre.item_code,
+					batch_no=sb.batch_no,
+					warehouse=sre.warehouse,
+					stock_reservation_entry=sre.name,
+					stock_reservation_entry_detail=sb.name,
+					manufacturing_work_order=sre.manufacturing_work_order,
+					sre_remaining_qty=sre_remaining,
+					already_received_qty=already_received_for_item,
+					already_received_pcs=already_received_pcs_for_item,
+					mop_log_balance_map=mop_log_balance_map,
+				)
+				# Available to receive = min(SRE remaining, MOP balance).
+				# The helper has already done that math; surface the value
+				# under the spec-mandated key. Exclude rows where the
+				# operator has nothing to receive (either because SRE is
+				# empty or — new rule — because MOP balance was lost to
+				# Employee IR / loss attribution since the SRE was cut).
+				if flt(ctx["available_qty"]) <= tolerance:
+					continue
+				rows.append(
+					{
+						"stock_reservation_entry": sre.name,
+						"stock_reservation_entry_detail": sb.name,
+						"item_code": sre.item_code,
+						"s_warehouse": sre.warehouse,
+						"t_warehouse": t_warehouse,
+						"batch_no": sb.batch_no,
+						# Reserved Qty in the popup is the SRE remaining
+						# (not the original), per spec. The original
+						# `sre.reserved_qty` stays accessible via the SRE
+						# document if anyone needs it.
+						"reserved_qty": sre_remaining,
+						"delivered_qty": flt(sb.delivered_qty),
+						"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
+						"available_to_receive_qty": flt(ctx["available_qty"]),
+						"reserved_pcs": cint(ctx["reserved_pcs"] or 0),
+						"mop_available_pcs": cint(ctx["mop_log_balance_pcs"]),
+						"available_to_receive_pcs": cint(ctx["available_pcs"]),
+						"already_received_qty": already_received_for_item,
+						"already_received_pcs": ctx["already_received_pcs"],
+						"is_pcs_item": ctx["is_pcs_item"],
+						"mop_log_reference": ctx["mop_log_reference"],
+						"voucher_type": sre.voucher_type,
+						"voucher_no": sre.voucher_no,
+						"voucher_detail_no": sre.voucher_detail_no,
+						"reservation_based_on": sre.reservation_based_on,
+						"stock_uom": sre.stock_uom,
+						"manufacturing_work_order": sre.manufacturing_work_order,
+						"manufacturing_operation": sre.manufacturing_operation,
+						"department": mo.department,
+					}
+				)
+		else:
+			sre_remaining = flt(sre.reserved_qty) - flt(sre.delivered_qty)
+			if sre_remaining <= tolerance:
+				continue
+			ctx = get_available_qty_pcs_for_mop_item(
+				manufacturing_operation=mo.name,
+				item_code=sre.item_code,
+				batch_no=None,
+				warehouse=sre.warehouse,
+				stock_reservation_entry=sre.name,
+				stock_reservation_entry_detail=None,
+				manufacturing_work_order=sre.manufacturing_work_order,
+				sre_remaining_qty=sre_remaining,
+				already_received_qty=already_received_for_item,
+				already_received_pcs=already_received_pcs_for_item,
+				mop_log_balance_map=mop_log_balance_map,
+			)
+			if flt(ctx["available_qty"]) <= tolerance:
+				continue
+			rows.append(
+				{
+					"stock_reservation_entry": sre.name,
+					"stock_reservation_entry_detail": None,
+					"item_code": sre.item_code,
+					"s_warehouse": sre.warehouse,
+					"t_warehouse": t_warehouse,
+					"batch_no": None,
+					"reserved_qty": sre_remaining,
+					"delivered_qty": flt(sre.delivered_qty),
+					"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
+					"available_to_receive_qty": flt(ctx["available_qty"]),
+					"reserved_pcs": cint(ctx["reserved_pcs"] or 0),
+					"mop_available_pcs": cint(ctx["mop_log_balance_pcs"]),
+					"available_to_receive_pcs": cint(ctx["available_pcs"]),
+					"already_received_qty": already_received_for_item,
+					"already_received_pcs": ctx["already_received_pcs"],
+					"is_pcs_item": ctx["is_pcs_item"],
+					"mop_log_reference": ctx["mop_log_reference"],
+					"voucher_type": sre.voucher_type,
+					"voucher_no": sre.voucher_no,
+					"voucher_detail_no": sre.voucher_detail_no,
+					"reservation_based_on": sre.reservation_based_on,
+					"stock_uom": sre.stock_uom,
+					"manufacturing_work_order": sre.manufacturing_work_order,
+					"manufacturing_operation": sre.manufacturing_operation,
+					"department": mo.department,
+				}
+			)
+
+	return rows
+
+
+def _float_tolerance(precision=None):
+	"""Return the tolerance value used to compare floats against zero.
+	Falls back to 0.0001 when System Settings has no precision configured.
+	"""
+	if precision is None:
+		precision = cint(
+			frappe.db.get_single_value("System Settings", "float_precision")
+		)
+	return 10**-precision if precision else 0.0001
+
+
+def _is_positive_qty(qty, tolerance=None):
+	"""True iff qty is strictly greater than the float tolerance.
+	Centralised so every zero-or-near-zero check uses the same rule and
+	never falls into the "Available Qty to Reserve is required" trap."""
+	if tolerance is None:
+		tolerance = _float_tolerance()
+	return flt(qty) > tolerance
+
+
+def _build_replacement_sre(original_sre, remaining_qty, sb_remaining=None):
+	"""Construct a new Stock Reservation Entry for the leftover qty after a
+	partial Material Receive. Mirrors the field set used by
+	stock_reservation_entry_for_mwo in doc_events/stock_entry.py.
+
+	original_sre: the cancelled SRE document.
+	remaining_qty: total remaining qty for the new SRE (Qty-based).
+	sb_remaining: list of {"batch_no": ..., "qty": ...} for batch-based SREs.
+
+	Returns the new SRE name on success, or None when the inputs would
+	otherwise create a zero-qty / empty-batch SRE. Callers must treat None
+	as "no replacement needed".
+
+	ERPNext's `Stock Reservation Entry.validate_mandatory` requires
+	`available_qty` (label "Available Qty to Reserve") in addition to
+	`reserved_qty`. We mirror the existing project convention from
+	`stock_reservation_entry_for_mwo` in doc_events/stock_entry.py:
+	  available_qty = max(get_available_qty_to_reserve(...), reserved_qty)
+	and use `insert(ignore_links=1)` rather than `save()` to match how the
+	project saves SREs everywhere else.
+	"""
+	from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+		get_available_qty_to_reserve,
+	)
+
+	tolerance = _float_tolerance()
+
+	# Filter batch rows once; we use the filtered list for both the SRE check
+	# and the actual append loop to keep them in lockstep.
+	positive_sb_rows = []
+	if sb_remaining:
+		for sb in sb_remaining:
+			if _is_positive_qty(sb.get("qty"), tolerance):
+				positive_sb_rows.append(sb)
+
+	# Guard 1: zero / near-zero total reserved qty -> no replacement.
+	if not _is_positive_qty(remaining_qty, tolerance):
+		return None
+
+	# Guard 2: Serial-and-Batch reservations require at least one positive
+	# sb_entries row; otherwise the SRE will fail validation.
+	is_batch_based = getattr(original_sre, "reservation_based_on", None) != "Qty"
+	if is_batch_based and not positive_sb_rows:
+		return None
+
+	new_sre = frappe.new_doc("Stock Reservation Entry")
+	new_sre.voucher_type = original_sre.voucher_type
+	new_sre.voucher_no = original_sre.voucher_no
+	new_sre.voucher_detail_no = original_sre.voucher_detail_no
+	new_sre.item_code = original_sre.item_code
+	new_sre.warehouse = original_sre.warehouse
+	new_sre.voucher_qty = original_sre.voucher_qty
+	new_sre.reserved_qty = remaining_qty
+	new_sre.company = original_sre.company
+	new_sre.stock_uom = original_sre.stock_uom
+	new_sre.reservation_based_on = original_sre.reservation_based_on
+	new_sre.manufacturing_work_order = original_sre.manufacturing_work_order
+	new_sre.manufacturing_operation = original_sre.manufacturing_operation
+
+	# has_batch_no / has_serial_no — required so ERPNext picks the right
+	# validation branch. Resolve from Item master (matches stock_entry.py:667).
+	has_batch_no, has_serial_no = frappe.get_cached_value(
+		"Item", original_sre.item_code, ["has_batch_no", "has_serial_no"]
+	)
+	new_sre.has_batch_no = cint(has_batch_no)
+	new_sre.has_serial_no = cint(has_serial_no)
+
+	# available_qty (label "Available Qty to Reserve") is mandatory in
+	# ERPNext's validate_mandatory. For batch-tracked items pass the first
+	# batch's qty for the lookup; otherwise warehouse-level.
+	if positive_sb_rows and cint(has_batch_no):
+		available_qty_to_reserve = get_available_qty_to_reserve(
+			original_sre.item_code,
+			original_sre.warehouse,
+			batch_no=positive_sb_rows[0].get("batch_no"),
+		)
+	else:
+		available_qty_to_reserve = get_available_qty_to_reserve(
+			original_sre.item_code, original_sre.warehouse
+		)
+	# Mirror existing project pattern in stock_entry.py:720.
+	new_sre.available_qty = max(flt(available_qty_to_reserve), flt(remaining_qty))
+
+	for sb in positive_sb_rows:
+		new_sre.append(
+			"sb_entries",
+			{"batch_no": sb["batch_no"], "qty": sb["qty"]},
+		)
+
+	new_sre.flags.ignore_permissions = True
+	# insert(ignore_links=1) matches stock_entry.py:737 — required because
+	# the source MR is cancelled before we get here.
+	new_sre.insert(ignore_links=1)
+	new_sre.submit()
+	return new_sre.name
+
+
+@frappe.whitelist()
+def create_mr_wo_stock_entry(se_data, request_id=None):
+	"""Refactored Make Receive Entry creator.
+
+	- Re-fetches every Stock Reservation Entry server-side (client values are
+	  advisory only).
+	- Validates available_qty = reserved_qty - delivered_qty (for active SRE)
+	  on each requested row, with float-precision tolerance.
+	- Creates a single Stock Entry of type Material Receive (WORK ORDER)
+	  stamped with custom_request_id for double-submit idempotency.
+	- After SE submit, cancels (full) or cancels+recreates (partial) each SRE.
+	- Relies on doc_events/stock_entry.sync_mop_log_for_stock_entry to bridge
+	  MOP Log rows (is_synced=1).
+	"""
 	if isinstance(se_data, str):
 		se_data = json.loads(se_data)
 
 	if not se_data.get("receive_items"):
 		return frappe.msgprint("No Receive Items Found.")
 
-	department = se_data.get("department")
-	t_warehouse = frappe.db.get_value(
-		"Warehouse",
-		{"warehouse_type": "Raw Material", "department": department},
-		"name",
-	)
+	mo_name = se_data.get("manufacturing_operation")
+	if not mo_name:
+		frappe.throw(_("Manufacturing Operation is required"))
 
-	# t_warehouse = get_warehouse_from_user(frappe.session.user, "Raw Material")
-	if not t_warehouse:
-		frappe.throw("No warehouse found for warehouse type Raw Material")
-
-	s_warehouse = se_data.get("receive_items")[0].get("s_warehouse")
-	department = se_data.get("department")
-	to_department = se_data.get("receive_items")[0].get("to_department")
-
-	se_doc = frappe.new_doc("Stock Entry")
-	se_doc.update(
-		{
-			"stock_entry_type": "Material Receive (WORK ORDER)",
-			"manufacturing_work_order": se_data.get("manufacturing_work_order"),
-			"manufacturing_order": se_data.get("manufacturing_order"),
-			"manufacturing_operation": se_data.get("manufacturing_operation"),
-			"department": department,
-			"to_department": to_department,
-			"to_warehouse": t_warehouse,
-			"from_warehouse": s_warehouse,
-		}
-	)
-
-	def validate_item_material(row):
-		variant_of = frappe.db.get_value("Item", row.get("item_code"), "variant_of")
-
-		if variant_of in ["D", "G"]:
-			item_type = "Diamond" if variant_of == "D" else "Gemstone"
-			frappe.throw(
-				f"<b>Row: {row.get('idx')}</b> {item_type} Item should have pcs value. Please provide pcs for <b>{row.get('item_code')}</b>."
+	mo = frappe.get_doc("Manufacturing Operation", mo_name)
+	if not mo.manufacturing_work_order:
+		frappe.throw(_("Manufacturing Work Order is required for Make Receive Entry"))
+	if mo.status == "Finished":
+		frappe.throw(
+			_(
+				"Cannot create Material Receive Entry on a Finished Manufacturing Operation."
 			)
-
-	for row in se_data.get("receive_items"):
-		# if not row.get("pcs"):
-		# 	validate_item_material(row)
-
-		se_doc.append(
-			"items",
-			{
-				"item_code": row.get("item_code"),
-				"qty": row.get("qty"),
-				"pcs": row.get("pcs"),
-				"use_serial_batch_fields": 1,
-				"batch_no": row.get("batch_no"),
-				"manufacturing_operation": se_data.get("manufacturing_operation"),
-				"s_warehouse": row.get("s_warehouse"),
-				"t_warehouse": t_warehouse,
-				"inventory_type": row.get("inventory_type"),
-				"customer": row.get("customer"),
-			},
 		)
 
-	# set flag to update pcs
-	frappe.flags.update_pcs = True
+	# Idempotency: same request_id under same MOP + SE type returns the existing SE.
+	if request_id:
+		existing = frappe.db.get_value(
+			"Stock Entry",
+			{
+				"custom_request_id": request_id,
+				"manufacturing_operation": mo.name,
+				"stock_entry_type": "Material Receive (WORK ORDER)",
+				"docstatus": ["!=", 2],
+			},
+			"name",
+		)
+		if existing:
+			return {
+				"doctype": "Stock Entry",
+				"docname": existing,
+				"request_id": request_id,
+				"idempotent": True,
+			}
 
-	se_doc.save()
-	se_doc.submit()
+	t_warehouse = frappe.db.get_value(
+		"Warehouse",
+		{"warehouse_type": "Raw Material", "department": mo.department},
+		"name",
+	)
+	if not t_warehouse:
+		frappe.throw(_("No warehouse found for warehouse type Raw Material"))
 
-	return {"doctype": se_doc.doctype, "docname": se_doc.name}
+	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
+	tolerance = _float_tolerance(precision)
+
+	# Re-fetch and validate every requested row server-side.
+	# Build (validated_rows, sre_actions) before creating the SE.
+	validated_rows = []
+	# sre_actions: list of dicts describing what to do with each SRE post-submit.
+	sre_actions = []
+	for row in se_data.get("receive_items"):
+		sre_name = row.get("stock_reservation_entry")
+		if not sre_name:
+			frappe.throw(
+				_("Row {0}: Stock Reservation Entry is required").format(
+					row.get("idx") or "?"
+				)
+			)
+
+		sre = frappe.db.get_value(
+			"Stock Reservation Entry",
+			sre_name,
+			[
+				"name",
+				"docstatus",
+				"item_code",
+				"warehouse",
+				"reserved_qty",
+				"delivered_qty",
+				"stock_uom",
+				"has_batch_no",
+				"reservation_based_on",
+				"manufacturing_work_order",
+			],
+			as_dict=True,
+		)
+		if not sre or sre.docstatus != 1:
+			frappe.throw(
+				_("Row {0}: Stock Reservation Entry {1} is not active").format(
+					row.get("idx") or "?", sre_name
+				)
+			)
+		if sre.manufacturing_work_order != mo.manufacturing_work_order:
+			frappe.throw(
+				_(
+					"Row {0}: Stock Reservation Entry {1} does not belong to "
+					"this Manufacturing Work Order"
+				).format(row.get("idx") or "?", sre_name)
+			)
+
+		# Authoritative SRE-side remaining qty.
+		batch_based = cint(sre.has_batch_no) and sre.reservation_based_on != "Qty"
+		sb_row = None
+		if batch_based:
+			sb_detail = row.get("stock_reservation_entry_detail")
+			if not sb_detail:
+				frappe.throw(
+					_(
+						"Row {0}: Batch reservation requires "
+						"stock_reservation_entry_detail"
+					).format(row.get("idx") or "?")
+				)
+			sb_row = frappe.db.get_value(
+				"Serial and Batch Entry",
+				sb_detail,
+				["name", "batch_no", "qty", "delivered_qty"],
+				as_dict=True,
+			)
+			if not sb_row:
+				frappe.throw(
+					_("Row {0}: Stock Reservation batch row {1} not found").format(
+						row.get("idx") or "?", sb_detail
+					)
+				)
+			sre_remaining_qty = flt(sb_row.qty) - flt(sb_row.delivered_qty)
+		else:
+			sre_remaining_qty = flt(sre.reserved_qty) - flt(sre.delivered_qty)
+
+		batch_no = (sb_row.batch_no if sb_row else row.get("batch_no")) or None
+
+		req_qty = flt(row.get("qty"))
+		if req_qty <= 0:
+			frappe.throw(
+				_("Row {0}: Receive Qty must be greater than 0").format(
+					row.get("idx") or "?"
+				)
+			)
+		# 1) Reserved-qty cap. Protects the SRE contract; cheap to check
+		#    BEFORE we hit the MOP Log helper so reject-fast tests don't
+		#    need MOP Log mocks.
+		if req_qty > sre_remaining_qty + tolerance:
+			frappe.throw(
+				_(
+					"Row {0}: Receive Qty {1} exceeds reserved qty {2} on "
+					"Stock Reservation Entry {3}"
+				).format(
+					row.get("idx") or "?",
+					req_qty,
+					round(sre_remaining_qty, precision),
+					sre_name,
+				)
+			)
+
+		# Reconciled context: MOP Log balance + min(SRE remaining, MOP balance).
+		# Computed for ALL rows (not just D/G) so qty validation enforces both
+		# the SRE cap and the MOP-balance cap. The helper's `available_qty`
+		# already encodes min(SRE, MOP).
+		ctx = get_available_qty_pcs_for_mop_item(
+			manufacturing_operation=mo.name,
+			item_code=sre.item_code,
+			batch_no=batch_no,
+			warehouse=sre.warehouse,
+			stock_reservation_entry=sre.name,
+			manufacturing_work_order=sre.manufacturing_work_order,
+			sre_remaining_qty=sre_remaining_qty,
+		)
+		mop_available_qty = flt(ctx["mop_log_balance_qty"])
+		available_to_receive_qty = flt(ctx["available_qty"])
+
+		# 2) MOP-balance cap — protects against receiving material that has
+		#    been lost or consumed via Employee IR loss / MOP loss deltas
+		#    since the SRE was created. Skipped when the helper has no MOP
+		#    data for (item, batch) — in that case `available_to_receive_qty`
+		#    falls back to `sre_remaining_qty` and the cap is silent.
+		if req_qty > available_to_receive_qty + tolerance:
+			frappe.throw(
+				_(
+					"Row {0} item {1} batch {2}: Receive Qty {3} exceeds MOP "
+					"available qty {4} (loss/consumption since reservation)"
+				).format(
+					row.get("idx") or "?",
+					sre.item_code,
+					batch_no,
+					req_qty,
+					round(available_to_receive_qty, precision),
+				)
+			)
+
+		# PCS reconciliation (server-side, authoritative). For non-D/G items
+		# PCS is meaningless and is force-zeroed regardless of client value.
+		# For D/G items, the same context above carries the MOP-side PCS cap.
+		first_char = (sre.item_code or "")[0] if sre.item_code else ""
+		is_pcs_item = first_char in ("D", "G")
+		if not is_pcs_item:
+			req_pcs = 0
+		else:
+			req_pcs = cint(row.get("pcs") or 0)
+			if req_pcs < 0:
+				frappe.throw(
+					_("Row {0}: Receive PCS must be >= 0").format(row.get("idx") or "?")
+				)
+			# SRE has no PCS field in this codebase — `reserved_pcs` is None
+			# (unknown). When `available_pcs` is positive (MOP knows the
+			# value), cap by it. Otherwise PCS is unconstrained from the
+			# server's perspective; the caller still enforces >= 0.
+			if ctx["available_pcs"] and req_pcs > ctx["available_pcs"]:
+				frappe.throw(
+					_(
+						"Row {0} item {1} batch {2}: Receive PCS {3} exceeds "
+						"MOP available PCS {4}"
+					).format(
+						row.get("idx") or "?",
+						sre.item_code,
+						batch_no,
+						req_pcs,
+						ctx["available_pcs"],
+					)
+				)
+
+		validated_rows.append(
+			{
+				"item_code": sre.item_code,
+				"qty": req_qty,
+				"pcs": req_pcs,
+				"batch_no": batch_no,
+				"s_warehouse": sre.warehouse,
+				"inventory_type": row.get("inventory_type"),
+				"customer": row.get("customer"),
+			}
+		)
+
+		full = abs(req_qty - sre_remaining_qty) <= tolerance
+		# `mop_data_present` lets the replacement-SRE block distinguish
+		# "MOP Log shows 0g for this batch" (cap replacement to 0g) from
+		# "MOP Log has no row for this (item, batch)" (no cap, fall back
+		# to SRE-only). Without this signal the safe rule would shrink
+		# every replacement to 0 in environments without MOP data.
+		sre_actions.append(
+			{
+				"sre_name": sre.name,
+				"batch_based": batch_based,
+				"sb_row_name": sb_row.name if sb_row else None,
+				"req_qty": req_qty,
+				"sre_remaining_qty": sre_remaining_qty,
+				"mop_available_qty": mop_available_qty,
+				"mop_data_present": bool(ctx.get("mop_log_reference")),
+				"full": full,
+			}
+		)
+
+	# Build the Stock Entry. All preceding validations succeeded.
+	frappe.db.savepoint("make_receive_entry")
+	try:
+		se_doc = frappe.new_doc("Stock Entry")
+		se_doc.update(
+			{
+				"stock_entry_type": "Material Receive (WORK ORDER)",
+				"manufacturing_work_order": mo.manufacturing_work_order,
+				"manufacturing_order": mo.manufacturing_order,
+				"manufacturing_operation": mo.name,
+				"department": mo.department,
+				"to_warehouse": t_warehouse,
+				"from_warehouse": validated_rows[0]["s_warehouse"],
+			}
+		)
+		if request_id:
+			se_doc.custom_request_id = request_id
+
+		for vrow in validated_rows:
+			se_doc.append(
+				"items",
+				{
+					"item_code": vrow["item_code"],
+					"qty": vrow["qty"],
+					"pcs": vrow["pcs"],
+					"use_serial_batch_fields": 1,
+					"batch_no": vrow["batch_no"],
+					"manufacturing_operation": mo.name,
+					"s_warehouse": vrow["s_warehouse"],
+					"t_warehouse": t_warehouse,
+					"inventory_type": vrow["inventory_type"],
+					"customer": vrow["customer"],
+				},
+			)
+
+		# Preserve existing flag — load-bearing for downstream pcs handling.
+		frappe.flags.update_pcs = True
+
+		se_doc.save()
+		se_doc.submit()
+
+		# Post-submit SRE mutation. Full receive cancels; partial cancels and
+		# recreates with remaining qty, preserving voucher_*, batch metadata.
+		# Replacement qty is capped at the remaining MOP balance after the
+		# receive (the safe rule): a reservation must never claim material
+		# that MOP Log says is already lost/consumed. When the helper had no
+		# MOP data, `mop_available_qty` falls back to `sre_remaining_qty`
+		# which makes the cap silent and preserves the prior behavior.
+		sre_outcomes = []
+		for action in sre_actions:
+			original = frappe.get_doc("Stock Reservation Entry", action["sre_name"])
+			# A "full" receive against the SRE remaining cancels with no
+			# replacement regardless of MOP balance — there is nothing left
+			# to reserve.
+			if action["full"] and not action["batch_based"]:
+				original.cancel()
+				sre_outcomes.append(
+					{"old": action["sre_name"], "new": None, "action": "cancelled"}
+				)
+				continue
+
+			if action["batch_based"]:
+				# Recompute remaining batch rows: for the consumed batch the
+				# replacement qty is min(SRE-remaining-after, MOP-remaining-after)
+				# when MOP data is present; otherwise SRE-remaining-after
+				# alone. Untouched batches keep their full SRE remaining
+				# (their MOP balance is independent of the consumed batch).
+				sb_remaining = []
+				new_total = 0.0
+				for sb in frappe.get_all(
+					"Serial and Batch Entry",
+					filters={"parent": original.name},
+					fields=["name", "batch_no", "qty", "delivered_qty"],
+				):
+					if sb.name == action["sb_row_name"]:
+						reserved_after = max(
+							0.0,
+							flt(sb.qty) - flt(sb.delivered_qty) - action["req_qty"],
+						)
+						if action.get("mop_data_present"):
+							mop_after = max(
+								0.0,
+								flt(action["mop_available_qty"]) - action["req_qty"],
+							)
+							left = min(reserved_after, mop_after)
+						else:
+							left = reserved_after
+					else:
+						left = flt(sb.qty) - flt(sb.delivered_qty)
+					if _is_positive_qty(left, tolerance):
+						sb_remaining.append({"batch_no": sb.batch_no, "qty": left})
+						new_total += left
+				original.cancel()
+				new_name = None
+				if _is_positive_qty(new_total, tolerance):
+					new_name = _build_replacement_sre(
+						original, new_total, sb_remaining=sb_remaining
+					)
+				sre_outcomes.append(
+					{
+						"old": action["sre_name"],
+						"new": new_name,
+						"action": "recreated" if new_name else "cancelled",
+					}
+				)
+			else:
+				# Qty-based partial: cancel + recreate with the safe-rule cap.
+				# When MOP data is present:
+				#   replacement_qty = min(remaining_reserved_after_receive,
+				#                          remaining_mop_after_receive)
+				# When MOP data is absent (test envs / freshly-created MOPs):
+				#   replacement_qty = remaining_reserved_after_receive
+				reserved_after = max(
+					0.0,
+					flt(action["sre_remaining_qty"]) - flt(action["req_qty"]),
+				)
+				if action.get("mop_data_present"):
+					mop_after = max(
+						0.0,
+						flt(action["mop_available_qty"]) - flt(action["req_qty"]),
+					)
+					remaining = min(reserved_after, mop_after)
+				else:
+					remaining = reserved_after
+				original.cancel()
+				new_name = None
+				if _is_positive_qty(remaining, tolerance):
+					new_name = _build_replacement_sre(original, remaining)
+				sre_outcomes.append(
+					{
+						"old": action["sre_name"],
+						"new": new_name,
+						"action": "recreated" if new_name else "cancelled",
+					}
+				)
+
+		frappe.db.release_savepoint("make_receive_entry")
+	except Exception:
+		frappe.db.rollback(save_point="make_receive_entry")
+		raise
+
+	return {
+		"doctype": se_doc.doctype,
+		"docname": se_doc.name,
+		"request_id": request_id,
+		"sre_actions": sre_outcomes,
+		"idempotent": False,
+	}
 
 
 def update_new_mop_wtg(self):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
@@ -46,9 +46,12 @@ class MOPLog(Document):
 						f"{prefix}_pcs": pcs_after_prefix,
 					}
 				)
-			frappe.db.set_value(
-				"Manufacturing Operation", self.manufacturing_operation, update_value
-			)
+			if not (self.get("loss_type")):
+				frappe.db.set_value(
+					"Manufacturing Operation",
+					self.manufacturing_operation,
+					update_value,
+				)
 			update_wt_detail(self.manufacturing_operation)
 
 
@@ -111,8 +114,12 @@ def create_mop_log_for_stock_transfer_to_mo(doc, row, is_synced=False):
 
 	first_char = item_code[0]
 	# safe numeric conversions (pcs might be None)
-	pcs = cint(row.get("pcs") or 0)
-	qty = flt(row.get("qty") or 0.0)
+	if doc.stock_entry_type == "Material Receive (WORK ORDER)":
+		pcs = -cint(row.get("pcs") or 0)
+		qty = -flt((row.get("qty") or 0.0), 3)
+	else:
+		pcs = cint(row.get("pcs") or 0)
+		qty = flt((row.get("qty") or 0.0), 3)
 	batch_no = row.get("batch_no")
 	mwo = doc.get("manufacturing_work_order")
 	mop_op = row.get("manufacturing_operation")
@@ -238,7 +245,13 @@ def get_last_mop_index(manufacturing_operation, voucher_type=None, voucher_no=No
 
 
 def get_current_mop_balance_rows(manufacturing_operation, include_fields=None):
-	"""Return the latest non-cancelled MOP Log row per item/batch for a MOP."""
+	"""Return the latest non-cancelled MOP Log row per item/batch for a MOP.
+
+	Loss-attribution rows (log_category="Loss Attribution") ARE included —
+	they post a real qty_change reduction so the balance after loss must be
+	reflected to downstream readers (e.g. Make Receive Entry availability,
+	manual loss validation, EOD SRE reconciliation).
+	"""
 	fields = list(
 		dict.fromkeys((include_fields or current_balance_fields) + ["name", "creation"])
 	)
@@ -261,6 +274,92 @@ def get_current_mop_balance_rows(manufacturing_operation, include_fields=None):
 			latest_by_key[key] = log
 
 	return list(reversed(list(latest_by_key.values())))
+
+
+def get_available_qty_pcs_for_mop_item(
+	manufacturing_operation,
+	item_code,
+	batch_no=None,
+	warehouse=None,
+	stock_reservation_entry=None,
+	stock_reservation_entry_detail=None,
+	manufacturing_work_order=None,
+	sre_remaining_qty=None,
+	already_received_qty=0,
+	already_received_pcs=0,
+	mop_log_balance_map=None,
+):
+	"""Reconcile Qty/PCS for a single MOP item/batch row.
+
+	Cross-checks Stock Reservation Entry, MOP Log, and Stock Entry to produce
+	a single dict the Make Receive Entry popup, the server validator
+	(``create_mr_wo_stock_entry``) and Employee IR manual-loss validation
+	can all consume.
+
+	is_pcs_item is gated by FIELD_MAP membership AND item_code[0] in (D, G).
+
+	available_qty = min(positive authoritative values among SRE remaining qty
+	and MOP Log batch-based qty). Missing values are treated as "no signal"
+	(spec: ``If one source does not store PCS, do not treat missing PCS as
+	zero. Treat it as unknown.`` — same rule applied to qty).
+
+	available_pcs:
+	  * 0 for non-D/G items.
+	  * For D/G, MOP Log batch-based PCS is the authoritative source. SRE has
+	    no PCS field, so it is excluded from the candidate set (treating it
+	    as 0 would force Available PCS to 0 incorrectly per spec).
+	  * 0 falls through when no MOP Log row exists for (item, batch).
+	"""
+	is_pcs_item = bool(item_code) and item_code[0] in ("D", "G")
+
+	if mop_log_balance_map is None:
+		rows = get_current_mop_balance_rows(manufacturing_operation)
+		mop_log_balance_map = {
+			(row.get("item_code"), row.get("batch_no")): row for row in rows
+		}
+
+	mop_row = mop_log_balance_map.get((item_code, batch_no))
+	mop_qty_raw = mop_row.get("qty_after_transaction_batch_based") if mop_row else None
+	mop_pcs_raw = mop_row.get("pcs_after_transaction_batch_based") if mop_row else None
+	mop_log_reference = mop_row.get("name") if mop_row else None
+
+	qty_candidates = []
+	if sre_remaining_qty is not None:
+		qty_candidates.append(flt(sre_remaining_qty))
+	if mop_qty_raw is not None:
+		qty_candidates.append(flt(mop_qty_raw))
+	# Clamp negative balances to 0; downstream callers/UI round for display.
+	available_qty = max(0.0, min(qty_candidates)) if qty_candidates else 0.0
+
+	if not is_pcs_item:
+		available_pcs = 0
+	else:
+		pcs_candidates = []
+		if mop_pcs_raw is not None:
+			pcs_candidates.append(cint(mop_pcs_raw))
+		# SRE never stores PCS, so it does NOT enter the candidate set.
+		available_pcs = max(0, min(pcs_candidates)) if pcs_candidates else 0
+
+	return {
+		"item_code": item_code,
+		"batch_no": batch_no,
+		"source_warehouse": warehouse,
+		"stock_reservation_entry": stock_reservation_entry,
+		"stock_reservation_entry_detail": stock_reservation_entry_detail,
+		"manufacturing_work_order": manufacturing_work_order,
+		"reserved_qty": flt(sre_remaining_qty or 0),
+		"reserved_pcs": None,
+		"mop_log_balance_qty": flt(mop_qty_raw or 0),
+		"mop_log_balance_pcs": cint(mop_pcs_raw or 0),
+		"stock_entry_transferred_qty": 0,
+		"stock_entry_transferred_pcs": 0,
+		"already_received_qty": flt(already_received_qty or 0),
+		"already_received_pcs": cint(already_received_pcs or 0),
+		"available_qty": available_qty,
+		"available_pcs": available_pcs,
+		"is_pcs_item": is_pcs_item,
+		"mop_log_reference": mop_log_reference,
+	}
 
 
 def create_mop_log_for_department_ir(
@@ -507,3 +606,116 @@ def create_mop_log_for_employee_ir_receive(
 		mop_log.batch_no = log.batch_no
 		mop_log.flow_index = log.flow_index + 1
 		mop_log.save()
+
+
+def create_mop_log_for_employee_ir_loss(
+	eir_doc, loss_row, loss_type, total_loss_for_mwo, from_wh=None, to_wh=None
+):
+	"""Bridge writer for Employee IR Receive loss attribution.
+
+	Posts each loss detail as a real MOP Log movement so the Manufacturing
+	Operation weight bucket is reduced by the loss amount. Concretely:
+
+	  qty_change                       = -loss_weight (gram)
+	  qty_after_transaction*           = previous balance - loss_weight
+
+	When MOPLog.validate() runs it writes ``qty_after_transaction`` into the
+	prefix bucket (net_wt / finding_wt / diamond_wt / gemstone_wt / other_wt)
+	on Manufacturing Operation, so the post-loss weight is reflected without
+	any additional bookkeeping here.
+
+	Carat-denominated rows (typical for D / G items) are converted to grams
+	via x0.2 so the MOP Log balance — which is gram-based — stays consistent.
+
+	Idempotent on (voucher_type, voucher_no, manufacturing_operation,
+	loss_source_row, loss_type, is_cancelled=0). is_synced=1 keeps the EOD
+	sync from re-materializing it.
+	"""
+	raw = flt(loss_row.proportionally_loss)
+	stock_uom = frappe.get_cached_value("Item", loss_row.item_code, "stock_uom")
+	loss_weight = raw * 0.2 if stock_uom == "Carat" else raw
+	if loss_weight <= 0:
+		return None
+
+	if frappe.db.exists(
+		"MOP Log",
+		{
+			"voucher_type": "Employee IR",
+			"voucher_no": eir_doc.name,
+			"manufacturing_operation": loss_row.manufacturing_operation,
+			"loss_source_row": loss_row.name,
+			"loss_type": loss_type,
+			"is_cancelled": 0,
+		},
+	):
+		return None
+
+	pct = (loss_weight / total_loss_for_mwo) if total_loss_for_mwo else 0
+
+	# Latest balance for this (item, batch) on the same MOP. Includes any
+	# prior loss-attribution rows so successive loss postings stack.
+	latest = (
+		frappe.db.get_value(
+			"MOP Log",
+			{
+				"manufacturing_operation": loss_row.manufacturing_operation,
+				"item_code": loss_row.item_code,
+				"batch_no": loss_row.batch_no,
+				"is_cancelled": 0,
+			},
+			[
+				"qty_after_transaction",
+				"qty_after_transaction_item_based",
+				"qty_after_transaction_batch_based",
+				"pcs_after_transaction",
+				"pcs_after_transaction_item_based",
+				"pcs_after_transaction_batch_based",
+				"flow_index",
+			],
+			order_by="creation desc",
+			as_dict=True,
+		)
+		or {}
+	)
+
+	# Loss reduces qty balance by loss_weight; PCS balance is preserved (loss
+	# is recorded by weight, not by piece count).
+	pcs_change = 0
+	if loss_row.item_code[0] in ("D", "G"):
+		pcs_change = -cint(loss_row.pcs or 0)
+	mop_log = frappe.new_doc("MOP Log")
+	mop_log.item_code = loss_row.item_code
+	mop_log.batch_no = loss_row.batch_no
+	mop_log.qty_change = -flt(loss_weight, 3)
+	mop_log.pcs_change = pcs_change
+	for k in (
+		"qty_after_transaction",
+		"qty_after_transaction_item_based",
+		"qty_after_transaction_batch_based",
+	):
+		mop_log.set(k, flt(latest.get(k) or 0) - flt(loss_weight, 3))
+	for k in (
+		"pcs_after_transaction",
+		"pcs_after_transaction_item_based",
+		"pcs_after_transaction_batch_based",
+	):
+		mop_log.set(k, latest.get(k) or 0)
+	# Do not advance flow_index — loss attribution is booked at the same
+	# materialization tier as the receive that triggered it.
+	mop_log.flow_index = latest.get("flow_index") or 0
+	mop_log.from_warehouse = from_wh
+	mop_log.to_warehouse = to_wh
+	mop_log.voucher_type = "Employee IR"
+	mop_log.voucher_no = eir_doc.name
+	mop_log.manufacturing_operation = loss_row.manufacturing_operation
+	mop_log.manufacturing_work_order = loss_row.manufacturing_work_order
+	mop_log.row_name = loss_row.name
+	mop_log.is_synced = 1
+	# Loss attribution fields (custom_fields/mop_log.json)
+	mop_log.log_category = "Loss Attribution"
+	mop_log.loss_type = loss_type
+	mop_log.loss_weight = flt(loss_weight, 3)
+	mop_log.loss_percentage = flt(pct * 100, 4)
+	mop_log.loss_source_row = loss_row.name
+	mop_log.save()
+	return mop_log.name

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_lineage_stock_entry_bridge.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_lineage_stock_entry_bridge.py
@@ -7,11 +7,25 @@ from unittest.mock import MagicMock, patch
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
-	update_balance_table,
+try:
+	from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
+		update_balance_table,
+	)
+except ImportError:
+	# `update_balance_table` was removed when MOP balance moved from the
+	# legacy mop_balance_table child to the MOP Log table. Fall through with
+	# a stub so this module is still importable; the test class below is
+	# skipped at runtime via @unittest.skipIf.
+	update_balance_table = None
+
+
+import unittest
+
+
+@unittest.skipIf(
+	update_balance_table is None,
+	"update_balance_table was removed; MOP Log is now the source of truth.",
 )
-
-
 class TestStockEntryLegacyBalanceTable(FrappeTestCase):
 	def test_update_balance_table_appends_rows_per_legacy_key(self):
 		mop_doc = MagicMock()
@@ -132,9 +146,7 @@ class TestStockEntryMopLogBridge(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.exists",
 		return_value=False,
 	)
-	@patch(
-		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.create_mop_log"
-	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.create_mop_log")
 	def test_bridge_writes_one_log_per_mop_bound_row(self, mock_create, mock_exists):
 		from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
 			sync_mop_log_for_stock_entry,
@@ -159,10 +171,10 @@ class TestStockEntryMopLogBridge(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.exists",
 		return_value=True,
 	)
-	@patch(
-		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.create_mop_log"
-	)
-	def test_bridge_is_idempotent_when_log_already_exists(self, mock_create, mock_exists):
+	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.create_mop_log")
+	def test_bridge_is_idempotent_when_log_already_exists(
+		self, mock_create, mock_exists
+	):
 		from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
 			sync_mop_log_for_stock_entry,
 		)
@@ -225,11 +237,10 @@ class TestEmployeeIrDiamondLineageAudit(FrappeTestCase):
 	def test_diagnoses_missing_mop_log_when_se_exists(self):
 		from jewellery_erpnext import mop_lineage_audit
 
-		with patch.object(
-			mop_lineage_audit.frappe.db, "get_value", return_value=None
-		), patch.object(
-			mop_lineage_audit.frappe.db, "sql"
-		) as mock_sql:
+		with (
+			patch.object(mop_lineage_audit.frappe.db, "get_value", return_value=None),
+			patch.object(mop_lineage_audit.frappe.db, "sql") as mock_sql,
+		):
 			mock_sql.side_effect = [
 				[("EIR-ISSUE-1",)],
 				[],

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
@@ -35,7 +35,7 @@ department transfer. Physical batch validation is unchanged; splitting does not 
 
 import frappe
 from frappe import _
-from frappe.utils import flt, cint
+from frappe.utils import cint, flt
 
 
 def sync_mop_logs():
@@ -50,6 +50,17 @@ def sync_mop_logs():
 			se_names, count = _sync_consolidated_group(group_key, mop_data_list)
 			stock_entries.extend(se_names)
 			processed += count
+			# Stamp Manufacturing Operation only on success — never on rollback.
+			# update_modified=False keeps the audit "modified" timestamp clean.
+			now_ts = frappe.utils.now()
+			for d in mop_data_list:
+				frappe.db.set_value(
+					"Manufacturing Operation",
+					d["mop_name"],
+					"last_eod_sync_on",
+					now_ts,
+					update_modified=False,
+				)
 			frappe.db.release_savepoint("mop_eod_sync_hop")
 		except Exception:
 			frappe.db.rollback(save_point="mop_eod_sync_hop")
@@ -59,7 +70,101 @@ def sync_mop_logs():
 				message=f"Failed routing {first_wh} -> {last_wh}\n{frappe.get_traceback()}",
 			)
 
+	# Audit-first SRE reconciliation. Default dry_run=True simply logs what
+	# would be cancelled; pass dry_run=False from a console session to actually
+	# cancel zero-balance reservations.
+	processed_mwos = {key[1] for key in unsynced_groups.keys()}
+	for mwo in processed_mwos:
+		try:
+			_reconcile_reservations_for_mwo(mwo, dry_run=True)
+		except Exception:
+			frappe.log_error(
+				title=f"MOP EOD SRE reconcile failed for MWO {mwo}",
+				message=frappe.get_traceback(),
+			)
+
 	return {"processed": processed, "stock_entries": stock_entries}
+
+
+def _reconcile_reservations_for_mwo(mwo, dry_run=True):
+	"""Audit-first Stock Reservation Entry reconciliation.
+
+	Iterates active SREs for a MWO and finds rows where:
+	  - SRE has remaining qty (reserved - delivered > 0), AND
+	  - the latest non-cancelled MOP movement balance for the same
+	    (item_code, warehouse) is zero.
+
+	When dry_run=True (default), only logs which SREs would be cancelled.
+	When dry_run=False, cancels them under per-SRE savepoints so a single bad
+	reservation does not poison the entire EOD run.
+
+	Never cancels SREs with ambiguous (positive but partial) balances.
+	"""
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+		get_current_mop_balance_rows,
+	)
+
+	sres = frappe.db.get_all(
+		"Stock Reservation Entry",
+		filters={
+			"manufacturing_work_order": mwo,
+			"docstatus": 1,
+		},
+		fields=[
+			"name",
+			"item_code",
+			"warehouse",
+			"reserved_qty",
+			"delivered_qty",
+			"manufacturing_operation",
+		],
+	)
+	for sre in sres:
+		remaining = flt(sre.reserved_qty) - flt(sre.delivered_qty)
+		if remaining <= 0:
+			continue
+		if not sre.manufacturing_operation:
+			continue
+		# Use the existing balance helper (filters out loss-attribution rows).
+		balance_rows = get_current_mop_balance_rows(
+			sre.manufacturing_operation,
+			include_fields=[
+				"item_code",
+				"batch_no",
+				"qty_after_transaction_batch_based as qty",
+				"to_warehouse",
+			],
+		)
+		# Match on item_code and to_warehouse — t_warehouse on the inbound
+		# movement equals SRE.warehouse (verified against
+		# stock_entry.stock_reservation_entry_for_mwo).
+		matched = [
+			b
+			for b in balance_rows
+			if b.get("item_code") == sre.item_code
+			and b.get("to_warehouse") == sre.warehouse
+		]
+		balance_qty = sum(flt(b.get("qty")) for b in matched)
+		if balance_qty <= 0:
+			msg = (
+				f"EOD SRE reconcile: {sre.name} (MWO {mwo}, item "
+				f"{sre.item_code}, wh {sre.warehouse}) has no MOP balance "
+				f"(remaining={remaining}, balance=0)."
+			)
+			if dry_run:
+				frappe.logger().info(f"{msg} DRY-RUN -- would cancel.")
+			else:
+				frappe.db.savepoint("eod_sre_reconcile")
+				try:
+					frappe.get_doc("Stock Reservation Entry", sre.name).cancel()
+					frappe.logger().info(f"{msg} CANCELLED.")
+					frappe.db.release_savepoint("eod_sre_reconcile")
+				except Exception:
+					frappe.db.rollback(save_point="eod_sre_reconcile")
+					frappe.log_error(
+						title=f"EOD SRE reconcile cancel failed: {sre.name}",
+						message=frappe.get_traceback(),
+					)
 
 
 def _get_unsynced_mop_groups():
@@ -67,6 +172,9 @@ def _get_unsynced_mop_groups():
 	Return a dict of {(company, mwo, first_wh, last_wh): [{'mop_name': ..., 'mop_doc': ..., 'logs': ...}]}
 	for all unsynced logs grouped by routing hop.
 	"""
+	# Loss-attribution rows are written with is_synced=1 (Employee IR bridge
+	# writer), so they are excluded here naturally — no extra log_category
+	# filter is needed.
 	logs = frappe.db.get_all(
 		"MOP Log",
 		filters={"is_synced": 0, "is_cancelled": 0},
@@ -111,11 +219,11 @@ def _get_unsynced_mop_groups():
 				as_dict=True,
 			)
 			mop_cache[mop_name] = mop_doc_dict
-			
+
 		mop = mop_cache[mop_name]
 		if not mop:
 			continue
-			
+
 		first_wh, last_wh = _resolve_warehouses(op_logs)
 		if not first_wh or not last_wh:
 			frappe.log_error(
@@ -128,11 +236,9 @@ def _get_unsynced_mop_groups():
 			continue
 
 		group_key = (mop.company, mop.manufacturing_work_order, first_wh, last_wh)
-		groups.setdefault(group_key, []).append({
-			"mop_name": mop_name,
-			"mop_doc": mop,
-			"logs": op_logs
-		})
+		groups.setdefault(group_key, []).append(
+			{"mop_name": mop_name, "mop_doc": mop, "logs": op_logs}
+		)
 
 	return groups
 
@@ -140,8 +246,8 @@ def _get_unsynced_mop_groups():
 def _latest_flow_logs(logs):
 	if not logs:
 		return []
-	max_idx = max(l.flow_index for l in logs)
-	return [l for l in logs if l.flow_index == max_idx]
+	max_idx = max(log.flow_index for log in logs)
+	return [log for log in logs if log.flow_index == max_idx]
 
 
 def _mop_manufacturer_label(mop):
@@ -225,7 +331,9 @@ def _sync_consolidated_group(group_key, mop_data_list):
 		if not manufacturing_order:
 			manufacturing_order = mop.manufacturing_order
 
-		items_to_transfer.extend(_build_transfer_rows_for_mop(mop_data, first_wh, last_wh))
+		items_to_transfer.extend(
+			_build_transfer_rows_for_mop(mop_data, first_wh, last_wh)
+		)
 
 		latest_logs = _latest_flow_logs(logs)
 		loss_wt = flt(mop.loss_wt, 3)
@@ -292,7 +400,9 @@ def _sync_consolidated_group(group_key, mop_data_list):
 				loss_wt = flt(mop.loss_wt, 3)
 				if loss_wt < 0:
 					se_names.extend(
-						_create_loss_entries(mop, mop_name, latest_logs, last_wh, abs(loss_wt))
+						_create_loss_entries(
+							mop, mop_name, latest_logs, last_wh, abs(loss_wt)
+						)
 					)
 
 	if not used_per_mop_fallback:
@@ -304,9 +414,6 @@ def _sync_consolidated_group(group_key, mop_data_list):
 	return se_names, len(all_processed_logs)
 
 
-
-
-
 def _resolve_warehouses(logs):
 	"""Determine the first source warehouse and last target warehouse from the log chain."""
 	if not logs:
@@ -315,8 +422,8 @@ def _resolve_warehouses(logs):
 	first_wh = None
 	last_wh = None
 
-	min_idx = min(l.flow_index for l in logs)
-	max_idx = max(l.flow_index for l in logs)
+	min_idx = min(log.flow_index for log in logs)
+	max_idx = max(log.flow_index for log in logs)
 
 	for log in logs:
 		if log.flow_index == min_idx and log.from_warehouse and not first_wh:
@@ -395,7 +502,9 @@ def _collect_mop_names(mop_data_list):
 	return ", ".join(names)
 
 
-def _list_open_sre_for_batch(item_code, warehouse, batch_no, manufacturing_work_order=None):
+def _list_open_sre_for_batch(
+	item_code, warehouse, batch_no, manufacturing_work_order=None
+):
 	"""Submitted Serial/Batch SRE rows with undelivered qty at ``warehouse`` (diagnostics)."""
 	from frappe.query_builder.functions import Sum
 
@@ -464,7 +573,9 @@ def _format_batch_short_diagnostics(
 	if company:
 		lines.append(_("Company: {0}").format(company))
 	if manufacturing_work_order:
-		lines.append(_("Manufacturing Work Order: {0}").format(manufacturing_work_order))
+		lines.append(
+			_("Manufacturing Work Order: {0}").format(manufacturing_work_order)
+		)
 	mops = _collect_mop_names(mop_data_list)
 	if mops:
 		lines.append(_("Manufacturing Operation(s): {0}").format(mops))
@@ -475,10 +586,15 @@ def _format_batch_short_diagnostics(
 		lines.append(_("Manufacturer: (not set on Operation / Work Order)"))
 
 	sre_here = _list_open_sre_for_batch(
-		item_code, warehouse, batch_no, manufacturing_work_order=manufacturing_work_order
+		item_code,
+		warehouse,
+		batch_no,
+		manufacturing_work_order=manufacturing_work_order,
 	)
 	if not sre_here and manufacturing_work_order:
-		sre_here = _list_open_sre_for_batch(item_code, warehouse, batch_no, manufacturing_work_order=None)
+		sre_here = _list_open_sre_for_batch(
+			item_code, warehouse, batch_no, manufacturing_work_order=None
+		)
 
 	total_open_here = 0.0
 	for row in sre_here:
@@ -516,13 +632,17 @@ def _format_batch_short_diagnostics(
 			]
 			if parts:
 				lines.append(
-					_("Open reservations on other warehouse(s) (sample): {0}").format("; ".join(parts))
+					_("Open reservations on other warehouse(s) (sample): {0}").format(
+						"; ".join(parts)
+					)
 				)
 
 	return "\n".join(lines)
 
 
-def _get_sre_undelivered_batch_qty(item_code, warehouse, batch_no, manufacturing_work_order=None):
+def _get_sre_undelivered_batch_qty(
+	item_code, warehouse, batch_no, manufacturing_work_order=None
+):
 	"""Sum undelivered qty on submitted Serial/Batch Stock Reservation Entry rows (audit helper)."""
 	from frappe.query_builder.functions import Sum
 
@@ -626,7 +746,10 @@ def _validate_eod_source_batch_stock(
 
 		if manufacturing_work_order:
 			sre_open = _get_sre_undelivered_batch_qty(
-				item_code, wh, batch_no, manufacturing_work_order=manufacturing_work_order
+				item_code,
+				wh,
+				batch_no,
+				manufacturing_work_order=manufacturing_work_order,
 			)
 			if sre_open + 1e-6 < req_qty:
 				frappe.log_error(
@@ -650,15 +773,19 @@ def _validate_eod_source_batch_stock(
 def _create_loss_entries(mop, mop_name, latest_logs, warehouse, total_loss):
 	"""Create Repack Stock Entry for process loss."""
 	from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
-		get_item_loss_item,
+		get_loss_item_from_manufacturer_mapping,
 	)
 
 	se_names = []
-	metal_logs = [l for l in latest_logs if l.item_code and l.item_code[0] in ("M", "F")]
+	metal_logs = [
+		log for log in latest_logs if log.item_code and log.item_code[0] in ("M", "F")
+	]
 	if not metal_logs:
 		return se_names
 
-	total_metal_qty = sum(flt(l.qty_after_transaction_batch_based, 3) for l in metal_logs)
+	total_metal_qty = sum(
+		flt(log.qty_after_transaction_batch_based, 3) for log in metal_logs
+	)
 	if total_metal_qty <= 0:
 		return se_names
 
@@ -673,9 +800,9 @@ def _create_loss_entries(mop, mop_name, latest_logs, warehouse, total_loss):
 	if variant_loss_details:
 		if variant_loss_details.get("loss_warehouse"):
 			loss_warehouse = variant_loss_details.get("loss_warehouse")
-		elif variant_loss_details.get("consider_department_warehouse") and variant_loss_details.get(
-			"warehouse_type"
-		):
+		elif variant_loss_details.get(
+			"consider_department_warehouse"
+		) and variant_loss_details.get("warehouse_type"):
 			loss_warehouse = frappe.db.get_value(
 				"Warehouse",
 				{
@@ -721,7 +848,12 @@ def _create_loss_entries(mop, mop_name, latest_logs, warehouse, total_loss):
 		)
 
 	if se.items:
-		loss_item = get_item_loss_item(mop.company, se.items[0].item_code, "M")
+		# Manufacturer-scoped resolution. Throws a clear configuration error
+		# when the Manufacturer's Variant Loss Table mapping is missing — does
+		# not silently fall through.
+		loss_item = get_loss_item_from_manufacturer_mapping(
+			se.items[0].item_code, mop.manufacturer, loss_type="Loss"
+		)
 		if loss_item:
 			se.append(
 				"items",
@@ -743,7 +875,7 @@ def _create_loss_entries(mop, mop_name, latest_logs, warehouse, total_loss):
 
 def _mark_synced(logs):
 	"""Mark all MOP Log entries as synced."""
-	log_names = [l.name for l in logs]
+	log_names = [log.name for log in logs]
 	if log_names:
 		frappe.db.set_value(
 			"MOP Log",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_eod_sync.py
@@ -75,38 +75,68 @@ class FlakyFakeStockEntry(FakeStockEntry):
 
 
 class TestMopEodSyncGrouping(FrappeTestCase):
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_all")
-	def test_get_unsynced_mop_groups_groups_by_routing_hop(self, mock_get_all, mock_get_value):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_all"
+	)
+	def test_get_unsynced_mop_groups_groups_by_routing_hop(
+		self, mock_get_all, mock_get_value
+	):
 		mock_get_all.return_value = [
-			_log(name="LOG-1", manufacturing_operation="MOP-A", flow_index=1, from_warehouse="WH-1", to_warehouse="WH-2", manufacturing_work_order="MWO-1"),
-			_log(name="LOG-2", manufacturing_operation="MOP-B", flow_index=1, from_warehouse="WH-1", to_warehouse="WH-2", manufacturing_work_order="MWO-1"),
-			_log(name="LOG-3", manufacturing_operation="MOP-C", flow_index=1, from_warehouse="WH-2", to_warehouse="WH-3", manufacturing_work_order="MWO-1"),
+			_log(
+				name="LOG-1",
+				manufacturing_operation="MOP-A",
+				flow_index=1,
+				from_warehouse="WH-1",
+				to_warehouse="WH-2",
+				manufacturing_work_order="MWO-1",
+			),
+			_log(
+				name="LOG-2",
+				manufacturing_operation="MOP-B",
+				flow_index=1,
+				from_warehouse="WH-1",
+				to_warehouse="WH-2",
+				manufacturing_work_order="MWO-1",
+			),
+			_log(
+				name="LOG-3",
+				manufacturing_operation="MOP-C",
+				flow_index=1,
+				from_warehouse="WH-2",
+				to_warehouse="WH-3",
+				manufacturing_work_order="MWO-1",
+			),
 		]
-		
+
 		# Mocking the MOP metadata fetches
 		def mock_mop_value(dt, name, fields, as_dict):
-			return FrappeDict({
-				"company": "Company",
-				"manufacturer": "MF-1",
-				"manufacturing_work_order": "MWO-1",
-				"manufacturing_order": "MO-1",
-				"department": "Dept",
-				"loss_wt": 0,
-			})
+			return FrappeDict(
+				{
+					"company": "Company",
+					"manufacturer": "MF-1",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_order": "MO-1",
+					"department": "Dept",
+					"loss_wt": 0,
+				}
+			)
+
 		mock_get_value.side_effect = mock_mop_value
 
 		out = _get_unsynced_mop_groups()
 
 		group_keys = sorted(list(out.keys()))
 		self.assertEqual(len(group_keys), 2)
-		
+
 		key_wh1_wh2 = ("Company", "MWO-1", "WH-1", "WH-2")
 		key_wh2_wh3 = ("Company", "MWO-1", "WH-2", "WH-3")
-		
+
 		self.assertIn(key_wh1_wh2, group_keys)
 		self.assertIn(key_wh2_wh3, group_keys)
-		
+
 		# MOP A and B should be in the WH1->WH2 bucket
 		self.assertEqual(len(out[key_wh1_wh2]), 2)
 		self.assertEqual(out[key_wh1_wh2][0]["mop_name"], "MOP-A")
@@ -124,7 +154,9 @@ class TestMopEodSyncHelpers(FrappeTestCase):
 
 	def test_mop_manufacturer_label_dict_attr_and_none(self):
 		self.assertIsNone(_mop_manufacturer_label(None))
-		self.assertEqual(_mop_manufacturer_label(FrappeDict({"manufacturer": "MF-DICT"})), "MF-DICT")
+		self.assertEqual(
+			_mop_manufacturer_label(FrappeDict({"manufacturer": "MF-DICT"})), "MF-DICT"
+		)
 
 		class _MopObj:
 			manufacturer = "MF-ATTR"
@@ -159,10 +191,19 @@ class TestMopEodSyncHelpers(FrappeTestCase):
 
 
 class TestSyncConsolidatedGroup(FrappeTestCase):
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mark_synced")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._create_loss_entries", return_value=[])
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.new_doc")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mark_synced"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._create_loss_entries",
+		return_value=[],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.new_doc"
+	)
 	@patch("erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=100.0)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_sre_undelivered_batch_qty",
@@ -181,23 +222,45 @@ class TestSyncConsolidatedGroup(FrappeTestCase):
 		mock_new_doc.return_value = se
 
 		def _get_value_side_effect(doctype, name, field, *args, **kwargs):
-			if doctype == "Item" and name == "M-1" and field == ["has_batch_no", "has_serial_no"]:
+			if (
+				doctype == "Item"
+				and name == "M-1"
+				and field == ["has_batch_no", "has_serial_no"]
+			):
 				return (0, 0)
 			return None
 
 		mock_get_value.side_effect = _get_value_side_effect
 
 		group_key = ("Test Co", "MWO-1", "WH-START", "WH-END")
-		
-		mop_doc = FrappeDict({
-			"manufacturing_order": "MO-1",
-			"manufacturing_work_order": "MWO-1",
-			"loss_wt": 0,
-		})
-		
-		logs_a = [_log(name="LOG-1", flow_index=1, item_code="M-1", batch_no="B1", qty_after_transaction_batch_based=1.0)]
-		logs_b = [_log(name="LOG-2", flow_index=1, item_code="M-1", batch_no="B1", qty_after_transaction_batch_based=2.5)]
-		
+
+		mop_doc = FrappeDict(
+			{
+				"manufacturing_order": "MO-1",
+				"manufacturing_work_order": "MWO-1",
+				"loss_wt": 0,
+			}
+		)
+
+		logs_a = [
+			_log(
+				name="LOG-1",
+				flow_index=1,
+				item_code="M-1",
+				batch_no="B1",
+				qty_after_transaction_batch_based=1.0,
+			)
+		]
+		logs_b = [
+			_log(
+				name="LOG-2",
+				flow_index=1,
+				item_code="M-1",
+				batch_no="B1",
+				qty_after_transaction_batch_based=2.5,
+			)
+		]
+
 		mop_data_list = [
 			{"mop_name": "MOP-A", "mop_doc": mop_doc, "logs": logs_a},
 			{"mop_name": "MOP-B", "mop_doc": mop_doc, "logs": logs_b},
@@ -216,14 +279,25 @@ class TestSyncConsolidatedGroup(FrappeTestCase):
 		self.assertEqual(se.items[0].manufacturing_operation, "MOP-A")
 		self.assertEqual(se.items[1].qty, 2.5)
 		self.assertEqual(se.items[1].manufacturing_operation, "MOP-B")
-		
+
 		mock_mark_synced.assert_called_once()
 
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mark_synced")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._create_loss_entries", return_value=[])
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.new_doc")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mark_synced"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._create_loss_entries",
+		return_value=[],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.new_doc"
+	)
 	@patch("erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=100.0)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_sre_undelivered_batch_qty",
@@ -250,7 +324,11 @@ class TestSyncConsolidatedGroup(FrappeTestCase):
 		mock_new_doc.side_effect = _new_doc
 
 		def _get_value_side_effect(doctype, name, field, *args, **kwargs):
-			if doctype == "Item" and name == "M-1" and field == ["has_batch_no", "has_serial_no"]:
+			if (
+				doctype == "Item"
+				and name == "M-1"
+				and field == ["has_batch_no", "has_serial_no"]
+			):
 				return (0, 0)
 			return None
 
@@ -266,10 +344,22 @@ class TestSyncConsolidatedGroup(FrappeTestCase):
 			}
 		)
 		logs_a = [
-			_log(name="LOG-1", flow_index=1, item_code="M-1", batch_no="B1", qty_after_transaction_batch_based=1.0)
+			_log(
+				name="LOG-1",
+				flow_index=1,
+				item_code="M-1",
+				batch_no="B1",
+				qty_after_transaction_batch_based=1.0,
+			)
 		]
 		logs_b = [
-			_log(name="LOG-2", flow_index=1, item_code="M-1", batch_no="B1", qty_after_transaction_batch_based=2.5)
+			_log(
+				name="LOG-2",
+				flow_index=1,
+				item_code="M-1",
+				batch_no="B1",
+				qty_after_transaction_batch_based=2.5,
+			)
 		]
 		mop_data_list = [
 			{"mop_name": "MOP-A", "mop_doc": mop_doc, "logs": logs_a},
@@ -365,7 +455,9 @@ class TestValidateEodSourceBatchStock(FrappeTestCase):
 			)
 		self.assertIn("Manufacturer: MF-EOD-TEST", str(ctx.exception))
 
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_sre_undelivered_batch_qty",
 		return_value=0.5,
@@ -386,7 +478,9 @@ class TestValidateEodSourceBatchStock(FrappeTestCase):
 		_validate_eod_source_batch_stock(items, manufacturing_work_order="MWO-1")
 		mock_log_error.assert_called_once()
 
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_sre_undelivered_batch_qty",
 		return_value=5.0,
@@ -413,11 +507,11 @@ class TestCreateLossEntries(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value"
 	)
 	@patch(
-		"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.get_item_loss_item",
+		"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.get_loss_item_from_manufacturer_mapping",
 		return_value="LOSS-M-ITEM",
 	)
 	def test_create_loss_entries_builds_repack_entry(
-		self, _get_item_loss_item, mock_get_value, mock_new_doc
+		self, _get_loss_item, mock_get_value, mock_new_doc
 	):
 		mock_get_value.return_value = FrappeDict(
 			{
@@ -438,9 +532,17 @@ class TestCreateLossEntries(FrappeTestCase):
 			}
 		)
 		latest_logs = [
-			_log(item_code="M-ONE", batch_no="B1", qty_after_transaction_batch_based=2.0),
-			_log(item_code="F-TWO", batch_no="B2", qty_after_transaction_batch_based=1.0),
-			_log(item_code="D-THREE", batch_no="BD1", qty_after_transaction_batch_based=9.0),
+			_log(
+				item_code="M-ONE", batch_no="B1", qty_after_transaction_batch_based=2.0
+			),
+			_log(
+				item_code="F-TWO", batch_no="B2", qty_after_transaction_batch_based=1.0
+			),
+			_log(
+				item_code="D-THREE",
+				batch_no="BD1",
+				qty_after_transaction_batch_based=9.0,
+			),
 		]
 
 		out = _create_loss_entries(mop, "MOP-TEST-001", latest_logs, "WH-END", 0.9)
@@ -451,21 +553,39 @@ class TestCreateLossEntries(FrappeTestCase):
 
 
 class TestSyncMopLogsEntryPoint(FrappeTestCase):
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.savepoint")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.release_savepoint")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.rollback")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._sync_consolidated_group")
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_unsynced_mop_groups")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._sync_consolidated_group"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_unsynced_mop_groups"
+	)
 	def test_sync_mop_logs_continues_after_transaction_failure(
-		self, mock_get_groups, mock_sync_group, mock_log_error, mock_rollback, mock_release, mock_savepoint
+		self,
+		mock_get_groups,
+		mock_sync_group,
+		mock_log_error,
+		mock_rollback,
+		mock_release,
+		mock_savepoint,
 	):
 		logs_a = [{"mop_name": "MOP-A", "logs": []}]
 		logs_b = [{"mop_name": "MOP-B", "logs": []}]
-		
+
 		key_a = ("Co", "MWO", "WH1", "WH2")
 		key_b = ("Co", "MWO", "WH2", "WH3")
-		
+
 		mock_get_groups.return_value = {key_a: logs_a, key_b: logs_b}
 
 		def sync_side_effect(group_key, data):
@@ -479,9 +599,8 @@ class TestSyncMopLogsEntryPoint(FrappeTestCase):
 
 		self.assertEqual(out["processed"], 1)
 		self.assertEqual(out["stock_entries"], ["SE-A"])
-		
+
 		self.assertEqual(mock_savepoint.call_count, 2)
 		mock_release.assert_called_once()
 		mock_rollback.assert_called_once()
 		mock_log_error.assert_called_once()
-

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_settings.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_settings.py
@@ -23,17 +23,20 @@ class TestMOPSettings(FrappeTestCase):
 		kwargs = mock_msgprint.call_args[1]
 		self.assertEqual(kwargs.get("indicator"), "orange")
 
-	def test_validate_silent_when_both_eir_types_configured(self):
+	def test_validate_silent_when_all_eir_types_configured(self):
+		# _RESERVATION_TYPES_FOR_EIR requires three SE types: Repack,
+		# Material Transfer (WORK ORDER), Material Receive (WORK ORDER).
 		doc = frappe.get_doc("MOP Settings")
 		doc.stock_entry_type_to_reservation = []
-		doc.append(
-			"stock_entry_type_to_reservation",
-			{"stock_entry_type_to_reservation": "Material Transfer (WORK ORDER)"},
-		)
-		doc.append(
-			"stock_entry_type_to_reservation",
-			{"stock_entry_type_to_reservation": "Repack"},
-		)
+		for se_type in (
+			"Material Transfer (WORK ORDER)",
+			"Repack",
+			"Material Receive (WORK ORDER)",
+		):
+			doc.append(
+				"stock_entry_type_to_reservation",
+				{"stock_entry_type_to_reservation": se_type},
+			)
 		with patch.object(frappe, "msgprint") as mock_msgprint:
 			doc.validate()
 		mock_msgprint.assert_not_called()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
@@ -241,6 +241,7 @@ def to_prepare_data_for_make_mnf_stock_entry(self):
 				)
 				if bin_name:
 					bin_doc = frappe.get_doc("Bin", bin_name)
+					bin_doc.flags.ignore_permissions = True
 					bin_doc.recalculate_qty()
 					bin_doc.update_reserved_stock()
 

--- a/jewellery_erpnext/jewellery_erpnext/tests/_flow_and_perf_audit.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/_flow_and_perf_audit.py
@@ -1,0 +1,414 @@
+"""End-to-end flow exercises + microbenchmarks for the audit cycle.
+
+Invoked from `bench --site gk execute` so it runs inside a real frappe
+context with full DocType metadata and DB. Designed to be idempotent and
+read-only — no document inserts, no SE submits, no MOP Log writes. The
+goal is to (a) exercise the production helper paths with real data and
+(b) record timings for the popup helper, the reconciliation helper, and
+get_current_mop_balance_rows.
+
+Usage:
+        bench --site gk execute \
+                jewellery_erpnext.jewellery_erpnext.tests._flow_and_perf_audit.run_audit
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from time import perf_counter
+
+import frappe
+
+# ---------------------------------------------------------------------------
+# Timing helpers
+# ---------------------------------------------------------------------------
+
+
+def _time_call(fn, *args, **kwargs):
+	t0 = perf_counter()
+	out = fn(*args, **kwargs)
+	return out, perf_counter() - t0
+
+
+def _summarize(label, samples):
+	"""Build a summary dict for a population of timings (seconds)."""
+	if not samples:
+		return {"label": label, "n": 0}
+	samples = sorted(samples)
+	return {
+		"label": label,
+		"n": len(samples),
+		"min_ms": round(samples[0] * 1000, 3),
+		"max_ms": round(samples[-1] * 1000, 3),
+		"avg_ms": round(statistics.mean(samples) * 1000, 3),
+		"p50_ms": round(samples[len(samples) // 2] * 1000, 3),
+		"p95_ms": round(
+			samples[min(len(samples) - 1, int(len(samples) * 0.95))] * 1000, 3
+		),
+		"total_ms": round(sum(samples) * 1000, 3),
+	}
+
+
+# ---------------------------------------------------------------------------
+# Population samplers (read-only)
+# ---------------------------------------------------------------------------
+
+
+def _sample_mops(limit=50):
+	"""Return up to N Manufacturing Operation names that have MOP Log rows.
+
+	We rank by recency so we exercise hot data, not stale rows.
+	"""
+	return frappe.db.sql(
+		"""
+		SELECT DISTINCT mo.name
+		FROM `tabManufacturing Operation` mo
+		INNER JOIN `tabMOP Log` ml ON ml.manufacturing_operation = mo.name
+		WHERE ml.is_cancelled = 0
+		ORDER BY mo.modified DESC
+		LIMIT %s
+		""",
+		(limit,),
+		as_list=True,
+	)
+
+
+def _sample_active_sre_mops(limit=50):
+	"""MOPs that have at least one active Stock Reservation Entry.
+
+	Make Receive Entry only ever runs against these — perfect popup load test.
+	"""
+	return frappe.db.sql(
+		"""
+		SELECT DISTINCT mo.name
+		FROM `tabManufacturing Operation` mo
+		INNER JOIN `tabStock Reservation Entry` sre
+		    ON sre.manufacturing_work_order = mo.manufacturing_work_order
+		WHERE sre.docstatus = 1
+		  AND mo.manufacturing_work_order IS NOT NULL
+		ORDER BY mo.modified DESC
+		LIMIT %s
+		""",
+		(limit,),
+		as_list=True,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Flow exercises (read-only — no submits)
+# ---------------------------------------------------------------------------
+
+
+def flow_make_receive_popup(mop_names):
+	"""Flow 1+2+3: Make Receive Entry popup row fetch.
+
+	Drives `get_make_receive_entry_rows` against real MOPs. Confirms the
+	endpoint:
+	  - returns rows, including new keys (mop_log_balance_qty/pcs,
+	    available_pcs, is_pcs_item, mop_log_reference)
+	  - times within a reasonable budget per MOP
+	"""
+	from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+		get_make_receive_entry_rows,
+	)
+
+	out = []
+	timings = []
+	for (mop_name,) in mop_names:
+		try:
+			rows, elapsed = _time_call(get_make_receive_entry_rows, mop_name)
+		except frappe.ValidationError as exc:
+			# MOP without MWO. Acceptable — the endpoint guards on this.
+			out.append({"mop": mop_name, "skipped": str(exc)})
+			continue
+		except Exception as exc:  # pragma: no cover — surface unexpected breakage
+			out.append({"mop": mop_name, "error": f"{type(exc).__name__}: {exc}"})
+			continue
+
+		timings.append(elapsed)
+		row_keys = set()
+		pcs_rows = 0
+		non_pcs_rows = 0
+		for r in rows:
+			row_keys.update(r.keys())
+			if r.get("is_pcs_item"):
+				pcs_rows += 1
+			else:
+				non_pcs_rows += 1
+		out.append(
+			{
+				"mop": mop_name,
+				"row_count": len(rows),
+				"elapsed_ms": round(elapsed * 1000, 3),
+				"pcs_rows": pcs_rows,
+				"non_pcs_rows": non_pcs_rows,
+				"missing_new_keys": sorted(
+					{
+						"reserved_pcs",
+						"mop_log_balance_qty",
+						"mop_log_balance_pcs",
+						"already_received_pcs",
+						"available_pcs",
+						"is_pcs_item",
+						"mop_log_reference",
+					}
+					- row_keys
+				)
+				if rows
+				else [],
+			}
+		)
+	return out, _summarize("get_make_receive_entry_rows", timings)
+
+
+def flow_reconciliation_helper(mop_names):
+	"""Flow 4+5: Direct exercise of get_available_qty_pcs_for_mop_item.
+
+	For each MOP we pick the latest MOP Log row (regardless of item prefix)
+	and feed (item_code, batch_no) through the helper. Confirms it returns
+	is_pcs_item correctly and surfaces non-zero available_pcs only for D/G.
+	"""
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+		get_available_qty_pcs_for_mop_item,
+	)
+
+	out = []
+	timings = []
+	for (mop_name,) in mop_names:
+		ml = frappe.db.get_value(
+			"MOP Log",
+			{"manufacturing_operation": mop_name, "is_cancelled": 0},
+			["item_code", "batch_no"],
+			as_dict=True,
+			order_by="creation desc",
+		)
+		if not ml:
+			continue
+		ctx, elapsed = _time_call(
+			get_available_qty_pcs_for_mop_item,
+			manufacturing_operation=mop_name,
+			item_code=ml.item_code,
+			batch_no=ml.batch_no,
+		)
+		timings.append(elapsed)
+		out.append(
+			{
+				"mop": mop_name,
+				"item_code": ml.item_code,
+				"batch_no": ml.batch_no,
+				"is_pcs_item": ctx["is_pcs_item"],
+				"available_qty": ctx["available_qty"],
+				"available_pcs": ctx["available_pcs"],
+				"mop_log_balance_qty": ctx["mop_log_balance_qty"],
+				"mop_log_balance_pcs": ctx["mop_log_balance_pcs"],
+				"elapsed_ms": round(elapsed * 1000, 3),
+			}
+		)
+	return out, _summarize("get_available_qty_pcs_for_mop_item", timings)
+
+
+def flow_balance_helper(mop_names):
+	"""Flow 9: get_current_mop_balance_rows on real MOPs."""
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+		get_current_mop_balance_rows,
+	)
+
+	timings = []
+	row_counts = []
+	for (mop_name,) in mop_names:
+		rows, elapsed = _time_call(get_current_mop_balance_rows, mop_name)
+		timings.append(elapsed)
+		row_counts.append(len(rows))
+	return {
+		"mops_sampled": len(mop_names),
+		"row_count_min": min(row_counts) if row_counts else 0,
+		"row_count_max": max(row_counts) if row_counts else 0,
+		"row_count_avg": round(statistics.mean(row_counts), 2) if row_counts else 0,
+	}, _summarize("get_current_mop_balance_rows", timings)
+
+
+def flow_eod_idempotency_audit():
+	"""Flow 9: EOD sync audit — count is_synced=0 vs is_synced=1 rows.
+
+	Read-only sanity check: confirms the load-bearing flag is present on
+	MOP Log rows and that no `log_category=Loss Attribution` rows have
+	is_synced=0 (which would mean the EOD filter is missing them).
+	"""
+	totals = frappe.db.sql(
+		"""
+		SELECT
+		    COUNT(*) AS total,
+		    SUM(CASE WHEN is_synced = 0 THEN 1 ELSE 0 END) AS unsynced,
+		    SUM(CASE WHEN is_synced = 1 THEN 1 ELSE 0 END) AS synced,
+		    SUM(CASE WHEN is_cancelled = 1 THEN 1 ELSE 0 END) AS cancelled,
+		    SUM(CASE WHEN log_category = 'Loss Attribution' AND is_synced = 0 AND is_cancelled = 0 THEN 1 ELSE 0 END) AS unsynced_loss_rows
+		FROM `tabMOP Log`
+		""",
+		as_dict=True,
+	)
+	return totals[0] if totals else {}
+
+
+def flow_no_dust_item_dependency():
+	"""Phase F sanity: verify there is no MOP Settings.dust_item field
+	referenced by any production code path. We grep is sufficient — the
+	MOP Settings DocType JSON has no dust_item field."""
+	row = frappe.db.sql(
+		"""
+		SELECT COUNT(*) AS c
+		FROM `tabDocField`
+		WHERE parent = 'MOP Settings'
+		  AND fieldname = 'dust_item'
+		""",
+		as_dict=True,
+	)
+	count = (row[0] or {}).get("c", 0) if row else 0
+	# Custom Field surface
+	cf_count = frappe.db.count(
+		"Custom Field", {"dt": "MOP Settings", "fieldname": "dust_item"}
+	)
+	return {"docfield_count": count, "custom_field_count": cf_count}
+
+
+def flow_manufacturer_loss_mapping_health():
+	"""Phase F sanity: count Manufacturer rows with a configured
+	custom_variant_loss_table — non-zero means the mapping is in use."""
+	rows = frappe.db.sql(
+		"""
+		SELECT
+		    COUNT(DISTINCT vlt.parent) AS mfrs_with_mapping,
+		    COUNT(*) AS total_mapping_rows,
+		    COUNT(DISTINCT vlt.variant) AS variants_mapped,
+		    COUNT(DISTINCT vlt.loss_type) AS loss_types_mapped
+		FROM `tabVariant Loss Table` vlt
+		WHERE vlt.parenttype = 'Manufacturer'
+		""",
+		as_dict=True,
+	)
+	return rows[0] if rows else {}
+
+
+# ---------------------------------------------------------------------------
+# Load tests (read-only)
+# ---------------------------------------------------------------------------
+
+
+def load_test_helper_repeated_calls(mop_names, iterations=10):
+	"""Run get_available_qty_pcs_for_mop_item N times against the same
+	MOP+item to measure cached vs cold-path per-call latency. Useful for
+	spotting query-amplification regressions.
+	"""
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+		get_available_qty_pcs_for_mop_item,
+	)
+
+	if not mop_names:
+		return _summarize("helper_repeat_loop", [])
+
+	(mop_name,) = mop_names[0]
+	ml = frappe.db.get_value(
+		"MOP Log",
+		{"manufacturing_operation": mop_name, "is_cancelled": 0},
+		["item_code", "batch_no"],
+		as_dict=True,
+		order_by="creation desc",
+	)
+	if not ml:
+		return _summarize("helper_repeat_loop", [])
+
+	timings = []
+	for _ in range(iterations):
+		_, elapsed = _time_call(
+			get_available_qty_pcs_for_mop_item,
+			manufacturing_operation=mop_name,
+			item_code=ml.item_code,
+			batch_no=ml.batch_no,
+		)
+		timings.append(elapsed)
+	return _summarize(f"helper_repeat_loop_x{iterations}", timings)
+
+
+def load_test_popup_repeated_calls(mop_names, iterations=10):
+	"""Run get_make_receive_entry_rows N times against the same MOP."""
+	from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+		get_make_receive_entry_rows,
+	)
+
+	if not mop_names:
+		return _summarize("popup_repeat_loop", [])
+
+	timings = []
+	for (mop_name,) in mop_names[:5]:
+		try:
+			for _ in range(iterations):
+				_, elapsed = _time_call(get_make_receive_entry_rows, mop_name)
+				timings.append(elapsed)
+		except frappe.ValidationError:
+			continue
+	return _summarize(f"popup_repeat_loop_x{iterations}", timings)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def run_audit():
+	"""Top-level driver. Prints a JSON report to the bench log."""
+	report = {
+		"phase": "Phase 6+7 — flow + perf audit",
+		"site": frappe.local.site if hasattr(frappe.local, "site") else "<unknown>",
+		"flows": {},
+		"perf": {},
+		"sanity": {},
+	}
+
+	mops_for_balance = _sample_mops(limit=50)
+	mops_for_popup = _sample_active_sre_mops(limit=20)
+
+	report["flows"]["mops_with_logs_sampled"] = len(mops_for_balance)
+	report["flows"]["mops_with_active_sre_sampled"] = len(mops_for_popup)
+
+	# Flow 1: popup row fetch
+	popup_results, popup_timing = flow_make_receive_popup(mops_for_popup)
+	report["flows"]["make_receive_popup_per_mop"] = popup_results
+	report["perf"]["make_receive_popup"] = popup_timing
+
+	# Flow 4: helper exercises
+	helper_results, helper_timing = flow_reconciliation_helper(mops_for_balance)
+	report["flows"]["reconciliation_helper_per_mop"] = helper_results[
+		:10
+	]  # truncate for log readability
+	report["flows"]["reconciliation_helper_total_sampled"] = len(helper_results)
+	report["perf"]["reconciliation_helper"] = helper_timing
+
+	# Flow 9: balance helper
+	balance_summary, balance_timing = flow_balance_helper(mops_for_balance)
+	report["flows"]["balance_helper_summary"] = balance_summary
+	report["perf"]["balance_helper"] = balance_timing
+
+	# EOD idempotency audit
+	report["sanity"]["eod_mop_log_counts"] = flow_eod_idempotency_audit()
+
+	# No dust_item dependency on MOP Settings
+	report["sanity"]["no_dust_item_on_mop_settings"] = flow_no_dust_item_dependency()
+
+	# Manufacturer mapping health
+	report["sanity"][
+		"manufacturer_loss_mapping_health"
+	] = flow_manufacturer_loss_mapping_health()
+
+	# Load tests
+	report["perf"]["helper_repeat_loop"] = load_test_helper_repeated_calls(
+		mops_for_balance, iterations=20
+	)
+	report["perf"]["popup_repeat_loop"] = load_test_popup_repeated_calls(
+		mops_for_popup, iterations=10
+	)
+
+	# Print compact JSON the bench log can capture
+	print("\n=== AUDIT_REPORT_BEGIN ===")
+	print(json.dumps(report, indent=2, default=str))
+	print("=== AUDIT_REPORT_END ===\n")
+	return report

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_baseline.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_baseline.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for Employee IR loss baseline + precision-3 reconciliation.
+
+Covers:
+- validate_process_loss: ``mop_loss_details_total`` is the pre-deduction MOP
+  baseline (sum of gross_wt - received_gross_wt across employee_ir_operations),
+  not the post-deduction auto-distributed total.
+- book_metal_loss: independently rounded proportional rows are reconciled so
+  that sum(employee_loss_details.proportionally_loss) == flt(loss, 3) exactly.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class _StubEIR:
+	"""Minimal stand-in that supports the pieces validate_process_loss touches.
+
+	Avoids the full Document machinery so the baseline calculation can be
+	verified in isolation without a site-level fixture.
+	"""
+
+	def __init__(self, ops, book_metal_loss_returns=None):
+		self.docstatus = 0
+		self.type = "Receive"
+		self.company = "GE"
+		self.department = "Trishul - GEPL"
+		self.employee_ir_operations = ops
+		self.employee_loss_details = []
+		self.manually_book_loss_details = []
+		self.mop_loss_details_total = 0
+		self._bml_returns = book_metal_loss_returns or []
+
+	def append(self, table, row):
+		assert table == "employee_loss_details"
+		self.employee_loss_details.append(frappe._dict(row))
+
+	def book_metal_loss(self, *args, **kwargs):
+		# `validate_process_loss` invokes `self.book_metal_loss(...)`; bind it
+		# to a stub return so the baseline calculation under test runs in
+		# isolation from the proportional-distribution algorithm.
+		return self._bml_returns
+
+
+class TestMopLossDetailsTotalBaseline(FrappeTestCase):
+	"""mop_loss_details_total reflects the MOP baseline available for loss,
+	independent of how that loss is later split between auto and manual rows.
+	"""
+
+	def _run(self, ops, book_metal_loss_returns=None):
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir import (
+			EmployeeIR,
+		)
+
+		stub = _StubEIR(ops, book_metal_loss_returns=book_metal_loss_returns)
+
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.frappe.get_cached_value",
+				return_value=None,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.frappe.db.get_value",
+				return_value=None,
+			),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+		EmployeeIR.validate_process_loss(stub)
+		return stub
+
+	def test_baseline_is_sum_of_gwt_minus_rgwt(self):
+		ops = [
+			frappe._dict(
+				{
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+					"gross_wt": 4.6528,
+					"received_gross_wt": 4.0,
+				}
+			),
+			frappe._dict(
+				{
+					"manufacturing_work_order": "MWO-2",
+					"manufacturing_operation": "MOP-2",
+					"gross_wt": 5.0,
+					"received_gross_wt": 4.5,
+				}
+			),
+		]
+		stub = self._run(ops)
+		self.assertAlmostEqual(stub.mop_loss_details_total, 1.153, places=3)
+
+	def test_baseline_ignores_gain_rows(self):
+		"""Rows where received >= gross don't contribute to the loss baseline."""
+		ops = [
+			frappe._dict(
+				{
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+					"gross_wt": 4.0,
+					"received_gross_wt": 4.5,
+				}
+			),
+			frappe._dict(
+				{
+					"manufacturing_work_order": "MWO-2",
+					"manufacturing_operation": "MOP-2",
+					"gross_wt": 5.0,
+					"received_gross_wt": 4.5,
+				}
+			),
+		]
+		stub = self._run(ops)
+		self.assertAlmostEqual(stub.mop_loss_details_total, 0.5, places=3)
+
+	def test_baseline_independent_of_manual_loss(self):
+		"""Adding manual loss rows must NOT shrink mop_loss_details_total —
+		that's the whole point of the pre-deduction semantic.
+		"""
+		ops = [
+			frappe._dict(
+				{
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+					"gross_wt": 10.0,
+					"received_gross_wt": 7.0,
+				}
+			),
+		]
+		stub = self._run(ops)
+		stub.manually_book_loss_details = [
+			frappe._dict(
+				{"proportionally_loss": 1.0, "manufacturing_work_order": "MWO-1"}
+			)
+		]
+		# Re-running validate_process_loss with a manual row present must not
+		# change the baseline; only the auto-distributed total would shrink.
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir import (
+			EmployeeIR,
+		)
+
+		EmployeeIR.validate_process_loss(stub)
+		self.assertAlmostEqual(stub.mop_loss_details_total, 3.0, places=3)
+
+
+class TestBookMetalLossPrecisionResidual(FrappeTestCase):
+	"""Independently-rounded rows must reconcile to flt(loss, 3) exactly."""
+
+	def _run(self, mop_log_rows, gwt, r_gwt, manual_loss_rows=None):
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir import (
+			EmployeeIR,
+		)
+
+		doc = MagicMock()
+		doc.manually_book_loss_details = manual_loss_rows or []
+
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.frappe.db.get_all",
+				return_value=mop_log_rows,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.frappe.db.get_value",
+				return_value=frappe._dict(
+					{
+						"metal_type": "Gold",
+						"metal_touch": "22KT",
+						"metal_purity": "91.9",
+						"master_bom": "BOM-X",
+						"is_finding_mwo": 0,
+					}
+				),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.get_item_from_attribute_full",
+				return_value=frappe._dict({"name": "M-G-22KT-91.9-Y"}),
+			),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+		return EmployeeIR.book_metal_loss(
+			doc,
+			mwo="MWO-1",
+			opt="MOP-1",
+			gwt=gwt,
+			r_gwt=r_gwt,
+			allowed_loss_percentage=None,
+		)
+
+	def test_three_equal_rows_residual_anchored(self):
+		"""3 rows × 1.0g, loss 1.0g => each rounds to 0.333 (sum 0.999).
+		The residual 0.001 must be added to one row so the sum is 1.000.
+		"""
+		rows = [
+			frappe._dict(
+				{
+					"item_code": "M-G-22KT-91.9-Y",
+					"batch_no": f"B{i}",
+					"qty": 1.0,
+					"pcs": 0,
+				}
+			)
+			for i in range(3)
+		]
+		result = self._run(rows, gwt=4.0, r_gwt=3.0)
+		total = sum(flt(e["proportionally_loss"], 3) for e in result)
+		self.assertAlmostEqual(total, 1.000, places=3)
+		# Each row is rounded to 3 dp; one carries the residual.
+		for entry in result:
+			self.assertEqual(
+				entry["proportionally_loss"], flt(entry["proportionally_loss"], 3)
+			)
+
+	def test_sum_matches_loss_after_manual_deduction(self):
+		"""Manual loss reduces the auto baseline; the auto rows still
+		reconcile exactly to (gwt - r_gwt - manual) at precision 3.
+		"""
+		rows = [
+			frappe._dict(
+				{"item_code": "M-G-22KT-91.9-Y", "batch_no": "B1", "qty": 1.7, "pcs": 0}
+			),
+			frappe._dict(
+				{"item_code": "F-G-18KT-75.4-Y", "batch_no": "B2", "qty": 1.3, "pcs": 0}
+			),
+		]
+		manual = [
+			frappe._dict(
+				{
+					"manufacturing_work_order": "MWO-1",
+					"proportionally_loss": 0.5,
+					"stock_uom": "Gram",
+				}
+			)
+		]
+		# gwt 5.0 - r_gwt 4.0 - manual 0.5 => loss 0.5 distributed across rows.
+		result = self._run(rows, gwt=5.0, r_gwt=4.0, manual_loss_rows=manual)
+		total = sum(flt(e["proportionally_loss"], 3) for e in result)
+		self.assertAlmostEqual(total, 0.500, places=3)
+
+
+# Test imports use the same `flt` ERPNext does so the rounding semantics
+# match between code-under-test and assertions.
+from frappe.utils import flt  # noqa: E402

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_mop_log.py
@@ -1,0 +1,565 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for Employee IR Receive loss MOP Log writes and the manual loss cap.
+
+Covers:
+- create_mop_log_for_employee_ir_loss (helper) — gram conversion, idempotency,
+  negative qty_change contract that reduces the MOP weight bucket.
+- validate_manually_book_loss_details — true-baseline cap.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCreateMopLogForEmployeeIrLoss(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=False,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+		return_value=None,
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_auto_loss_emits_negative_qty_change(
+		self, mock_new_doc, _mock_value, _mock_exists, _mock_uom
+	):
+		"""Loss row writes qty_change = -loss_weight so MOPLog.validate
+		propagates the reduced qty_after_transaction into the prefix bucket.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		eir = MagicMock()
+		eir.name = "EIR-1"
+
+		loss_row = MagicMock()
+		loss_row.name = "ELD-row-1"
+		loss_row.item_code = "M-G-22KT-91.9-Y"
+		loss_row.batch_no = "B-1"
+		loss_row.proportionally_loss = 1.126
+		loss_row.manufacturing_operation = "MOP-1"
+		loss_row.manufacturing_work_order = "MWO-1"
+
+		recorded = {}
+		mop_log_doc = MagicMock()
+
+		def _set(name, value):
+			recorded[name] = value
+			setattr(mop_log_doc, name, value)
+
+		mop_log_doc.set.side_effect = _set
+		mock_new_doc.return_value = mop_log_doc
+
+		create_mop_log_for_employee_ir_loss(eir, loss_row, "Auto Employee Loss", 1.130)
+
+		# Real loss delta — qty_change is the negative gram-equivalent.
+		self.assertAlmostEqual(mop_log_doc.qty_change, -1.126, places=3)
+		# PCS not tracked for metal/finding loss.
+		self.assertEqual(mop_log_doc.pcs_change, 0)
+		# bridge writer marker
+		self.assertEqual(mop_log_doc.is_synced, 1)
+		# attribution fields
+		self.assertEqual(mop_log_doc.log_category, "Loss Attribution")
+		self.assertEqual(mop_log_doc.loss_type, "Auto Employee Loss")
+		self.assertAlmostEqual(mop_log_doc.loss_weight, 1.126, places=3)
+		self.assertEqual(mop_log_doc.loss_source_row, "ELD-row-1")
+		# voucher linkage
+		self.assertEqual(mop_log_doc.voucher_type, "Employee IR")
+		self.assertEqual(mop_log_doc.voucher_no, "EIR-1")
+		mop_log_doc.save.assert_called_once()
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Carat",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=False,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+		return_value=None,
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_carat_to_gram_manual_loss(
+		self, mock_new_doc, _mock_value, _mock_exists, _mock_uom
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		eir = MagicMock()
+		eir.name = "EIR-2"
+		loss_row = MagicMock()
+		loss_row.name = "MBL-1"
+		loss_row.item_code = "D-X"
+		loss_row.batch_no = "B-D-1"
+		loss_row.proportionally_loss = 5.0
+		loss_row.manufacturing_operation = "MOP-1"
+		loss_row.manufacturing_work_order = "MWO-1"
+
+		mop_log_doc = MagicMock()
+		mock_new_doc.return_value = mop_log_doc
+
+		create_mop_log_for_employee_ir_loss(eir, loss_row, "Manually Booked Loss", 5.0)
+
+		# 5 carats × 0.2 = 1 g
+		self.assertAlmostEqual(mop_log_doc.loss_weight, 1.0, places=3)
+		# qty_change carries the gram-equivalent loss as a negative delta.
+		self.assertAlmostEqual(mop_log_doc.qty_change, -1.0, places=3)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=True,
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_loss_log_idempotency(self, mock_new_doc, _mock_exists, _mock_uom):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		eir = MagicMock()
+		eir.name = "EIR-3"
+		loss_row = MagicMock()
+		loss_row.name = "ELD-1"
+		loss_row.item_code = "M-X"
+		loss_row.batch_no = "B-1"
+		loss_row.proportionally_loss = 1.0
+		loss_row.manufacturing_operation = "MOP-1"
+		loss_row.manufacturing_work_order = "MWO-1"
+
+		out = create_mop_log_for_employee_ir_loss(
+			eir, loss_row, "Auto Employee Loss", 1.0
+		)
+
+		self.assertIsNone(out)
+		mock_new_doc.assert_not_called()
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_no_loss_when_zero_or_negative(self, mock_new_doc, _mock_uom):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		eir = MagicMock()
+		eir.name = "EIR-4"
+		loss_row = MagicMock()
+		loss_row.name = "ELD-0"
+		loss_row.item_code = "M-X"
+		loss_row.batch_no = "B-1"
+		loss_row.proportionally_loss = 0
+		loss_row.manufacturing_operation = "MOP-1"
+		loss_row.manufacturing_work_order = "MWO-1"
+
+		out = create_mop_log_for_employee_ir_loss(
+			eir, loss_row, "Auto Employee Loss", 0
+		)
+		self.assertIsNone(out)
+		mock_new_doc.assert_not_called()
+
+
+class TestManualLossCap(FrappeTestCase):
+	"""Per-MWO total cap: total manual loss cannot exceed (gwt - r_gwt)."""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		return_value=100.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_manual_loss_cap_against_true_baseline(self, *_):
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		doc = MagicMock()
+		doc.docstatus = 0
+
+		# Operation: gwt 10 g, received 9 g => baseline 1 g for MWO-1.
+		op = MagicMock()
+		op.gross_wt = 10.0
+		op.received_gross_wt = 9.0
+		op.manufacturing_work_order = "MWO-1"
+		doc.employee_ir_operations = [op]
+
+		# Manual loss row attempting 1.5 g (exceeds 1 g baseline).
+		mbl = MagicMock()
+		mbl.idx = 1
+		mbl.item_code = "M-X"
+		mbl.batch_no = "B-1"
+		mbl.manufacturing_operation = "MOP-1"
+		mbl.manufacturing_work_order = "MWO-1"
+		mbl.proportionally_loss = 1.5
+		doc.manually_book_loss_details = [mbl]
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_manually_book_loss_details(doc)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all",
+		return_value=[],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Carat",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		return_value=100.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_manual_loss_carat_converted_to_grams_for_cap(self, *_):
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		doc = MagicMock()
+		doc.docstatus = 0
+
+		# Baseline 0.5 g.
+		op = MagicMock()
+		op.gross_wt = 10.0
+		op.received_gross_wt = 9.5
+		op.manufacturing_work_order = "MWO-1"
+		doc.employee_ir_operations = [op]
+
+		# 5 carats == 1 g (after ×0.2). Exceeds 0.5 g cap.
+		mbl = MagicMock()
+		mbl.idx = 1
+		mbl.item_code = "D-X"
+		mbl.batch_no = "B-D"
+		mbl.manufacturing_operation = "MOP-1"
+		mbl.manufacturing_work_order = "MWO-1"
+		mbl.proportionally_loss = 5.0
+		# Pin pcs to 0 so the new D/G PCS reconciliation skips the helper
+		# (helper is mocked to return [] anyway, but explicit is clearer).
+		mbl.pcs = 0
+		doc.manually_book_loss_details = [mbl]
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_manually_book_loss_details(doc)
+
+
+class TestBookMetalLossSpecExamples(FrappeTestCase):
+	"""Run the spec's worked examples directly through book_metal_loss and
+	assert the proportional loss values. Verifies the C4 fix is correct.
+	"""
+
+	def _run(self, mop_log_rows, gwt, r_gwt, manual_loss_rows=None):
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir import (
+			EmployeeIR,
+		)
+
+		doc = MagicMock()
+		doc.manually_book_loss_details = manual_loss_rows or []
+
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.frappe.db.get_all",
+				return_value=mop_log_rows,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.frappe.db.get_value",
+				return_value=frappe._dict(
+					{
+						"metal_type": "Gold",
+						"metal_touch": "22KT",
+						"metal_purity": "91.9",
+						"master_bom": "BOM-X",
+						"is_finding_mwo": 0,
+					}
+				),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.employee_ir.get_item_from_attribute_full",
+				return_value=frappe._dict({"name": "M-G-22KT-91.9-Y"}),
+			),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+		return EmployeeIR.book_metal_loss(
+			doc,
+			mwo="MWO-1",
+			opt="MOP-1",
+			gwt=gwt,
+			r_gwt=r_gwt,
+			allowed_loss_percentage=None,
+		)
+
+	def test_example1_same_metal_multiple_batches(self):
+		"""Example 1 from the spec:
+		25.75 + 0.09 = 25.84, total loss 1.130
+		Proportional => 1.126 / 0.004
+		"""
+		rows = [
+			frappe._dict(
+				{
+					"item_code": "M-G-22KT-91.9-Y",
+					"batch_no": "B1",
+					"qty": 25.75,
+					"pcs": 0,
+				}
+			),
+			frappe._dict(
+				{
+					"item_code": "M-G-22KT-91.9-Y",
+					"batch_no": "B2",
+					"qty": 0.09,
+					"pcs": 0,
+				}
+			),
+		]
+		result = self._run(rows, gwt=25.84, r_gwt=24.71)
+
+		by_batch = {entry["batch_no"]: entry for entry in result}
+		self.assertAlmostEqual(by_batch["B1"]["proportionally_loss"], 1.126, places=2)
+		self.assertAlmostEqual(by_batch["B2"]["proportionally_loss"], 0.004, places=2)
+		total_loss = sum(e["proportionally_loss"] for e in result)
+		self.assertAlmostEqual(total_loss, 1.130, places=2)
+
+	def test_example2_metal_and_finding(self):
+		"""Example 2 from the spec:
+		Items 2, 0.5, 1.5, 1 (total 5), loss 1
+		Expected: 0.4, 0.1, 0.3, 0.2
+		"""
+		rows = [
+			frappe._dict(
+				{"item_code": "M-G-22KT-91.9-Y", "batch_no": "B1", "qty": 2.0, "pcs": 0}
+			),
+			frappe._dict(
+				{"item_code": "M-G-22KT-91.9-Y", "batch_no": "B2", "qty": 0.5, "pcs": 0}
+			),
+			frappe._dict(
+				{
+					"item_code": "F-G-18KT-75.4-Y-BL",
+					"batch_no": "B3",
+					"qty": 1.5,
+					"pcs": 0,
+				}
+			),
+			frappe._dict(
+				{
+					"item_code": "F-G-18KT-75.4-Y-CHA",
+					"batch_no": "B4",
+					"qty": 1.0,
+					"pcs": 0,
+				}
+			),
+		]
+		result = self._run(rows, gwt=5.0, r_gwt=4.0)
+
+		by_batch = {entry["batch_no"]: entry for entry in result}
+		self.assertAlmostEqual(by_batch["B1"]["proportionally_loss"], 0.4, places=2)
+		self.assertAlmostEqual(by_batch["B2"]["proportionally_loss"], 0.1, places=2)
+		self.assertAlmostEqual(by_batch["B3"]["proportionally_loss"], 0.3, places=2)
+		self.assertAlmostEqual(by_batch["B4"]["proportionally_loss"], 0.2, places=2)
+
+	def test_no_loss_when_gwt_equals_r_gwt(self):
+		"""gwt == r_gwt => no loss, empty result."""
+		rows = [
+			frappe._dict(
+				{"item_code": "M-G-22KT-91.9-Y", "batch_no": "B1", "qty": 5.0, "pcs": 0}
+			),
+		]
+		result = self._run(rows, gwt=5.0, r_gwt=5.0)
+		self.assertEqual(result, [])
+
+	def test_dgo_rows_excluded_from_auto_loss(self):
+		"""Rows with item_code prefix not in M/F must not be allocated loss."""
+		rows = [
+			frappe._dict(
+				{"item_code": "M-G-22KT-91.9-Y", "batch_no": "B1", "qty": 1.0, "pcs": 0}
+			),
+			frappe._dict({"item_code": "D-X", "batch_no": "BD1", "qty": 2.0, "pcs": 5}),
+			frappe._dict(
+				{"item_code": "G-X", "batch_no": "BG1", "qty": 3.0, "pcs": 10}
+			),
+			frappe._dict({"item_code": "O-X", "batch_no": "BO1", "qty": 4.0, "pcs": 0}),
+		]
+		result = self._run(rows, gwt=1.0, r_gwt=0.5)
+
+		batches = {entry["batch_no"] for entry in result}
+		self.assertEqual(batches, {"B1"})
+
+
+class TestLossLogIncludedInBalance(FrappeTestCase):
+	"""Loss attribution rows post a real qty_change reduction, so the balance
+	helper MUST include them so downstream consumers (Make Receive Entry
+	availability, manual loss validation, EOD SRE reconcile) see the
+	post-loss balance.
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all"
+	)
+	def test_get_current_mop_balance_rows_does_not_filter_log_category(
+		self, mock_get_all
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			get_current_mop_balance_rows,
+		)
+
+		mock_get_all.return_value = []
+
+		get_current_mop_balance_rows("MOP-1")
+
+		_args, kwargs = mock_get_all.call_args
+		filters = kwargs["filters"]
+		# Filter must NOT exclude loss-attribution rows — they affect balance.
+		self.assertNotIn("log_category", filters)
+		self.assertEqual(filters["is_cancelled"], 0)
+		self.assertEqual(filters["manufacturing_operation"], "MOP-1")
+
+
+class TestLossMopLogReducesBalance(FrappeTestCase):
+	"""Negative qty_change must reduce qty_after_transaction across the three
+	balance views (overall prefix, item-based, batch-based) and PCS balances
+	must be preserved (loss is recorded by weight, not by piece count).
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=False,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value"
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_qty_after_transaction_drops_by_loss_weight(
+		self, mock_new_doc, mock_get_value, _mock_exists, _mock_uom
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		# Pre-loss balance for (item, batch) on the MOP.
+		mock_get_value.return_value = {
+			"qty_after_transaction": 10.0,
+			"qty_after_transaction_item_based": 8.0,
+			"qty_after_transaction_batch_based": 6.0,
+			"pcs_after_transaction": 4,
+			"pcs_after_transaction_item_based": 4,
+			"pcs_after_transaction_batch_based": 4,
+			"flow_index": 3,
+		}
+
+		recorded = {}
+		mop_log_doc = MagicMock()
+
+		def _set(name, value):
+			recorded[name] = value
+
+		mop_log_doc.set.side_effect = _set
+		mock_new_doc.return_value = mop_log_doc
+
+		eir = MagicMock()
+		eir.name = "EIR-X"
+		loss_row = MagicMock()
+		loss_row.name = "ELD-X"
+		loss_row.item_code = "M-X"
+		loss_row.batch_no = "B-X"
+		loss_row.proportionally_loss = 1.5
+		loss_row.manufacturing_operation = "MOP-X"
+		loss_row.manufacturing_work_order = "MWO-X"
+
+		create_mop_log_for_employee_ir_loss(eir, loss_row, "Auto Employee Loss", 1.5)
+
+		# Each qty_after_transaction view drops by 1.5 g.
+		self.assertAlmostEqual(recorded["qty_after_transaction"], 8.5, places=3)
+		self.assertAlmostEqual(
+			recorded["qty_after_transaction_item_based"], 6.5, places=3
+		)
+		self.assertAlmostEqual(
+			recorded["qty_after_transaction_batch_based"], 4.5, places=3
+		)
+		# PCS balances preserved at the prior values.
+		self.assertEqual(recorded["pcs_after_transaction"], 4)
+		self.assertEqual(recorded["pcs_after_transaction_item_based"], 4)
+		self.assertEqual(recorded["pcs_after_transaction_batch_based"], 4)
+		# flow_index does not advance — loss is booked at the same tier.
+		self.assertEqual(mop_log_doc.flow_index, 3)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=False,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+		return_value=None,
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_no_prior_balance_yields_negative_qty_after_transaction(
+		self, mock_new_doc, _mock_value, _mock_exists, _mock_uom
+	):
+		"""Edge case: no prior MOP Log row for this (item, batch). Loss still
+		records the delta so MOP Log + Manufacturing Operation reflect the
+		discrepancy (a missing prior balance is itself a problem the operator
+		needs to see).
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		recorded = {}
+		mop_log_doc = MagicMock()
+
+		def _set(name, value):
+			recorded[name] = value
+
+		mop_log_doc.set.side_effect = _set
+		mock_new_doc.return_value = mop_log_doc
+
+		eir = MagicMock()
+		eir.name = "EIR-EMPTY"
+		loss_row = MagicMock()
+		loss_row.name = "ELD-EMPTY"
+		loss_row.item_code = "M-X"
+		loss_row.batch_no = "B-X"
+		loss_row.proportionally_loss = 0.5
+		loss_row.manufacturing_operation = "MOP-EMPTY"
+		loss_row.manufacturing_work_order = "MWO-EMPTY"
+
+		create_mop_log_for_employee_ir_loss(eir, loss_row, "Auto Employee Loss", 0.5)
+
+		# qty_change is -0.5 regardless of prior balance.
+		self.assertAlmostEqual(mop_log_doc.qty_change, -0.5, places=3)
+		# qty_after_transaction = 0 - 0.5 = -0.5 (balance now negative; flag
+		# to operator that prior balance was missing).
+		self.assertAlmostEqual(recorded["qty_after_transaction"], -0.5, places=3)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_pcs.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_pcs.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for D/G manual-loss PCS reconciliation in Employee IR.
+
+Covers:
+- validate_manually_book_loss_details — PCS cap on D/G rows.
+- create_mop_log_for_employee_ir_loss — D/G negative pcs_change regression.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestManualLossDgPcsValidation(FrappeTestCase):
+	"""validate_manually_book_loss_details adds a D/G PCS cap that consults
+	the same MOP Log balance helper used by Make Receive Entry.
+	"""
+
+	def _make_doc(self, manual_rows, op_baseline=None):
+		"""Compose the minimum doc-shape needed for validate_*."""
+		doc = MagicMock()
+		doc.docstatus = 0
+		doc.manually_book_loss_details = manual_rows
+		# Baseline source for the per-MWO cap; default = generous (10g).
+		op = MagicMock()
+		if op_baseline:
+			op.gross_wt, op.received_gross_wt, op.manufacturing_work_order = op_baseline
+		else:
+			op.gross_wt = 100.0
+			op.received_gross_wt = 90.0
+			op.manufacturing_work_order = "MWO-1"
+		doc.employee_ir_operations = [op]
+		return doc
+
+	def _mbl(self, item_code, batch_no, loss_qty, pcs):
+		row = MagicMock()
+		row.idx = 1
+		row.item_code = item_code
+		row.batch_no = batch_no
+		row.proportionally_loss = loss_qty
+		row.pcs = pcs
+		row.manufacturing_operation = "MOP-1"
+		row.manufacturing_work_order = "MWO-1"
+		row.variant_of = item_code[0]
+		return row
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Carat",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		# qty_after_transaction_batch_based balance lookup → 5g (covers loss).
+		return_value=5.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all"
+	)
+	def test_t17_d_pcs_within_available_passes(self, mock_get_all, *_):
+		"""T17 — D row with PCS <= available_pcs passes validation."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		# Helper sees MOP Log batch with 10 PCS available.
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"item_code": "D-X",
+					"batch_no": "BD1",
+					"qty_after_transaction_batch_based": 5.0,
+					"pcs_after_transaction_batch_based": 10,
+					"name": "MOPLOG-D17",
+				}
+			)
+		]
+		doc = self._make_doc([self._mbl("D-X", "BD1", 1.0, 5)])
+		# 1 carat == 0.2g loss; baseline 10g → cap fine; PCS 5 ≤ 10 → fine.
+		validate_manually_book_loss_details(doc)  # must not raise
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Carat",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		return_value=5.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all"
+	)
+	def test_t18_d_pcs_over_available_throws(self, mock_get_all, *_):
+		"""T18 — D row with PCS > available_pcs throws."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"item_code": "D-X",
+					"batch_no": "BD1",
+					"qty_after_transaction_batch_based": 5.0,
+					"pcs_after_transaction_batch_based": 3,
+					"name": "MOPLOG-D18",
+				}
+			)
+		]
+		doc = self._make_doc([self._mbl("D-X", "BD1", 1.0, 5)])
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_manually_book_loss_details(doc)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Carat",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		return_value=5.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all"
+	)
+	def test_t19_g_pcs_over_available_throws(self, mock_get_all, *_):
+		"""T19 — G row with PCS > available_pcs throws (same rule as D)."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"item_code": "G-X",
+					"batch_no": "BG1",
+					"qty_after_transaction_batch_based": 5.0,
+					"pcs_after_transaction_batch_based": 2,
+					"name": "MOPLOG-G19",
+				}
+			)
+		]
+		doc = self._make_doc([self._mbl("G-X", "BG1", 1.0, 5)])
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_manually_book_loss_details(doc)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Carat",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		return_value=5.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all",
+		return_value=[],
+	)
+	def test_t20_d_negative_pcs_throws(self, *_):
+		"""T20 — D row with negative pcs throws."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		doc = self._make_doc([self._mbl("D-X", "BD1", 1.0, -1)])
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_manually_book_loss_details(doc)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils.frappe.db.get_value",
+		return_value=5.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all"
+	)
+	def test_t21_mf_loss_skips_pcs_check(self, mock_get_all, *_):
+		"""T21 — M/F manual loss does not invoke PCS gate even when pcs is 0
+		on a balance that would otherwise cap to 0; i.e. no spurious throw.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			validate_manually_book_loss_details,
+		)
+
+		mock_get_all.return_value = []
+		doc = self._make_doc([self._mbl("M-X", "B1", 1.0, 0)])
+		validate_manually_book_loss_details(doc)
+
+
+class TestLossMopLogPcsRegression(FrappeTestCase):
+	"""Regression guards for the existing D/G negative pcs_change contract
+	in create_mop_log_for_employee_ir_loss. PCS reconciliation must NOT
+	change the loss MOP Log emission rules.
+	"""
+
+	def _setup(self, item_code, pcs):
+		eir = MagicMock()
+		eir.name = "EIR-PCS"
+		loss_row = MagicMock()
+		loss_row.name = "MBL-PCS"
+		loss_row.item_code = item_code
+		loss_row.batch_no = "B1"
+		loss_row.proportionally_loss = 1.0
+		loss_row.pcs = pcs
+		loss_row.manufacturing_operation = "MOP-1"
+		loss_row.manufacturing_work_order = "MWO-1"
+		return eir, loss_row
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=False,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+		return_value=None,
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_t22_d_loss_emits_negative_pcs_change(self, mock_new_doc, *_):
+		"""T22 — D loss MOP Log must emit pcs_change = -loss_row.pcs."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		eir, loss_row = self._setup("D-X", 4)
+		mop_log_doc = MagicMock()
+		mock_new_doc.return_value = mop_log_doc
+		create_mop_log_for_employee_ir_loss(eir, loss_row, "Manually Booked Loss", 1.0)
+		self.assertEqual(mop_log_doc.pcs_change, -4)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.get_cached_value",
+		return_value="Gram",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+		return_value=False,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+		return_value=None,
+	)
+	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
+	def test_t23_m_loss_emits_zero_pcs_change(self, mock_new_doc, *_):
+		"""T23 — M loss MOP Log keeps pcs_change=0 even when loss_row.pcs is set."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			create_mop_log_for_employee_ir_loss,
+		)
+
+		eir, loss_row = self._setup("M-X", 4)  # pcs would be ignored for M
+		mop_log_doc = MagicMock()
+		mock_new_doc.return_value = mop_log_doc
+		create_mop_log_for_employee_ir_loss(eir, loss_row, "Manually Booked Loss", 1.0)
+		self.assertEqual(mop_log_doc.pcs_change, 0)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_eod_sync_gap_fill.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_eod_sync_gap_fill.py
@@ -1,0 +1,588 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for the EOD gap-fill additions:
+
+- Manufacturer-scoped loss item resolution (get_loss_item_from_manufacturer_mapping).
+- last_eod_sync_on stamp on Manufacturing Operation success path.
+- Audit-first SRE reconciliation (_reconcile_reservations_for_mwo).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestLossItemFromManufacturerMapping(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.set_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_value"
+	)
+	def test_resolves_metal_to_ml(self, mock_get_value, mock_get_all, _mock_set):
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		# 1) Item.variant_of -> "M"
+		# 2) Variant Loss Table mapping (parent=Manufacturer, variant=M, loss_type=Loss) -> "ML"
+		mock_get_value.side_effect = ["M", "ML"]
+		mock_get_all.return_value = [
+			{"item_attribute": "Metal Type", "attribute_value": "Gold"}
+		]
+
+		# set_items_from_attribute returns a doc-like object with .name
+		resolved_item = MagicMock()
+		resolved_item.name = "ML-G-22KT-91.9-Y"
+		with patch(
+			"jewellery_erpnext.utils.set_items_from_attribute",
+			return_value=resolved_item,
+		):
+			result = get_loss_item_from_manufacturer_mapping(
+				"M-G-22KT-91.9-Y", "Shubh", loss_type="Loss"
+			)
+
+		self.assertEqual(result, "ML-G-22KT-91.9-Y")
+
+		# Ensure the per-Manufacturer query was used.
+		# Second invocation: doctype is "Variant Loss Table", filters scoped to Manufacturer.
+		args, kwargs = mock_get_value.call_args_list[1]
+		self.assertEqual(args[0], "Variant Loss Table")
+		self.assertEqual(args[1]["parenttype"], "Manufacturer")
+		self.assertEqual(args[1]["parent"], "Shubh")
+		self.assertEqual(args[1]["parentfield"], "custom_variant_loss_table")
+		self.assertEqual(args[1]["variant"], "M")
+		self.assertEqual(args[1]["loss_type"], "Loss")
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_value"
+	)
+	def test_throws_clear_error_when_mapping_missing(self, mock_get_value):
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		# variant_of resolves, but mapping query returns None.
+		mock_get_value.side_effect = ["D", None]
+
+		with self.assertRaises(frappe.exceptions.ValidationError) as ctx:
+			get_loss_item_from_manufacturer_mapping("D-X", "Shubh", loss_type="Missing")
+
+		# Error message points to Manufacturer config, NOT MOP Settings.
+		self.assertIn("Manufacturer", str(ctx.exception))
+		self.assertNotIn("MOP Settings", str(ctx.exception))
+
+	def test_throws_when_manufacturer_missing(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			get_loss_item_from_manufacturer_mapping("M-X", manufacturer=None)
+
+	def test_throws_when_item_has_no_variant_of(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_value",
+			return_value=None,
+		):
+			with self.assertRaises(frappe.exceptions.ValidationError) as ctx:
+				get_loss_item_from_manufacturer_mapping(
+					"X-NOT-A-VARIANT", "Shubh", "Loss"
+				)
+			self.assertIn("variant", str(ctx.exception).lower())
+
+	def test_throws_when_target_loss_variant_unresolvable(self):
+		"""Mapping resolves to a loss_variant template, but no Item variant
+		exists for the source attributes.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_value",
+			side_effect=["M", "ML"],
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_all",
+			return_value=[],
+		), patch(
+			"jewellery_erpnext.utils.set_items_from_attribute",
+			return_value=None,
+		):
+			with self.assertRaises(frappe.exceptions.ValidationError) as ctx:
+				get_loss_item_from_manufacturer_mapping(
+					"M-G-22KT-91.9-Y", "Shubh", "Loss"
+				)
+			# Error path mentions the unresolved variant template.
+			self.assertIn("ML", str(ctx.exception))
+
+
+class TestManufacturerLossMappingMatrix(FrappeTestCase):
+	"""Variant + loss_type combinations described in the spec must all
+	resolve via the Manufacturer's custom_variant_loss_table.
+	"""
+
+	def _run_resolution(self, source_item, variant_of, loss_type, expected_template):
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		# get_value side_effects: (1) Item.variant_of, (2) Variant Loss Table loss_variant.
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_value",
+			side_effect=[variant_of, expected_template],
+		) as mock_get_value, patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_all",
+			return_value=[{"item_attribute": "Metal Type", "attribute_value": "Gold"}],
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.set_value"
+		), patch(
+			"jewellery_erpnext.utils.set_items_from_attribute",
+			return_value=MagicMock(name=f"{expected_template}-VARIANT"),
+		):
+			result = get_loss_item_from_manufacturer_mapping(
+				source_item, "Shubh", loss_type
+			)
+
+		# Result should be the resolved variant.
+		self.assertIsNotNone(result)
+		# The Variant Loss Table query was scoped to the right
+		# (variant, loss_type) combo and parented to Manufacturer.
+		_args, _kwargs = mock_get_value.call_args_list[1]
+		args = mock_get_value.call_args_list[1][0]
+		self.assertEqual(args[0], "Variant Loss Table")
+		self.assertEqual(args[1]["parenttype"], "Manufacturer")
+		self.assertEqual(args[1]["parent"], "Shubh")
+		self.assertEqual(args[1]["parentfield"], "custom_variant_loss_table")
+		self.assertEqual(args[1]["variant"], variant_of)
+		self.assertEqual(args[1]["loss_type"], loss_type)
+
+	def test_metal_loss_uses_ML(self):
+		self._run_resolution("M-G-22KT-91.9-Y", "M", "Loss", "ML")
+
+	def test_finding_loss_uses_FL(self):
+		self._run_resolution("F-G-18KT-75.4-Y-X", "F", "Loss", "FL")
+
+	def test_diamond_loss_uses_DL(self):
+		self._run_resolution("D-X", "D", "Loss", "DL")
+
+	def test_diamond_missing_uses_DM(self):
+		self._run_resolution("D-X", "D", "Missing", "DM")
+
+	def test_diamond_burn_uses_DB(self):
+		self._run_resolution("D-X", "D", "Burn", "DB")
+
+	def test_diamond_broken_uses_DBK(self):
+		self._run_resolution("D-X", "D", "Broken", "DBK")
+
+	def test_gemstone_loss_uses_GL(self):
+		self._run_resolution("G-X", "G", "Loss", "GL")
+
+	def test_gemstone_broken_uses_GB(self):
+		self._run_resolution("G-X", "G", "Broken", "GB")
+
+	def test_other_loss_uses_OL(self):
+		self._run_resolution("O-X", "O", "Loss", "OL")
+
+	def test_eod_loss_resolution_does_not_consult_mop_settings(self):
+		"""Defense check: the new helper must not read MOP Settings dust_item.
+		If anyone re-introduces that path, this test fails.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+			get_loss_item_from_manufacturer_mapping,
+		)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_value",
+			side_effect=["M", "ML"],
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_all",
+			return_value=[],
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.get_single_value"
+		) as mock_single, patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.frappe.db.set_value"
+		), patch(
+			"jewellery_erpnext.utils.set_items_from_attribute",
+			return_value=MagicMock(name="ML-VARIANT"),
+		):
+			get_loss_item_from_manufacturer_mapping("M-X", "Shubh", "Loss")
+
+		# Helper must not read MOP Settings.dust_item in the resolution path.
+		mock_single.assert_not_called()
+
+
+class TestSyncStamp(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._reconcile_reservations_for_mwo"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.utils.now",
+		return_value="2026-05-04 12:00:00",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.set_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._sync_consolidated_group",
+		return_value=(["STE-1"], 1),
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_unsynced_mop_groups"
+	)
+	def test_eod_sync_stamps_last_eod_sync_on_after_success(
+		self,
+		mock_groups,
+		_mock_consolidated,
+		_mock_savepoint,
+		_mock_release,
+		_mock_rollback,
+		mock_set_value,
+		_mock_now,
+		_mock_reconcile,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			sync_mop_logs,
+		)
+
+		mock_groups.return_value = {
+			("CO", "MWO-1", "WH-A", "WH-B"): [
+				{"mop_name": "MOP-1", "mop_doc": MagicMock(), "logs": []},
+				{"mop_name": "MOP-2", "mop_doc": MagicMock(), "logs": []},
+			]
+		}
+
+		out = sync_mop_logs()
+
+		# Stamp once per MOP in the successful group.
+		stamp_calls = [
+			c
+			for c in mock_set_value.call_args_list
+			if c[0][0] == "Manufacturing Operation" and c[0][2] == "last_eod_sync_on"
+		]
+		self.assertEqual(len(stamp_calls), 2)
+		# update_modified=False is part of the contract.
+		for c in stamp_calls:
+			self.assertEqual(c[1].get("update_modified"), False)
+		self.assertEqual(out["processed"], 1)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._reconcile_reservations_for_mwo"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.log_error"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.set_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._sync_consolidated_group",
+		side_effect=Exception("boom"),
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_unsynced_mop_groups"
+	)
+	def test_failed_group_does_not_stamp(
+		self,
+		mock_groups,
+		_mock_consolidated,
+		_mock_savepoint,
+		_mock_release,
+		_mock_rollback,
+		mock_set_value,
+		_mock_log,
+		_mock_reconcile,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			sync_mop_logs,
+		)
+
+		mock_groups.return_value = {
+			("CO", "MWO-1", "WH-A", "WH-B"): [
+				{"mop_name": "MOP-FAIL", "mop_doc": MagicMock(), "logs": []},
+			]
+		}
+
+		sync_mop_logs()
+
+		# The exception path skipped the stamp block entirely.
+		stamp_calls = [
+			c
+			for c in mock_set_value.call_args_list
+			if c[0][0] == "Manufacturing Operation" and c[0][2] == "last_eod_sync_on"
+		]
+		self.assertEqual(stamp_calls, [])
+
+
+class TestSreReconciliationDryRun(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.logger"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.get_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.get_current_mop_balance_rows",
+		return_value=[],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_all"
+	)
+	def test_dry_run_default_does_not_cancel(
+		self, mock_get_all, _mock_balance, mock_get_doc, mock_logger
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			_reconcile_reservations_for_mwo,
+		)
+
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"name": "SRE-zero",
+					"item_code": "M-X",
+					"warehouse": "WH-Y",
+					"reserved_qty": 5.0,
+					"delivered_qty": 0.0,
+					"manufacturing_operation": "MOP-1",
+				}
+			)
+		]
+		log = MagicMock()
+		mock_logger.return_value = log
+
+		_reconcile_reservations_for_mwo("MWO-1")
+
+		# Dry run: NEVER call frappe.get_doc to cancel.
+		mock_get_doc.assert_not_called()
+		# Logged the would-cancel decision.
+		log.info.assert_called()
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.logger"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.get_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.get_current_mop_balance_rows",
+		return_value=[],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_all"
+	)
+	def test_destructive_cancels_zero_balance(
+		self,
+		mock_get_all,
+		_mock_balance,
+		mock_get_doc,
+		_mock_logger,
+		_mock_savepoint,
+		_mock_release,
+		_mock_rollback,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			_reconcile_reservations_for_mwo,
+		)
+
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"name": "SRE-cancel-me",
+					"item_code": "M-X",
+					"warehouse": "WH-Y",
+					"reserved_qty": 5.0,
+					"delivered_qty": 0.0,
+					"manufacturing_operation": "MOP-1",
+				}
+			)
+		]
+		sre_doc = MagicMock()
+		mock_get_doc.return_value = sre_doc
+
+		_reconcile_reservations_for_mwo("MWO-1", dry_run=False)
+
+		mock_get_doc.assert_called_once_with("Stock Reservation Entry", "SRE-cancel-me")
+		sre_doc.cancel.assert_called_once()
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.get_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.get_current_mop_balance_rows"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_all"
+	)
+	def test_ambiguous_balance_never_cancels(
+		self, mock_get_all, mock_balance, mock_get_doc
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			_reconcile_reservations_for_mwo,
+		)
+
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"name": "SRE-partial",
+					"item_code": "M-X",
+					"warehouse": "WH-Y",
+					"reserved_qty": 10.0,
+					"delivered_qty": 2.0,
+					"manufacturing_operation": "MOP-1",
+				}
+			)
+		]
+		# Latest balance is positive — partial coverage; reconcile must skip.
+		mock_balance.return_value = [
+			{"item_code": "M-X", "to_warehouse": "WH-Y", "qty": 4.0}
+		]
+
+		_reconcile_reservations_for_mwo("MWO-1", dry_run=False)
+
+		mock_get_doc.assert_not_called()
+
+
+class TestEodSyncIdempotentRerun(FrappeTestCase):
+	"""When `_get_unsynced_mop_groups` returns an empty dict, EOD must be a
+	no-op — no Stock Entry created, no `last_eod_sync_on` stamps, no
+	reconciliation calls. This is the steady-state second run.
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._reconcile_reservations_for_mwo"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.set_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._sync_consolidated_group"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_unsynced_mop_groups",
+		return_value={},
+	)
+	def test_second_run_is_noop_when_no_unsynced_logs(
+		self, _mock_groups, mock_sync, mock_set_value, mock_reconcile
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			sync_mop_logs,
+		)
+
+		out = sync_mop_logs()
+
+		self.assertEqual(out["processed"], 0)
+		self.assertEqual(out["stock_entries"], [])
+		mock_sync.assert_not_called()
+		# No MOPs were touched; no stamps and no reconcile calls.
+		stamp_calls = [
+			c
+			for c in mock_set_value.call_args_list
+			if c[0][0] == "Manufacturing Operation" and c[0][2] == "last_eod_sync_on"
+		]
+		self.assertEqual(stamp_calls, [])
+		mock_reconcile.assert_not_called()
+
+
+class TestEodLossResolutionRequiresManufacturerMapping(FrappeTestCase):
+	"""The EOD loss path must resolve the loss item via Manufacturer mapping.
+	If the helper throws, _create_loss_entries propagates — there is no
+	silent skip, no MOP Settings fallback.
+	"""
+
+	def test_eod_loss_propagates_manufacturer_mapping_error(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			_create_loss_entries,
+		)
+
+		# Stand up a Stock Entry mock that records appended items.
+		stock_entry = MagicMock()
+		stock_entry.items = []
+
+		def append(_, payload):
+			row = MagicMock()
+			row.item_code = payload.get("item_code")
+			row.qty = payload.get("qty")
+			stock_entry.items.append(row)
+
+		stock_entry.append.side_effect = append
+
+		variant_loss_dict = frappe._dict(
+			{
+				"loss_warehouse": "WH-LOSS",
+				"consider_department_warehouse": 0,
+				"warehouse_type": None,
+			}
+		)
+		mop = frappe._dict(
+			{
+				"company": "Test Co",
+				"manufacturer": "Shubh",
+				"manufacturing_work_order": "MWO-1",
+				"manufacturing_order": "MO-1",
+				"department": "Waxing - GEPL",
+			}
+		)
+		latest_logs = [
+			frappe._dict(
+				{
+					"item_code": "M-X",
+					"batch_no": "B1",
+					"qty_after_transaction_batch_based": 5.0,
+				}
+			)
+		]
+
+		# Build all patches inline so frappe.exceptions.ValidationError is
+		# instantiated lazily (after frappe.connect, when the test body runs).
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.new_doc",
+			return_value=stock_entry,
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_value",
+			return_value=variant_loss_dict,
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip.get_loss_item_from_manufacturer_mapping",
+			side_effect=frappe.exceptions.ValidationError(
+				"Loss Item could not be resolved for Item M-X. "
+				"Configure Manufacturer Shubh -> Variant Loss Table."
+			),
+		):
+			with self.assertRaises(frappe.exceptions.ValidationError) as ctx:
+				_create_loss_entries(mop, "MOP-1", latest_logs, "WH-END", 0.5)
+			self.assertIn("Manufacturer", str(ctx.exception))

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_loss_qty_normalization.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_loss_qty_normalization.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for the loss-qty gram normalization helper.
+
+Pure-function tests; no DB, no Frappe site required.
+"""
+
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestGetLossQtyInGrams(FrappeTestCase):
+	def setUp(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+			get_loss_qty_in_grams,
+		)
+
+		self.norm = get_loss_qty_in_grams
+
+	def test_diamond_carat_to_gram(self):
+		# 1 carat = 0.2 g
+		self.assertAlmostEqual(self.norm("D-G-18KT-75.4-Y", 1.0), 0.200, places=3)
+
+	def test_gemstone_carat_to_gram(self):
+		# 2 carat = 0.4 g
+		self.assertAlmostEqual(self.norm("G-G-18KT-75.4-Y", 2.0), 0.400, places=3)
+
+	def test_metal_unchanged(self):
+		self.assertAlmostEqual(self.norm("M-G-22KT-91.9-Y", 1.0), 1.000, places=3)
+
+	def test_finding_unchanged(self):
+		self.assertAlmostEqual(self.norm("F-G-18KT-75.4-Y", 1.0), 1.000, places=3)
+
+	def test_other_unchanged(self):
+		self.assertAlmostEqual(self.norm("O-MISC-001", 1.0), 1.000, places=3)
+
+	def test_zero_qty(self):
+		self.assertEqual(self.norm("D-G-18KT-75.4-Y", 0), 0.0)
+		self.assertEqual(self.norm("M-G-22KT-91.9-Y", 0), 0.0)
+
+	def test_none_item_code_returns_qty_unchanged(self):
+		# Defensive path for callers that hand in a missing item_code.
+		self.assertAlmostEqual(self.norm(None, 1.5), 1.500, places=3)
+		self.assertAlmostEqual(self.norm("", 1.5), 1.500, places=3)
+
+	def test_precision_3_rounding(self):
+		# 5 carat -> 1 g exactly; ensure we round to 3 dp not extend precision.
+		self.assertEqual(self.norm("D-X", 5.0), 1.000)
+		# 0.333... carat -> 0.0666... g -> rounded to 0.067
+		self.assertAlmostEqual(self.norm("D-X", 1.0 / 3), 0.067, places=3)
+
+	def test_dg_prefix_decided_by_first_char_only(self):
+		# Items with prefix Dx-... or Gx-... still convert (single-char rule).
+		self.assertAlmostEqual(self.norm("D2-FOO", 5.0), 1.000, places=3)
+		# An item code starting with another letter does NOT convert even if
+		# 'D' or 'G' appears later.
+		self.assertAlmostEqual(self.norm("MD-FOO", 5.0), 5.000, places=3)
+
+	def test_negative_qty_preserved(self):
+		# Gain rows (negative loss) should normalize the sign too.
+		self.assertAlmostEqual(self.norm("D-X", -1.0), -0.200, places=3)
+
+	def test_mixed_basket_sum_matches_expected(self):
+		# Smoke test for the pattern callers will use: sum a heterogeneous
+		# loss basket and verify the gram-normalized total.
+		basket = [
+			("M-G-22KT-91.9-Y", 0.300),
+			("F-G-18KT-75.4-Y", 0.200),
+			("D-G-18KT-75.4-Y", 1.000),  # 1 ct -> 0.2 g
+			("G-G-18KT-75.4-Y", 0.500),  # 0.5 ct -> 0.1 g
+		]
+		total = sum(self.norm(code, qty) for code, qty in basket)
+		self.assertAlmostEqual(total, 0.800, places=3)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry.py
@@ -1,0 +1,1246 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for the SRE-source Make Receive Entry refactor.
+
+These are unit tests against the whitelisted methods in manufacturing_operation.py;
+they patch frappe DB / doc APIs to avoid needing a populated bench site.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+def _make_mo(name="MOP-1", mwo="MWO-1", department="DEPT-1", status="WIP"):
+	mo = MagicMock()
+	mo.name = name
+	mo.manufacturing_work_order = mwo
+	mo.manufacturing_operation = name
+	mo.manufacturing_order = "PMO-1"
+	mo.department = department
+	mo.status = status
+	return mo
+
+
+class TestGetMakeReceiveEntryRows(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_get_rows_returns_only_mwo_sres(
+		self, mock_get_doc, _mock_single, mock_get_value, mock_get_all, _mock_sql
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+
+		# get_all is called once: SRE listing for the MWO. Filter is the contract.
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"name": "SRE-1",
+					"item_code": "M-G-22KT-91.9-Y",
+					"warehouse": "WH-Src",
+					"reserved_qty": 10.0,
+					"delivered_qty": 0.0,
+					"stock_uom": "Gram",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "SOI-1",
+					"has_serial_no": 0,
+					"has_batch_no": 0,
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+				}
+			)
+		]
+
+		rows = get_make_receive_entry_rows("MOP-1")
+
+		# get_all is called twice now: first for SRE listing, second for MOP
+		# Log balance precompute. Inspect the first call (the SRE filter).
+		_args, kwargs = mock_get_all.call_args_list[0]
+		self.assertEqual(kwargs["filters"]["manufacturing_work_order"], "MWO-1")
+		self.assertEqual(kwargs["filters"]["docstatus"], 1)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["available_to_receive_qty"], 10.0)
+		self.assertEqual(rows[0]["reserved_qty"], 10.0)
+		self.assertEqual(rows[0]["mop_available_qty"], 0)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_make_receive_entry_rejects_mwo_missing(self, mock_get_doc):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mo = _make_mo(mwo=None)
+		mock_get_doc.return_value = mo
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			get_make_receive_entry_rows("MOP-1")
+
+
+class TestCreateMrWoStockEntryValidation(FrappeTestCase):
+	"""Server-side validation must reject over-receive even if the client
+	bypasses its own checks.
+	"""
+
+	def _patch_environment(self, sre_kwargs):
+		"""Common patch stack for create_mr_wo_stock_entry.
+
+		Returns the active patches as a list — caller starts/stops them.
+		"""
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+			),
+		]
+		return patches, sre_kwargs
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_over_receive_rejected_server_side(
+		self,
+		mock_get_doc,
+		_mock_single,
+		mock_get_value,
+		_mock_savepoint,
+		_mock_release,
+		_mock_rollback,
+		mock_new_doc,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		# get_value side effects: idempotency lookup -> None, t_warehouse -> "WH-Raw",
+		# SRE re-fetch (as_dict=True) -> dict.
+		mock_get_value.side_effect = [
+			None,  # idempotency lookup miss
+			"WH-Raw",  # target warehouse resolution
+			frappe._dict(
+				{
+					"name": "SRE-1",
+					"docstatus": 1,
+					"item_code": "M-G-22KT-91.9-Y",
+					"warehouse": "WH-Src",
+					"reserved_qty": 5.0,
+					"delivered_qty": 0.0,
+					"stock_uom": "Gram",
+					"has_batch_no": 0,
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+				}
+			),
+		]
+
+		se_data = {
+			"manufacturing_operation": "MOP-1",
+			"receive_items": [
+				{"stock_reservation_entry": "SRE-1", "qty": 10.0, "idx": 1}
+			],
+		}
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(se_data, request_id="req-1")
+
+		# Stock Entry must NOT have been instantiated.
+		mock_new_doc.assert_not_called()
+
+
+class TestRequestIdIdempotency(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_double_click_idempotency(self, mock_get_doc, mock_get_value):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		# Idempotency lookup hits an existing SE with the same request_id.
+		mock_get_value.return_value = "STE-EXISTING-1"
+
+		out = create_mr_wo_stock_entry(
+			{
+				"manufacturing_operation": "MOP-1",
+				"receive_items": [{"stock_reservation_entry": "SRE-1", "qty": 1.0}],
+			},
+			request_id="req-dedupe",
+		)
+
+		self.assertEqual(out["docname"], "STE-EXISTING-1")
+		self.assertTrue(out["idempotent"])
+
+
+def _patch_create_mr_environment(test_self, sre_data, get_value_extra=None):
+	"""Stand up the standard patch stack for create_mr_wo_stock_entry tests.
+
+	Returns a dict of mocks the caller can use. The caller is responsible for
+	configuring `mock_new_doc` if the test expects to reach the SE-creation
+	branch.
+	"""
+	patches = {
+		"get_doc": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+		),
+		"single": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+			return_value=3,
+		),
+		"get_value": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value"
+		),
+		"savepoint": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+		),
+		"release": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+		),
+		"rollback": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+		),
+		"new_doc": patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+		),
+	}
+	started = {k: p.start() for k, p in patches.items()}
+	for p in patches.values():
+		test_self.addCleanup(p.stop)
+
+	started["get_doc"].return_value = _make_mo()
+	# Default get_value side effects: idempotency miss, t_warehouse, then SRE re-fetch dict.
+	started["get_value"].side_effect = [None, "WH-Raw", sre_data] + (
+		get_value_extra or []
+	)
+	return started
+
+
+class TestCreateMrWoStockEntryEdgeCases(FrappeTestCase):
+	def _sre(self, **overrides):
+		base = frappe._dict(
+			{
+				"name": "SRE-1",
+				"docstatus": 1,
+				"item_code": "M-G-22KT-91.9-Y",
+				"warehouse": "WH-Src",
+				"reserved_qty": 5.0,
+				"delivered_qty": 0.0,
+				"stock_uom": "Gram",
+				"has_batch_no": 0,
+				"reservation_based_on": "Qty",
+				"manufacturing_work_order": "MWO-1",
+			}
+		)
+		base.update(overrides)
+		return base
+
+	def test_zero_qty_rejected(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mocks = _patch_create_mr_environment(self, self._sre())
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 0, "idx": 1}
+					],
+				}
+			)
+		mocks["new_doc"].assert_not_called()
+
+	def test_negative_qty_rejected(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mocks = _patch_create_mr_environment(self, self._sre())
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": -1.0, "idx": 1}
+					],
+				}
+			)
+		mocks["new_doc"].assert_not_called()
+
+	def test_wrong_mwo_sre_rejected(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mocks = _patch_create_mr_environment(
+			self, self._sre(manufacturing_work_order="MWO-OTHER")
+		)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 1.0, "idx": 1}
+					],
+				}
+			)
+		mocks["new_doc"].assert_not_called()
+
+	def test_cancelled_sre_rejected(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		# docstatus=2 means cancelled.
+		mocks = _patch_create_mr_environment(self, self._sre(docstatus=2))
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 1.0, "idx": 1}
+					],
+				}
+			)
+		mocks["new_doc"].assert_not_called()
+
+	def test_missing_sre_reference_rejected(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mocks = _patch_create_mr_environment(self, self._sre())
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [{"qty": 1.0, "idx": 1}],
+				}
+			)
+		mocks["new_doc"].assert_not_called()
+
+	def test_finished_mo_rejected(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		# Override the default MO with status="Finished" before the function runs.
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				return_value=_make_mo(status="Finished"),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+			),
+		]
+		started = [p.start() for p in patches]
+		for p in patches:
+			self.addCleanup(p.stop)
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 1.0, "idx": 1}
+					],
+				}
+			)
+		# new_doc must not have been touched.
+		started[-1].assert_not_called()
+
+	def test_no_receive_items_returns_msgprint(self):
+		"""Empty receive_items list short-circuits without raising."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.msgprint"
+		) as mock_msg:
+			create_mr_wo_stock_entry(
+				{"manufacturing_operation": "MOP-1", "receive_items": []}
+			)
+			mock_msg.assert_called()
+
+	def test_missing_target_warehouse_throws(self):
+		"""When (department, warehouse_type='Raw Material') resolves to None,
+		we throw the exact existing message — never silently fall through.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				return_value=_make_mo(),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			# Idempotency miss + target warehouse miss.
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+				side_effect=[None, None],
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+			),
+		]
+		started = [p.start() for p in patches]
+		for p in patches:
+			self.addCleanup(p.stop)
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 1.0, "idx": 1}
+					],
+				}
+			)
+		started[-1].assert_not_called()
+
+
+class TestGetMakeReceiveEntryRowsFilters(FrappeTestCase):
+	"""Listing must enforce active SRE only, MWO scope, and remaining-qty > 0."""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_zero_remaining_sre_filtered_out(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.return_value = [
+			# Fully delivered — should be filtered.
+			frappe._dict(
+				{
+					"name": "SRE-DONE",
+					"item_code": "M-X",
+					"warehouse": "WH-Y",
+					"reserved_qty": 5.0,
+					"delivered_qty": 5.0,
+					"stock_uom": "Gram",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "SOI-1",
+					"has_serial_no": 0,
+					"has_batch_no": 0,
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+				}
+			),
+			# Active with remaining qty.
+			frappe._dict(
+				{
+					"name": "SRE-ACTIVE",
+					"item_code": "M-X",
+					"warehouse": "WH-Y",
+					"reserved_qty": 10.0,
+					"delivered_qty": 4.0,
+					"stock_uom": "Gram",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-2",
+					"voucher_detail_no": "SOI-2",
+					"has_serial_no": 0,
+					"has_batch_no": 0,
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+				}
+			),
+		]
+
+		rows = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["stock_reservation_entry"], "SRE-ACTIVE")
+		self.assertAlmostEqual(rows[0]["available_to_receive_qty"], 6.0)
+		self.assertAlmostEqual(rows[0]["reserved_qty"], 6.0)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_get_all_filter_includes_docstatus_one(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.return_value = []
+
+		get_make_receive_entry_rows("MOP-1")
+
+		# Inspect the first get_all call — the SRE listing. (Second call is
+		# the MOP Log balance precompute introduced by the helper.)
+		_args, kwargs = mock_get_all.call_args_list[0]
+		filters = kwargs["filters"]
+		self.assertEqual(filters["docstatus"], 1)
+		self.assertEqual(filters["manufacturing_work_order"], "MWO-1")
+		# No hardcoded status whitelist (Correction 2).
+		self.assertNotIn("status", filters)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		# Aggregated already-received shape: (item_code, s_warehouse, sum_qty, sum_pcs).
+		return_value=[("M-X", "WH-Y", 2.5, 0)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_already_received_qty_does_not_reduce_available(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		"""Critical Correction 1 invariant: prior receives must NOT be
+		subtracted from active SRE remaining. SRE remaining is authoritative
+		because partial-receive flow cancels and recreates the SRE.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.return_value = [
+			frappe._dict(
+				{
+					"name": "SRE-NEW",
+					"item_code": "M-X",
+					"warehouse": "WH-Y",
+					"reserved_qty": 6.0,
+					"delivered_qty": 0.0,
+					"stock_uom": "Gram",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "SOI-1",
+					"has_serial_no": 0,
+					"has_batch_no": 0,
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-1",
+				}
+			)
+		]
+
+		rows = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(len(rows), 1)
+		# 6 reserved - 0 delivered = 6 SRE remaining; MOP unmocked = 0 (no
+		# data signal). available_to_receive_qty falls back to SRE
+		# remaining when the helper has no MOP row.
+		self.assertAlmostEqual(rows[0]["available_to_receive_qty"], 6.0)
+		self.assertAlmostEqual(rows[0]["reserved_qty"], 6.0)
+		self.assertAlmostEqual(rows[0]["already_received_qty"], 2.5)
+
+
+class TestPartialReceiveReplacement(FrappeTestCase):
+	"""End-to-end mock-driven test: partial receive cancels original and
+	submits a replacement carrying every voucher_* and metadata field.
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all",
+		return_value=[],
+	)
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry.get_available_qty_to_reserve",
+		return_value=20.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_cached_value",
+		return_value=(0, 0),
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.flags",
+		new_callable=MagicMock,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_partial_receive_cancels_original_and_recreates(
+		self,
+		_mock_single,
+		mock_get_value,
+		_mock_rollback,
+		_mock_release,
+		_mock_savepoint,
+		mock_get_doc,
+		mock_new_doc,
+		_mock_flags,
+		_mock_cached,
+		_mock_available,
+		_mock_mop_get_all,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		# 1) Manufacturing Operation lookup.
+		# 2) Receive flow then loads Stock Reservation Entry to cancel.
+		# We model both via separate calls to frappe.get_doc and pre-canned
+		# return values via side_effect.
+		mo = _make_mo()
+		original_sre = MagicMock()
+		original_sre.name = "SRE-ORIG"
+		original_sre.voucher_type = "Sales Order"
+		original_sre.voucher_no = "SO-1"
+		original_sre.voucher_detail_no = "SOI-1"
+		original_sre.item_code = "M-X"
+		original_sre.warehouse = "WH-Src"
+		original_sre.voucher_qty = 10.0
+		original_sre.company = "Test Co"
+		original_sre.stock_uom = "Gram"
+		original_sre.reservation_based_on = "Qty"
+		original_sre.manufacturing_work_order = "MWO-1"
+		original_sre.manufacturing_operation = "MOP-1"
+		mock_get_doc.side_effect = [mo, original_sre]
+
+		# 1: idempotency miss; 2: t_warehouse; 3: SRE re-fetch dict.
+		mock_get_value.side_effect = [
+			None,
+			"WH-Raw",
+			frappe._dict(
+				{
+					"name": "SRE-ORIG",
+					"docstatus": 1,
+					"item_code": "M-X",
+					"warehouse": "WH-Src",
+					"reserved_qty": 10.0,
+					"delivered_qty": 0.0,
+					"stock_uom": "Gram",
+					"has_batch_no": 0,
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+				}
+			),
+		]
+
+		# new_doc is called twice: once for the Stock Entry, once for
+		# the replacement Stock Reservation Entry.
+		# Make Stock Entry's `.update(dict)` setattr each pair, mirroring the
+		# Document.update contract Frappe code expects.
+		stock_entry = MagicMock()
+		stock_entry.doctype = "Stock Entry"
+		stock_entry.name = "STE-NEW-1"
+
+		def _update_setattr(values):
+			for k, v in values.items():
+				setattr(stock_entry, k, v)
+
+		stock_entry.update.side_effect = _update_setattr
+
+		replacement_sre = MagicMock()
+		replacement_sre.name = "SRE-REPLACEMENT"
+		mock_new_doc.side_effect = [stock_entry, replacement_sre]
+
+		out = create_mr_wo_stock_entry(
+			{
+				"manufacturing_operation": "MOP-1",
+				"receive_items": [
+					{"stock_reservation_entry": "SRE-ORIG", "qty": 4.0, "idx": 1}
+				],
+			},
+			request_id="req-partial",
+		)
+
+		# Stock Entry built and submitted.
+		self.assertEqual(stock_entry.stock_entry_type, "Material Receive (WORK ORDER)")
+		stock_entry.save.assert_called_once()
+		stock_entry.submit.assert_called_once()
+		# Replacement SRE preserves voucher_*, warehouse, MWO/MOP, stock_uom.
+		self.assertEqual(replacement_sre.voucher_type, "Sales Order")
+		self.assertEqual(replacement_sre.voucher_no, "SO-1")
+		self.assertEqual(replacement_sre.voucher_detail_no, "SOI-1")
+		self.assertEqual(replacement_sre.warehouse, "WH-Src")
+		self.assertEqual(replacement_sre.manufacturing_work_order, "MWO-1")
+		self.assertEqual(replacement_sre.manufacturing_operation, "MOP-1")
+		self.assertEqual(replacement_sre.stock_uom, "Gram")
+		# Remaining qty.
+		self.assertAlmostEqual(replacement_sre.reserved_qty, 6.0)
+		# ERPNext's validate_mandatory requires available_qty (label
+		# "Available Qty to Reserve"). Mirror existing project pattern:
+		# max(get_available_qty_to_reserve, reserved_qty).
+		self.assertAlmostEqual(replacement_sre.available_qty, 20.0)
+		# Project convention: insert(ignore_links=1), not save().
+		replacement_sre.insert.assert_called_once_with(ignore_links=1)
+		replacement_sre.submit.assert_called_once()
+		# Original SRE cancelled.
+		original_sre.cancel.assert_called_once()
+		# Output reflects recreate action.
+		self.assertEqual(out["doctype"], "Stock Entry")
+		self.assertEqual(out["docname"], "STE-NEW-1")
+		self.assertFalse(out["idempotent"])
+		actions = out["sre_actions"]
+		self.assertEqual(len(actions), 1)
+		self.assertEqual(actions[0]["action"], "recreated")
+		self.assertEqual(actions[0]["old"], "SRE-ORIG")
+
+
+class TestBuildReplacementSreZeroQty(FrappeTestCase):
+	"""Defensive guards in _build_replacement_sre: zero / sub-precision
+	remaining_qty and empty sb_entries must NOT trigger the
+	'Available Qty to Reserve is required' validation.
+	"""
+
+	def _original_sre(self, reservation_based_on="Qty"):
+		mock = MagicMock()
+		mock.voucher_type = "Sales Order"
+		mock.voucher_no = "SO-1"
+		mock.voucher_detail_no = "SOI-1"
+		mock.item_code = "M-X"
+		mock.warehouse = "WH-Src"
+		mock.voucher_qty = 10.0
+		mock.company = "Test Co"
+		mock.stock_uom = "Gram"
+		mock.reservation_based_on = reservation_based_on
+		mock.manufacturing_work_order = "MWO-1"
+		mock.manufacturing_operation = "MOP-1"
+		return mock
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_zero_remaining_qty_returns_none_no_save(self, _mock_single, mock_new_doc):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		out = _build_replacement_sre(self._original_sre(), remaining_qty=0)
+		self.assertIsNone(out)
+		mock_new_doc.assert_not_called()
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_sub_precision_remaining_qty_returns_none(self, _mock_single, mock_new_doc):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		# precision=3 -> tolerance=0.001. 0.0001 must be treated as zero.
+		out = _build_replacement_sre(self._original_sre(), remaining_qty=0.0001)
+		self.assertIsNone(out)
+		mock_new_doc.assert_not_called()
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_serial_and_batch_with_no_positive_rows_returns_none(
+		self, _mock_single, mock_new_doc
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		# Even with positive remaining_qty, S+B reservations require at least
+		# one positive sb_entries row to be valid.
+		out = _build_replacement_sre(
+			self._original_sre(reservation_based_on="Serial and Batch"),
+			remaining_qty=4.0,
+			sb_remaining=[
+				{"batch_no": "B1", "qty": 0},
+				{"batch_no": "B2", "qty": 0.0001},
+			],
+		)
+		self.assertIsNone(out)
+		mock_new_doc.assert_not_called()
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry.get_available_qty_to_reserve",
+		return_value=15.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_cached_value",
+		return_value=(1, 0),  # has_batch_no=1, has_serial_no=0
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_serial_and_batch_filters_zero_rows_keeps_positive(
+		self, _mock_single, mock_new_doc, _mock_cached, _mock_available
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		new_sre = MagicMock()
+		new_sre.name = "SRE-NEW"
+		mock_new_doc.return_value = new_sre
+
+		out = _build_replacement_sre(
+			self._original_sre(reservation_based_on="Serial and Batch"),
+			remaining_qty=2.0,
+			sb_remaining=[
+				{"batch_no": "B-ZERO", "qty": 0},
+				{"batch_no": "B-OK", "qty": 2.0},
+				{"batch_no": "B-NEAR-ZERO", "qty": 0.0001},
+			],
+		)
+
+		self.assertEqual(out, "SRE-NEW")
+		# Only the positive batch row was appended.
+		appended_batches = [
+			c.args[1]["batch_no"]
+			for c in new_sre.append.call_args_list
+			if c.args and c.args[0] == "sb_entries"
+		]
+		self.assertEqual(appended_batches, ["B-OK"])
+		# ERPNext mandatory: available_qty (max of available_to_reserve, remaining).
+		self.assertAlmostEqual(new_sre.available_qty, 15.0)
+		# has_batch_no propagated from Item master.
+		self.assertEqual(new_sre.has_batch_no, 1)
+		# Project convention.
+		new_sre.insert.assert_called_once_with(ignore_links=1)
+		new_sre.submit.assert_called_once()
+
+
+class TestPartialReceiveZeroBatchSkipsReplacement(FrappeTestCase):
+	"""End-to-end zero-qty contract for the Make Receive Entry caller:
+	when a batch receive consumes the only positive batch row in full and
+	all other batch rows were already delivered, no replacement SRE is
+	created and no zero-qty SRE submit happens.
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all",
+		return_value=[],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.flags",
+		new_callable=MagicMock,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_full_batch_receive_does_not_recreate_zero_sre(
+		self,
+		_mock_single,
+		mock_get_value,
+		_mock_rollback,
+		_mock_release,
+		_mock_savepoint,
+		mock_get_all,
+		mock_get_doc,
+		mock_new_doc,
+		_mock_flags,
+		_mock_mop_get_all,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mo = _make_mo()
+		original_sre = MagicMock()
+		original_sre.name = "SRE-BATCH-ORIG"
+		original_sre.voucher_type = "Sales Order"
+		original_sre.voucher_no = "SO-1"
+		original_sre.voucher_detail_no = "SOI-1"
+		original_sre.item_code = "M-X"
+		original_sre.warehouse = "WH-Src"
+		original_sre.voucher_qty = 5.0
+		original_sre.company = "Test Co"
+		original_sre.stock_uom = "Gram"
+		original_sre.reservation_based_on = "Serial and Batch"
+		original_sre.manufacturing_work_order = "MWO-1"
+		original_sre.manufacturing_operation = "MOP-1"
+		# Two get_doc calls: MO load, then SRE load to cancel.
+		mock_get_doc.side_effect = [mo, original_sre]
+
+		# Single batch row exhausted by the receive request.
+		mock_get_all.return_value = [
+			frappe._dict(
+				{"name": "SB-1", "batch_no": "B1", "qty": 5.0, "delivered_qty": 0.0}
+			)
+		]
+
+		# get_value sequence: idempotency miss + t_warehouse + SRE re-fetch + sb_row re-fetch.
+		mock_get_value.side_effect = [
+			None,
+			"WH-Raw",
+			frappe._dict(
+				{
+					"name": "SRE-BATCH-ORIG",
+					"docstatus": 1,
+					"item_code": "M-X",
+					"warehouse": "WH-Src",
+					"reserved_qty": 5.0,
+					"delivered_qty": 0.0,
+					"stock_uom": "Gram",
+					"has_batch_no": 1,
+					"reservation_based_on": "Serial and Batch",
+					"manufacturing_work_order": "MWO-1",
+				}
+			),
+			frappe._dict(
+				{"name": "SB-1", "batch_no": "B1", "qty": 5.0, "delivered_qty": 0.0}
+			),
+		]
+
+		# new_doc called only for the Stock Entry — never for a replacement SRE
+		# because all batches are zero after receive.
+		stock_entry = MagicMock()
+		stock_entry.doctype = "Stock Entry"
+		stock_entry.name = "STE-NEW-1"
+
+		def _update_setattr(values):
+			for k, v in values.items():
+				setattr(stock_entry, k, v)
+
+		stock_entry.update.side_effect = _update_setattr
+		mock_new_doc.return_value = stock_entry
+
+		out = create_mr_wo_stock_entry(
+			{
+				"manufacturing_operation": "MOP-1",
+				"receive_items": [
+					{
+						"stock_reservation_entry": "SRE-BATCH-ORIG",
+						"stock_reservation_entry_detail": "SB-1",
+						"qty": 5.0,
+						"idx": 1,
+					}
+				],
+			},
+			request_id="req-zero-batch",
+		)
+
+		# Stock Entry was created; SRE was cancelled; NO replacement SRE.
+		self.assertEqual(mock_new_doc.call_count, 1)
+		original_sre.cancel.assert_called_once()
+		actions = out["sre_actions"]
+		self.assertEqual(len(actions), 1)
+		self.assertEqual(actions[0]["action"], "cancelled")
+		self.assertIsNone(actions[0]["new"])
+
+
+class TestAvailableQtyMandatoryContract(FrappeTestCase):
+	"""Regression for the 'Available Qty to Reserve is required' bug.
+
+	ERPNext's Stock Reservation Entry.validate_mandatory requires
+	`available_qty` (label "Available Qty to Reserve"). The replacement SRE
+	must populate this field, mirroring the existing project pattern in
+	doc_events/stock_entry.py:720.
+	"""
+
+	def _original_sre(self):
+		mock = MagicMock()
+		mock.voucher_type = "Sales Order"
+		mock.voucher_no = "SO-1"
+		mock.voucher_detail_no = "SOI-1"
+		mock.item_code = "M-X"
+		mock.warehouse = "WH-Src"
+		mock.voucher_qty = 10.0
+		mock.company = "Test Co"
+		mock.stock_uom = "Gram"
+		mock.reservation_based_on = "Qty"
+		mock.manufacturing_work_order = "MWO-1"
+		mock.manufacturing_operation = "MOP-1"
+		return mock
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry.get_available_qty_to_reserve",
+		return_value=12.5,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_cached_value",
+		return_value=(0, 0),
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_available_qty_set_to_max_of_available_and_remaining(
+		self, _mock_single, mock_new_doc, _mock_cached, _mock_available
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		new_sre = MagicMock()
+		new_sre.name = "SRE-AVAIL"
+		mock_new_doc.return_value = new_sre
+
+		out = _build_replacement_sre(self._original_sre(), remaining_qty=6.0)
+
+		self.assertEqual(out, "SRE-AVAIL")
+		# available_qty == max(get_available_qty_to_reserve=12.5, reserved_qty=6.0).
+		self.assertAlmostEqual(new_sre.available_qty, 12.5)
+		self.assertAlmostEqual(new_sre.reserved_qty, 6.0)
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry.get_available_qty_to_reserve",
+		return_value=2.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_cached_value",
+		return_value=(0, 0),
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_available_qty_falls_back_to_remaining_when_warehouse_short(
+		self, _mock_single, mock_new_doc, _mock_cached, _mock_available
+	):
+		"""When ERPNext reports less than the qty we need to reserve (e.g.
+		stock just landed in the same transaction), `available_qty` must
+		still cover `reserved_qty` so validate_mandatory passes.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		new_sre = MagicMock()
+		new_sre.name = "SRE-FALLBACK"
+		mock_new_doc.return_value = new_sre
+
+		out = _build_replacement_sre(self._original_sre(), remaining_qty=6.0)
+
+		self.assertEqual(out, "SRE-FALLBACK")
+		# available_to_reserve=2.0 < remaining=6.0 ⇒ available_qty=6.0.
+		self.assertAlmostEqual(new_sre.available_qty, 6.0)
+		self.assertAlmostEqual(new_sre.reserved_qty, 6.0)
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry.get_available_qty_to_reserve",
+		return_value=8.0,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_cached_value",
+		return_value=(1, 0),
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	def test_batch_lookup_is_scoped_to_batch_no(
+		self,
+		_mock_single,
+		mock_new_doc,
+		_mock_cached,
+		mock_available,
+	):
+		"""For batch-tracked items, get_available_qty_to_reserve must be
+		called with the batch_no kwarg so the per-batch quantity drives
+		`available_qty`.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_build_replacement_sre,
+		)
+
+		original = self._original_sre()
+		original.reservation_based_on = "Serial and Batch"
+
+		new_sre = MagicMock()
+		new_sre.name = "SRE-BATCH"
+		mock_new_doc.return_value = new_sre
+
+		_build_replacement_sre(
+			original,
+			remaining_qty=4.0,
+			sb_remaining=[{"batch_no": "B-K1", "qty": 4.0}],
+		)
+
+		_, kwargs = mock_available.call_args
+		self.assertEqual(kwargs.get("batch_no"), "B-K1")

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_mop_cap.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_mop_cap.py
@@ -1,0 +1,480 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for the MOP-balance cap on Make Receive Entry.
+
+Covers:
+1. Popup surfaces BOTH `reserved_qty` (SRE remaining) and `mop_available_qty`
+   (MOP Log balance), plus `available_to_receive_qty = min(reserved, mop)`.
+2. Rows where `available_to_receive_qty <= 0` are excluded.
+3. `create_mr_wo_stock_entry` rejects qty over MOP balance with a precise
+   message — the SRE-cap and the MOP-cap give different errors.
+4. Replacement SRE qty is capped by min(remaining_reserved_after_receive,
+   remaining_mop_after_receive) — the safe rule.
+
+Implementation note on mocking: `manufacturing_operation.frappe.db.get_all`
+and `mop_log.frappe.db.get_all` resolve to the SAME underlying object, so
+patching them separately would not work — the later patch silently
+overwrites the earlier one. These tests instead install a single
+dispatcher on `frappe.db.get_all` that switches on doctype.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+def _make_mo(name="MOP-1", mwo="MWO-1", department="DEPT-1", status="WIP"):
+	mo = MagicMock()
+	mo.name = name
+	mo.manufacturing_work_order = mwo
+	mo.manufacturing_operation = name
+	mo.manufacturing_order = "PMO-1"
+	mo.department = department
+	mo.status = status
+	return mo
+
+
+def _sre_dict(reserved_qty=10.0, item_code="M-X", warehouse="WH-Y"):
+	return frappe._dict(
+		{
+			"name": "SRE-1",
+			"item_code": item_code,
+			"warehouse": warehouse,
+			"reserved_qty": reserved_qty,
+			"delivered_qty": 0.0,
+			"stock_uom": "Gram",
+			"voucher_type": "Sales Order",
+			"voucher_no": "SO-1",
+			"voucher_detail_no": "SOI-1",
+			"has_serial_no": 0,
+			"has_batch_no": 0,
+			"reservation_based_on": "Qty",
+			"manufacturing_work_order": "MWO-1",
+			"manufacturing_operation": "MOP-1",
+		}
+	)
+
+
+def _mop_log_row(item_code="M-X", batch_no=None, qty=7.0, pcs=0):
+	return frappe._dict(
+		{
+			"name": "MOPLOG-1",
+			"item_code": item_code,
+			"batch_no": batch_no,
+			"qty_after_transaction_batch_based": qty,
+			"pcs_after_transaction_batch_based": pcs,
+		}
+	)
+
+
+def _make_get_all_dispatcher(sre_rows=None, mop_rows=None, sb_rows=None):
+	"""Return a callable suitable for `side_effect` on a single
+	`frappe.db.get_all` patch. Switches on the first positional arg.
+	"""
+	sre_rows = sre_rows or []
+	mop_rows = mop_rows or []
+	sb_rows = sb_rows or []
+
+	def _dispatcher(doctype, *args, **kwargs):
+		if doctype == "Stock Reservation Entry":
+			return list(sre_rows)
+		if doctype == "MOP Log":
+			return list(mop_rows)
+		if doctype == "Serial and Batch Entry":
+			return list(sb_rows)
+		# DocType lookups (is_virtual_doctype etc.) and anything else.
+		return []
+
+	return _dispatcher
+
+
+# ---------------------------------------------------------------------------
+# Popup row composition
+# ---------------------------------------------------------------------------
+
+
+class TestPopupReservedVsMopFields(FrappeTestCase):
+	def _patch_popup(self, sre_rows, mop_rows):
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				return_value=_make_mo(),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+				return_value="WH-Raw",
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+				return_value=[],
+			),
+			patch(
+				"frappe.db.get_all",
+				side_effect=_make_get_all_dispatcher(
+					sre_rows=sre_rows, mop_rows=mop_rows
+				),
+			),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+	def test_t1_popup_shows_reserved_and_mop_separately(self):
+		"""SRE reserved 10g; MOP says only 7g available. Popup shows the
+		SRE-side reservation untouched and the MOP value separately, with
+		the min surfaced as `available_to_receive_qty`.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		self._patch_popup(
+			sre_rows=[_sre_dict(reserved_qty=10.0)],
+			mop_rows=[_mop_log_row(qty=7.0)],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(len(rows), 1)
+		row = rows[0]
+		self.assertAlmostEqual(row["reserved_qty"], 10.0)
+		self.assertAlmostEqual(row["mop_available_qty"], 7.0)
+		self.assertAlmostEqual(row["available_to_receive_qty"], 7.0)
+
+	def test_t7_row_excluded_when_mop_available_zero(self):
+		"""SRE has 10g reserved but MOP says 0 → row excluded from popup."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		self._patch_popup(
+			sre_rows=[_sre_dict(reserved_qty=10.0)],
+			mop_rows=[_mop_log_row(qty=0.0)],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(rows, [])
+
+	def test_t9_loss_delta_reduces_mop_available(self):
+		"""MOP balance reflects a prior loss (8.5g vs 10g reserved) →
+		mop_available_qty=8.5 caps available_to_receive_qty."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		self._patch_popup(
+			sre_rows=[_sre_dict(reserved_qty=10.0)],
+			mop_rows=[_mop_log_row(qty=8.5)],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(len(rows), 1)
+		self.assertAlmostEqual(rows[0]["mop_available_qty"], 8.5)
+		self.assertAlmostEqual(rows[0]["available_to_receive_qty"], 8.5)
+
+	def test_t10_d_item_pcs_columns_visible(self):
+		"""D/G item: surface Reserved PCS (0 since SRE has no PCS), MOP
+		Available PCS (12), Available to Receive PCS (12 — since SRE has
+		no PCS the MOP cap is the only one).
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		self._patch_popup(
+			sre_rows=[_sre_dict(reserved_qty=2.0, item_code="D-BRI-VS1")],
+			mop_rows=[_mop_log_row(item_code="D-BRI-VS1", qty=2.0, pcs=12)],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(len(rows), 1)
+		row = rows[0]
+		self.assertTrue(row["is_pcs_item"])
+		self.assertEqual(row["reserved_pcs"], 0)
+		self.assertEqual(row["mop_available_pcs"], 12)
+		self.assertEqual(row["available_to_receive_pcs"], 12)
+
+
+# ---------------------------------------------------------------------------
+# Server validation (qty MOP-cap, SRE-cap, server-recomputes-from-MOP-Log)
+# ---------------------------------------------------------------------------
+
+
+class TestServerQtyValidation(FrappeTestCase):
+	def _patch_validator(self, sre_qty, mop_qty):
+		"""Common patch stack for `create_mr_wo_stock_entry`.
+
+		Returns the new_doc mock so callers can `.assert_not_called()`.
+		"""
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				return_value=_make_mo(),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+				side_effect=[
+					None,
+					"WH-Raw",
+					frappe._dict(
+						{
+							"name": "SRE-1",
+							"docstatus": 1,
+							"item_code": "M-X",
+							"warehouse": "WH-Y",
+							"reserved_qty": sre_qty,
+							"delivered_qty": 0.0,
+							"stock_uom": "Gram",
+							"has_batch_no": 0,
+							"reservation_based_on": "Qty",
+							"manufacturing_work_order": "MWO-1",
+						}
+					),
+				],
+			),
+			patch(
+				"frappe.db.get_all",
+				side_effect=_make_get_all_dispatcher(
+					mop_rows=[_mop_log_row(qty=mop_qty)]
+				),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+			),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+		new_doc_patch = patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+		)
+		mock_new_doc = new_doc_patch.start()
+		self.addCleanup(new_doc_patch.stop)
+		return mock_new_doc
+
+	def test_t2_qty_over_mop_available_rejected(self):
+		"""SRE remaining 10, MOP available 7, qty=8 → reject with
+		MOP-cap message."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mock_new_doc = self._patch_validator(sre_qty=10.0, mop_qty=7.0)
+		with self.assertRaisesRegex(
+			frappe.exceptions.ValidationError, "MOP available qty"
+		):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 8.0, "idx": 1}
+					],
+				},
+				request_id="t2",
+			)
+		mock_new_doc.assert_not_called()
+
+	def test_t3_qty_over_reserved_uses_sre_message(self):
+		"""SRE remaining 5, MOP 10, qty=6 → reject with reserved-qty
+		message (SRE cap fires first)."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mock_new_doc = self._patch_validator(sre_qty=5.0, mop_qty=10.0)
+		with self.assertRaisesRegex(
+			frappe.exceptions.ValidationError, "exceeds reserved qty"
+		):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 6.0, "idx": 1}
+					],
+				},
+				request_id="t3",
+			)
+		mock_new_doc.assert_not_called()
+
+	def test_t14_server_ignores_client_side_available_to_receive(self):
+		"""Client passes a stale `available_to_receive_qty=10`. Server
+		recomputes from MOP Log directly and uses MOP=4 → qty=5 rejected.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		mock_new_doc = self._patch_validator(sre_qty=10.0, mop_qty=4.0)
+		with self.assertRaisesRegex(
+			frappe.exceptions.ValidationError, "MOP available qty"
+		):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{
+							"stock_reservation_entry": "SRE-1",
+							"qty": 5.0,
+							# Client lies — server must ignore.
+							"available_to_receive_qty": 10.0,
+							"idx": 1,
+						}
+					],
+				},
+				request_id="t14",
+			)
+		mock_new_doc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Replacement SRE safe-rule
+# ---------------------------------------------------------------------------
+
+
+class TestReplacementSafeRule(FrappeTestCase):
+	"""Replacement SRE qty must never exceed remaining MOP balance after
+	the receive."""
+
+	def _run_partial_receive(self, mop_qty, req_qty, sre_qty=10.0):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		original_sre = MagicMock()
+		original_sre.name = "SRE-T5"
+		original_sre.voucher_type = "Sales Order"
+		original_sre.voucher_no = "SO-1"
+		original_sre.voucher_detail_no = "SOI-1"
+		original_sre.item_code = "M-X"
+		original_sre.warehouse = "WH-Y"
+		original_sre.voucher_qty = sre_qty
+		original_sre.company = "Test Co"
+		original_sre.stock_uom = "Gram"
+		original_sre.reservation_based_on = "Qty"
+		original_sre.manufacturing_work_order = "MWO-1"
+		original_sre.manufacturing_operation = "MOP-1"
+
+		stock_entry = MagicMock()
+		stock_entry.doctype = "Stock Entry"
+		stock_entry.name = "STE-T5"
+
+		def _update_setattr(values):
+			for k, v in values.items():
+				setattr(stock_entry, k, v)
+
+		stock_entry.update.side_effect = _update_setattr
+
+		replacement_sre = MagicMock()
+		replacement_sre.name = "SRE-REPLACEMENT"
+
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				side_effect=[_make_mo(), original_sre],
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+				side_effect=[
+					None,
+					"WH-Raw",
+					frappe._dict(
+						{
+							"name": "SRE-T5",
+							"docstatus": 1,
+							"item_code": "M-X",
+							"warehouse": "WH-Y",
+							"reserved_qty": sre_qty,
+							"delivered_qty": 0.0,
+							"stock_uom": "Gram",
+							"has_batch_no": 0,
+							"reservation_based_on": "Qty",
+							"manufacturing_work_order": "MWO-1",
+						}
+					),
+				],
+			),
+			patch(
+				"frappe.db.get_all",
+				side_effect=_make_get_all_dispatcher(
+					mop_rows=[_mop_log_row(qty=mop_qty)]
+				),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+			),
+			patch(
+				"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry.get_available_qty_to_reserve",
+				return_value=20.0,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_cached_value",
+				return_value=(0, 0),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.flags",
+				new_callable=MagicMock,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc",
+				side_effect=[stock_entry, replacement_sre],
+			),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+		create_mr_wo_stock_entry(
+			{
+				"manufacturing_operation": "MOP-1",
+				"receive_items": [
+					{
+						"stock_reservation_entry": "SRE-T5",
+						"qty": req_qty,
+						"idx": 1,
+					}
+				],
+			},
+			request_id=f"t5-{mop_qty}-{req_qty}",
+		)
+		return replacement_sre, original_sre
+
+	def test_t5_replacement_capped_by_remaining_mop(self):
+		"""SRE 10g + MOP 8g + receive 3g → replacement = min(7, 5) = 5g."""
+		replacement_sre, original_sre = self._run_partial_receive(
+			mop_qty=8.0, req_qty=3.0
+		)
+		self.assertAlmostEqual(replacement_sre.reserved_qty, 5.0)
+		original_sre.cancel.assert_called_once()
+		replacement_sre.submit.assert_called_once()
+
+	def test_t6_no_replacement_when_mop_fully_received(self):
+		"""SRE 10g + MOP 7g + receive 7g → replacement = min(3, 0) = 0
+		→ no replacement SRE."""
+		replacement_sre, original_sre = self._run_partial_receive(
+			mop_qty=7.0, req_qty=7.0
+		)
+		original_sre.cancel.assert_called_once()
+		replacement_sre.submit.assert_not_called()
+		replacement_sre.insert.assert_not_called()

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_pcs.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_pcs.py
@@ -1,0 +1,489 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for the Qty/PCS reconciliation extension to Make Receive Entry.
+
+Covers:
+- get_available_qty_pcs_for_mop_item (helper) — dict shape, MOP Log balance
+  precedence, D/G vs M/F/O gating, missing-PCS-source handling.
+- get_make_receive_entry_rows endpoint — new context fields surface.
+- create_mr_wo_stock_entry server-side PCS validation.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestGetAvailableQtyPcsForMopItem(FrappeTestCase):
+	"""The helper is the single source of truth for popup, server validator,
+	and Employee IR manual-loss PCS check. These tests pin its contract.
+	"""
+
+	def _ctx(self, **kwargs):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			get_available_qty_pcs_for_mop_item,
+		)
+
+		return get_available_qty_pcs_for_mop_item(**kwargs)
+
+	def test_t1_dict_shape(self):
+		"""T1 — helper returns the documented context dict keys."""
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="M-X",
+			batch_no="B1",
+			sre_remaining_qty=10.0,
+			mop_log_balance_map={},
+		)
+		expected_keys = {
+			"item_code",
+			"batch_no",
+			"source_warehouse",
+			"stock_reservation_entry",
+			"stock_reservation_entry_detail",
+			"manufacturing_work_order",
+			"reserved_qty",
+			"reserved_pcs",
+			"mop_log_balance_qty",
+			"mop_log_balance_pcs",
+			"stock_entry_transferred_qty",
+			"stock_entry_transferred_pcs",
+			"already_received_qty",
+			"already_received_pcs",
+			"available_qty",
+			"available_pcs",
+			"is_pcs_item",
+			"mop_log_reference",
+		}
+		self.assertEqual(set(ctx.keys()), expected_keys)
+		# SRE never stores PCS — reserved_pcs must be None (unknown).
+		self.assertIsNone(ctx["reserved_pcs"])
+
+	def test_t2_available_qty_min_of_sre_and_mop_log(self):
+		"""T2 — available_qty = min(SRE remaining, MOP Log batch-based qty)."""
+		mop_balance_map = {
+			("M-X", "B1"): frappe._dict(
+				{
+					"item_code": "M-X",
+					"batch_no": "B1",
+					"qty_after_transaction_batch_based": 6.0,
+					"pcs_after_transaction_batch_based": 0,
+					"name": "MOPLOG-1",
+				}
+			)
+		}
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="M-X",
+			batch_no="B1",
+			sre_remaining_qty=10.0,
+			mop_log_balance_map=mop_balance_map,
+		)
+		# MOP Log shows 6 < SRE 10 — clamps to 6.
+		self.assertAlmostEqual(ctx["available_qty"], 6.0)
+		self.assertEqual(ctx["mop_log_reference"], "MOPLOG-1")
+
+	def test_t3_d_item_available_pcs_from_mop_log(self):
+		"""T3 — D-prefix item: available_pcs reads MOP Log batch-based PCS."""
+		mop_balance_map = {
+			("D-BRI-VS1", "BD1"): frappe._dict(
+				{
+					"item_code": "D-BRI-VS1",
+					"batch_no": "BD1",
+					"qty_after_transaction_batch_based": 2.0,
+					"pcs_after_transaction_batch_based": 12,
+					"name": "MOPLOG-D",
+				}
+			)
+		}
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="D-BRI-VS1",
+			batch_no="BD1",
+			sre_remaining_qty=2.0,
+			mop_log_balance_map=mop_balance_map,
+		)
+		self.assertTrue(ctx["is_pcs_item"])
+		self.assertEqual(ctx["available_pcs"], 12)
+		self.assertEqual(ctx["mop_log_balance_pcs"], 12)
+
+	def test_t4_g_item_available_pcs_from_mop_log(self):
+		"""T4 — G-prefix item: same path as D."""
+		mop_balance_map = {
+			("G-RUBY", "BG1"): frappe._dict(
+				{
+					"item_code": "G-RUBY",
+					"batch_no": "BG1",
+					"qty_after_transaction_batch_based": 5.0,
+					"pcs_after_transaction_batch_based": 8,
+					"name": "MOPLOG-G",
+				}
+			)
+		}
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="G-RUBY",
+			batch_no="BG1",
+			sre_remaining_qty=5.0,
+			mop_log_balance_map=mop_balance_map,
+		)
+		self.assertTrue(ctx["is_pcs_item"])
+		self.assertEqual(ctx["available_pcs"], 8)
+
+	def test_t5_m_f_o_items_are_not_pcs_items(self):
+		"""T5 — M/F/O items have is_pcs_item=False, available_pcs=0."""
+		for item_code in ("M-X", "F-Y", "O-Z"):
+			ctx = self._ctx(
+				manufacturing_operation="MOP-1",
+				item_code=item_code,
+				batch_no=None,
+				sre_remaining_qty=1.0,
+				mop_log_balance_map={},
+			)
+			self.assertFalse(ctx["is_pcs_item"], item_code)
+			self.assertEqual(ctx["available_pcs"], 0, item_code)
+
+	def test_t6_m_item_available_pcs_zero_no_false_positive(self):
+		"""T6 — M item with explicit MOP Log PCS=0 still yields
+		available_pcs=0 (non-D/G branch returns 0 unconditionally).
+		"""
+		mop_balance_map = {
+			("M-X", "B1"): frappe._dict(
+				{
+					"item_code": "M-X",
+					"batch_no": "B1",
+					"qty_after_transaction_batch_based": 5.0,
+					"pcs_after_transaction_batch_based": 0,
+					"name": "MOPLOG-M",
+				}
+			)
+		}
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="M-X",
+			batch_no="B1",
+			sre_remaining_qty=5.0,
+			mop_log_balance_map=mop_balance_map,
+		)
+		self.assertFalse(ctx["is_pcs_item"])
+		self.assertEqual(ctx["available_pcs"], 0)
+
+	def test_t7_d_item_missing_pcs_source_does_not_force_zero_unfairly(self):
+		"""T7 — D item with MOP Log row showing positive PCS yields that
+		PCS as available, even when SRE has no PCS field at all.
+		Spec: missing PCS source must NOT be treated as zero.
+		"""
+		mop_balance_map = {
+			("D-BRI", "BD1"): frappe._dict(
+				{
+					"item_code": "D-BRI",
+					"batch_no": "BD1",
+					"pcs_after_transaction_batch_based": 7,
+					"qty_after_transaction_batch_based": 1.4,
+					"name": "MOPLOG-D7",
+				}
+			)
+		}
+		# SRE doesn't have any PCS data — must not pull available_pcs to 0.
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="D-BRI",
+			batch_no="BD1",
+			sre_remaining_qty=1.4,
+			mop_log_balance_map=mop_balance_map,
+		)
+		self.assertEqual(ctx["available_pcs"], 7)
+
+	def test_helper_no_mop_log_row_yields_sre_only_qty(self):
+		"""Edge case — when MOP Log has no row for (item, batch), available_qty
+		falls back to SRE remaining (no false zero constraint).
+		"""
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="M-X",
+			batch_no="B1",
+			sre_remaining_qty=10.0,
+			mop_log_balance_map={},
+		)
+		self.assertAlmostEqual(ctx["available_qty"], 10.0)
+		# No D/G — available_pcs is 0 regardless of source.
+		self.assertEqual(ctx["available_pcs"], 0)
+
+	def test_helper_negative_mop_balance_clamps_to_zero(self):
+		"""Edge case — a corrupted balance below zero should not yield a
+		negative available_qty; clamp to 0.
+		"""
+		mop_balance_map = {
+			("M-X", "B1"): frappe._dict(
+				{
+					"qty_after_transaction_batch_based": -1.5,
+					"pcs_after_transaction_batch_based": 0,
+					"name": "MOPLOG-NEG",
+				}
+			)
+		}
+		ctx = self._ctx(
+			manufacturing_operation="MOP-1",
+			item_code="M-X",
+			batch_no="B1",
+			sre_remaining_qty=10.0,
+			mop_log_balance_map=mop_balance_map,
+		)
+		self.assertAlmostEqual(ctx["available_qty"], 0.0)
+
+
+def _make_mo(name="MOP-1", mwo="MWO-1", department="DEPT-1", status="WIP"):
+	mo = MagicMock()
+	mo.name = name
+	mo.manufacturing_work_order = mwo
+	mo.manufacturing_operation = name
+	mo.manufacturing_order = "PMO-1"
+	mo.department = department
+	mo.status = status
+	return mo
+
+
+class TestCreateMrWoStockEntryPcsValidation(FrappeTestCase):
+	"""Server-side PCS rules: D/G validate against available; M/F/O force 0."""
+
+	def _patches(self, sre_dict, mop_balance_map=None):
+		"""Common patch stack — get_doc, get_value, get_all (MOP Log fetch),
+		savepoint stubs.
+		"""
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				return_value=_make_mo(),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+				side_effect=[None, "WH-Raw", sre_dict],
+			),
+			# Helper inside create_mr_wo_stock_entry calls
+			# get_current_mop_balance_rows → frappe.db.get_all on MOP Log.
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all",
+				return_value=list((mop_balance_map or {}).values()),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.release_savepoint"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.rollback"
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.new_doc"
+			),
+		]
+		started = [p.start() for p in patches]
+		for p in patches:
+			self.addCleanup(p.stop)
+		return started
+
+	def test_t8_qty_over_available_rejected(self):
+		"""T8 — Receive Qty > available_qty server-rejected (regression-guard)."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		sre = frappe._dict(
+			{
+				"name": "SRE-1",
+				"docstatus": 1,
+				"item_code": "M-G-22KT-91.9-Y",
+				"warehouse": "WH-Src",
+				"reserved_qty": 5.0,
+				"delivered_qty": 0.0,
+				"stock_uom": "Gram",
+				"has_batch_no": 0,
+				"reservation_based_on": "Qty",
+				"manufacturing_work_order": "MWO-1",
+			}
+		)
+		started = self._patches(sre)
+		new_doc_mock = started[-1]
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{"stock_reservation_entry": "SRE-1", "qty": 10.0, "idx": 1}
+					],
+				},
+				request_id="t8",
+			)
+		new_doc_mock.assert_not_called()
+
+	def test_t9_d_item_pcs_over_available_rejected(self):
+		"""T9 — D item: receive_pcs > available_pcs server-rejected."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		sre = frappe._dict(
+			{
+				"name": "SRE-D",
+				"docstatus": 1,
+				"item_code": "D-BRI-VS1",
+				"warehouse": "WH-Src",
+				"reserved_qty": 5.0,
+				"delivered_qty": 0.0,
+				"stock_uom": "Carat",
+				"has_batch_no": 1,
+				"reservation_based_on": "Qty",
+				"manufacturing_work_order": "MWO-1",
+			}
+		)
+		# MOP Log shows only 3 PCS available.
+		mop_balance_map = {
+			("D-BRI-VS1", None): frappe._dict(
+				{
+					"item_code": "D-BRI-VS1",
+					"batch_no": None,
+					"qty_after_transaction_batch_based": 5.0,
+					"pcs_after_transaction_batch_based": 3,
+					"is_cancelled": 0,
+					"name": "MOPLOG-D9",
+				}
+			)
+		}
+		started = self._patches(sre, mop_balance_map=mop_balance_map)
+		new_doc_mock = started[-1]
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{
+							"stock_reservation_entry": "SRE-D",
+							"qty": 1.0,
+							"pcs": 5,  # over limit
+							"idx": 1,
+						}
+					],
+				},
+				request_id="t9",
+			)
+		new_doc_mock.assert_not_called()
+
+	def test_t10_m_item_forces_pcs_zero(self):
+		"""T10 — M item: even when client sends pcs > 0, server zeros it."""
+		self._assert_non_dg_pcs_force_zero("M-G-22KT-91.9-Y", 5)
+
+	def test_t11_f_item_forces_pcs_zero(self):
+		"""T11 — F item: same forced-zero rule."""
+		self._assert_non_dg_pcs_force_zero("F-G-18KT-CHA", 7)
+
+	def test_t12_o_item_forces_pcs_zero(self):
+		"""T12 — O item: same forced-zero rule."""
+		self._assert_non_dg_pcs_force_zero("O-PACKAGING", 3)
+
+	def _assert_non_dg_pcs_force_zero(self, item_code, client_pcs):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		sre = frappe._dict(
+			{
+				"name": "SRE-MFO",
+				"docstatus": 1,
+				"item_code": item_code,
+				"warehouse": "WH-Src",
+				"reserved_qty": 5.0,
+				"delivered_qty": 0.0,
+				"stock_uom": "Gram",
+				"has_batch_no": 0,
+				"reservation_based_on": "Qty",
+				"manufacturing_work_order": "MWO-1",
+			}
+		)
+		started = self._patches(sre, mop_balance_map={})
+		new_doc_mock = started[-1]
+
+		stock_entry = MagicMock()
+		stock_entry.doctype = "Stock Entry"
+		stock_entry.name = "STE-MFO"
+		appended = []
+
+		def _append(table, values):
+			appended.append(values)
+
+		stock_entry.append.side_effect = _append
+
+		def _update_setattr(values):
+			for k, v in values.items():
+				setattr(stock_entry, k, v)
+
+		stock_entry.update.side_effect = _update_setattr
+		new_doc_mock.return_value = stock_entry
+
+		create_mr_wo_stock_entry(
+			{
+				"manufacturing_operation": "MOP-1",
+				"receive_items": [
+					{
+						"stock_reservation_entry": "SRE-MFO",
+						"qty": 1.0,
+						"pcs": client_pcs,
+						"idx": 1,
+					}
+				],
+			},
+			request_id=f"t-mfo-{item_code}",
+		)
+		# At least one item appended, and the pcs field is forced to 0.
+		self.assertTrue(appended, "Stock Entry should have at least one item row")
+		self.assertEqual(
+			appended[0]["pcs"], 0, f"Server must force pcs=0 for {item_code}"
+		)
+
+	def test_t13_d_item_negative_pcs_rejected(self):
+		"""T13 — D item: receive_pcs < 0 server-rejected."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			create_mr_wo_stock_entry,
+		)
+
+		sre = frappe._dict(
+			{
+				"name": "SRE-D-NEG",
+				"docstatus": 1,
+				"item_code": "D-BRI-VS1",
+				"warehouse": "WH-Src",
+				"reserved_qty": 5.0,
+				"delivered_qty": 0.0,
+				"stock_uom": "Carat",
+				"has_batch_no": 0,
+				"reservation_based_on": "Qty",
+				"manufacturing_work_order": "MWO-1",
+			}
+		)
+		started = self._patches(sre, mop_balance_map={})
+		new_doc_mock = started[-1]
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			create_mr_wo_stock_entry(
+				{
+					"manufacturing_operation": "MOP-1",
+					"receive_items": [
+						{
+							"stock_reservation_entry": "SRE-D-NEG",
+							"qty": 1.0,
+							"pcs": -1,
+							"idx": 1,
+						}
+					],
+				},
+				request_id="t13",
+			)
+		new_doc_mock.assert_not_called()

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_mop_weight_recalc.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_mop_weight_recalc.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for recalculate_manufacturing_operation_weights.
+
+Covers the central MOP weight bucket recompute:
+- multi-batch sums (the regression that motivated the helper)
+- D/G carat-to-gram conversion in gross_wt
+- D/G PCS aggregation
+- cancelled rows are excluded
+- latest-by-creation wins per (item, batch)
+- pending in-flight row overrides DB
+- pending row being cancelled is dropped, not treated as authoritative
+"""
+
+from unittest.mock import MagicMock, patch
+
+from frappe.tests.utils import FrappeTestCase
+
+
+def _row(item_code, batch_no, qaf_batch, pcs_batch=0, name=None, creation=None):
+	return {
+		"item_code": item_code,
+		"batch_no": batch_no,
+		"qaf_batch": qaf_batch,
+		"pcs_batch": pcs_batch,
+		"name": name or f"{item_code}-{batch_no}",
+		"creation": creation,
+	}
+
+
+class _RecalcHarness:
+	"""Captures frappe.db.set_value calls so we can assert the bucket update."""
+
+	def __init__(self):
+		self.set_value_calls = []
+
+	def fake_set_value(self, doctype, name, value=None, *_args, **_kwargs):
+		self.set_value_calls.append((doctype, name, value))
+
+
+class TestRecalcManufacturingOperationWeights(FrappeTestCase):
+	def _run(self, db_rows, pending=None, prev_mop_gross=0.0, mop_state=None):
+		"""Drive the helper with mocked DB queries.
+
+		Returns (mop_update_dict, gross_wt_written) so tests can assert
+		final bucket values and gross_wt.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log import mop_log as mod
+
+		harness = _RecalcHarness()
+
+		# State the helper reads via update_wt_detail after writing buckets.
+		mop_state = mop_state or {}
+		default_state = {
+			"net_wt": 0,
+			"finding_wt": 0,
+			"diamond_wt_in_gram": 0,
+			"gemstone_wt_in_gram": 0,
+			"other_wt": 0,
+			"previous_mop": None,
+			"loss_wt": 0,
+		}
+		default_state.update(mop_state)
+
+		def fake_set_value(doctype, name, value):
+			harness.fake_set_value(doctype, name, value)
+			# Reflect bucket writes into our in-memory state so the
+			# subsequent update_wt_detail read sees them.
+			if isinstance(value, dict):
+				default_state.update(value)
+
+		def fake_get_value(doctype, name, fields):
+			# update_wt_detail reads either the multi-field tuple from MOP
+			# or the previous MOP gross. Distinguish by `fields` shape.
+			if isinstance(fields, list):
+				return tuple(default_state.get(f, 0) for f in fields)
+			# scalar field, e.g. previous_mop's gross_wt
+			return prev_mop_gross
+
+		with (
+			patch.object(mod.frappe.db, "sql", return_value=db_rows),
+			patch.object(mod.frappe.db, "set_value", side_effect=fake_set_value),
+			patch.object(mod.frappe.db, "get_value", side_effect=fake_get_value),
+		):
+			mod.recalculate_manufacturing_operation_weights("MOP-X", pending=pending)
+
+		bucket_calls = [
+			c
+			for c in harness.set_value_calls
+			if isinstance(c[2], dict) and "net_wt" in c[2]
+		]
+		gross_calls = [
+			c
+			for c in harness.set_value_calls
+			if isinstance(c[2], dict) and "gross_wt" in c[2]
+		]
+		assert bucket_calls, "no bucket update written"
+		assert gross_calls, "no gross_wt update written"
+		return bucket_calls[-1][2], gross_calls[-1][2]
+
+	def test_multi_batch_sum_per_prefix(self):
+		"""The MOP-EO481 regression: multiple batches per prefix must SUM,
+		not be overwritten by the last-saved row.
+		"""
+		rows = [
+			_row("M-G-18KT-75.4-P", "B-M-176", 2.074),
+			_row("M-G-18KT-75.4-P", "B-M-28", 0.199),
+			_row("F-X-CHA", "B-F-CHA", 2.018),
+			_row("F-X-CO", "B-F-CO", 0.316),
+		]
+		bucket, gross = self._run(rows)
+		self.assertAlmostEqual(bucket["net_wt"], 2.273, places=3)
+		self.assertAlmostEqual(bucket["finding_wt"], 2.334, places=3)
+		# gross = M + F + DG-in-gram + O
+		self.assertAlmostEqual(gross["gross_wt"], 2.273 + 2.334, places=3)
+
+	def test_dg_carat_converted_to_gram_in_gross_wt(self):
+		"""D/G buckets stay in carats; gross_wt rolls them up at × 0.2."""
+		rows = [
+			_row("D-X-1", "B-D-1", 1.0, pcs_batch=3),
+			_row("G-X-1", "B-G-1", 2.0, pcs_batch=5),
+		]
+		bucket, gross = self._run(rows)
+		self.assertEqual(bucket["diamond_wt"], 1.0)
+		self.assertEqual(bucket["gemstone_wt"], 2.0)
+		self.assertAlmostEqual(bucket["diamond_wt_in_gram"], 0.2, places=3)
+		self.assertAlmostEqual(bucket["gemstone_wt_in_gram"], 0.4, places=3)
+		# gross = 0.2 (D) + 0.4 (G)
+		self.assertAlmostEqual(gross["gross_wt"], 0.6, places=3)
+
+	def test_dg_pcs_aggregated_per_prefix(self):
+		rows = [
+			_row("D-X-1", "B-D-1", 0.05, pcs_batch=3),
+			_row("D-X-2", "B-D-2", 0.10, pcs_batch=4),
+		]
+		bucket, _gross = self._run(rows)
+		self.assertEqual(bucket["diamond_pcs"], 7.0)
+
+	def test_cancelled_rows_are_excluded(self):
+		"""The SQL filter `is_cancelled = 0` is the boundary; the helper
+		trusts the query. Pass DB rows that mimic the post-filter state.
+		"""
+		rows = [
+			_row("M-X", "B1", 5.0),
+			# A cancelled row would not appear here at all.
+		]
+		bucket, _gross = self._run(rows)
+		self.assertEqual(bucket["net_wt"], 5.0)
+
+	def test_latest_creation_wins_per_item_batch(self):
+		"""Two rows for the same (item, batch) — the LATER creation wins."""
+		rows = [
+			_row("M-X", "B1", 5.0, creation="2026-01-01 00:00:00"),
+			_row("M-X", "B1", 3.0, creation="2026-02-01 00:00:00"),
+		]
+		bucket, _gross = self._run(rows)
+		# DB rows are passed in ASC order so the dict update keeps the last
+		# (= latest creation) entry.
+		self.assertEqual(bucket["net_wt"], 3.0)
+
+	def test_pending_overrides_db_for_same_key(self):
+		"""validate() injects `self` as pending; it must override whatever
+		the DB shows for its (item, batch) since that row is being saved.
+		"""
+		rows = [_row("M-X", "B1", 5.0)]
+		pending = MagicMock()
+		pending.item_code = "M-X"
+		pending.batch_no = "B1"
+		pending.qty_after_transaction_batch_based = 4.5
+		pending.pcs_after_transaction_batch_based = 0
+		pending.is_cancelled = 0
+
+		bucket, _gross = self._run(rows, pending=pending)
+		self.assertEqual(bucket["net_wt"], 4.5)
+
+	def test_pending_for_new_key_adds_to_bucket(self):
+		"""A pending row whose (item, batch) isn't in DB yet still counts
+		toward the bucket — covers the insert path.
+		"""
+		rows = [_row("M-X", "B1", 5.0)]
+		pending = MagicMock()
+		pending.item_code = "M-Y"
+		pending.batch_no = "B-NEW"
+		pending.qty_after_transaction_batch_based = 1.0
+		pending.pcs_after_transaction_batch_based = 0
+		pending.is_cancelled = 0
+
+		bucket, _gross = self._run(rows, pending=pending)
+		self.assertAlmostEqual(bucket["net_wt"], 6.0, places=3)
+
+	def test_pending_being_cancelled_is_dropped_not_authoritative(self):
+		"""When the in-flight save is FLIPPING a row to is_cancelled=1, the
+		row must drop out of the latest map — otherwise it'd be treated as
+		authoritative and re-add itself to the bucket.
+		"""
+		pending = MagicMock()
+		pending.item_code = "M-X"
+		pending.batch_no = "B1"
+		pending.qty_after_transaction_batch_based = 5.0
+		pending.pcs_after_transaction_batch_based = 0
+		pending.is_cancelled = 1  # being cancelled now
+
+		# DB rows reflect post-cancel state already (no row for B1).
+		# So the helper should produce 0.
+		bucket, _gross = self._run([], pending=pending)
+		self.assertEqual(bucket["net_wt"], 0.0)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_mop_weight_recompute.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_mop_weight_recompute.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for recalculate_manufacturing_operation_weights.
+
+Mocks frappe.db.sql (active MOP Log rows) and frappe.db.set_value /
+frappe.db.get_value (Manufacturing Operation reads/writes), so the aggregation
+logic can be exercised without a site fixture.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+
+def _row(
+	item_code,
+	batch_no,
+	qaf_batch,
+	pcs_batch=0,
+	name="ML-X",
+	creation="2026-01-01 00:00:00",
+):
+	return {
+		"item_code": item_code,
+		"batch_no": batch_no,
+		"name": name,
+		"qaf_batch": qaf_batch,
+		"pcs_batch": pcs_batch,
+		"creation": creation,
+	}
+
+
+class TestRecalculateMopWeights(FrappeTestCase):
+	def _run(self, rows, pending=None):
+		# Capture writes; the helper calls set_value once for buckets, then
+		# update_wt_detail does a get_value for the bucket fields and a
+		# set_value for gross_wt + prev_gross_wt.
+		writes = []
+
+		def fake_set_value(doctype, name, update, *args, **kwargs):
+			writes.append((doctype, name, update))
+
+		def fake_get_value(doctype, name, fields, *args, **kwargs):
+			# Replay the latest write to the same MOP for the requested fields.
+			merged = {}
+			for d, n, u in writes:
+				if d == "Manufacturing Operation" and n == name and isinstance(u, dict):
+					merged.update(u)
+			# previous_mop is not under test here; treat as None.
+			merged.setdefault("previous_mop", None)
+			merged.setdefault("loss_wt", 0)
+			return tuple(merged.get(f) for f in fields)
+
+		with (
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.sql",
+				return_value=rows,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.set_value",
+				side_effect=fake_set_value,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+				side_effect=fake_get_value,
+			),
+		):
+			from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+				recalculate_manufacturing_operation_weights,
+			)
+
+			recalculate_manufacturing_operation_weights("MOP-TEST", pending=pending)
+		# Merge all bucket writes into a single dict for assertions.
+		merged = {}
+		for _d, _n, u in writes:
+			if isinstance(u, dict):
+				merged.update(u)
+		return merged
+
+	def test_multi_batch_single_prefix_sums(self):
+		# Two M batches on the same MOP. Old behavior would have stored only
+		# the latest single-row balance into net_wt; the helper must sum.
+		rows = [
+			_row("M-G-18KT", "B1", 2.074, name="ML-1"),
+			_row("M-G-18KT", "B2", 0.199, name="ML-2"),
+		]
+		out = self._run(rows)
+		self.assertAlmostEqual(out["net_wt"], 2.273, places=3)
+		self.assertAlmostEqual(out["gross_wt"], 2.273, places=3)
+
+	def test_multi_prefix_gross_wt_is_sum_of_buckets(self):
+		# M + F + D in carats; gross_wt should include D in grams (×0.2).
+		rows = [
+			_row("M-X", "BM", 2.273),
+			_row("F-X", "BF", 2.334),
+			_row("D-X", "BD", 0.253, pcs_batch=4),
+		]
+		out = self._run(rows)
+		self.assertAlmostEqual(out["net_wt"], 2.273, places=3)
+		self.assertAlmostEqual(out["finding_wt"], 2.334, places=3)
+		self.assertAlmostEqual(out["diamond_wt"], 0.253, places=3)
+		self.assertAlmostEqual(out["diamond_wt_in_gram"], 0.051, places=3)
+		self.assertEqual(out["diamond_pcs"], 4)
+		self.assertAlmostEqual(out["gross_wt"], 2.273 + 2.334 + 0.051, places=3)
+
+	def test_dg_carat_to_gram_in_gross_wt(self):
+		# 1 ct D + 2 ct G -> 0.2 + 0.4 = 0.6 g of gross_wt contribution.
+		rows = [
+			_row("D-X", "BD", 1.0, pcs_batch=1),
+			_row("G-X", "BG", 2.0, pcs_batch=2),
+		]
+		out = self._run(rows)
+		self.assertAlmostEqual(out["diamond_wt_in_gram"], 0.200, places=3)
+		self.assertAlmostEqual(out["gemstone_wt_in_gram"], 0.400, places=3)
+		self.assertAlmostEqual(out["gross_wt"], 0.600, places=3)
+
+	def test_latest_qty_after_per_batch_wins(self):
+		# Multiple rows for the same (item, batch); the dict-based "last write
+		# wins" after ORDER BY creation ASC means the newest row's
+		# qaf_batch is the active balance. We feed rows in chronological order.
+		rows = [
+			_row("M-X", "B1", 5.0, creation="2026-01-01"),
+			_row("M-X", "B1", 4.0, creation="2026-01-02"),  # later — wins
+		]
+		out = self._run(rows)
+		self.assertAlmostEqual(out["net_wt"], 4.000, places=3)
+		self.assertAlmostEqual(out["gross_wt"], 4.000, places=3)
+
+	def test_pending_row_overrides_db_for_same_key(self):
+		# In MOPLog.validate the in-flight row is not yet in DB; pending must
+		# be treated as authoritative for its (item, batch).
+		rows = [_row("M-X", "B1", 5.0)]
+		pending = SimpleNamespace(
+			item_code="M-X",
+			batch_no="B1",
+			qty_after_transaction_batch_based=4.5,
+			pcs_after_transaction_batch_based=0,
+			is_cancelled=0,
+		)
+		out = self._run(rows, pending=pending)
+		self.assertAlmostEqual(out["net_wt"], 4.500, places=3)
+
+	def test_cancelled_pending_row_does_not_override(self):
+		# When a row is being cancelled (is_cancelled=1 in pending), it should
+		# drop out of the balance, not overwrite the prior latest snapshot.
+		rows = [_row("M-X", "B1", 5.0)]
+		pending = SimpleNamespace(
+			item_code="M-X",
+			batch_no="B1",
+			qty_after_transaction_batch_based=999.0,  # bogus; must be ignored
+			pcs_after_transaction_batch_based=0,
+			is_cancelled=1,
+		)
+		out = self._run(rows, pending=pending)
+		self.assertAlmostEqual(out["net_wt"], 5.000, places=3)
+
+	def test_loss_row_reduces_gross_wt_exactly_once(self):
+		# Simulates the post-loss state on MOP-EO481: latest active balance per
+		# (item, batch) is the loss-row qty_after_batch. Total = sum of those
+		# = 4.658 g. Verifies the post-loss MOP gross_wt matches the expected
+		# real balance after the j59i8rf5m8-1 loss attribution.
+		rows = [
+			_row("M-G-18KT-75.4-P", "GE2D081-MGL18754P0-176", 2.074),
+			_row("M-G-18KT-75.4-P", "GE2D081-MGL18754P0-28", 0.199),
+			_row("F-CHA", "GE2D075-FGL754P0182FCC90MM0-02", 2.018),
+			_row("F-CO", "GE2D075-FGL754P0184KKCJ00MM0-01", 0.316),
+			_row("D-NT-RO-6B-+4-4.5", "GE2E094-DNTROX6D00D05-J70O9", 0.08, pcs_batch=1),
+			_row(
+				"D-NT-RO-6B-+4.5-5", "GE2E094-DNTROX6D05E00-261XA", 0.173, pcs_batch=1
+			),
+		]
+		out = self._run(rows)
+		# 2.074 + 0.199 + 2.018 + 0.316 + 0.253*0.2 = 4.6576 -> rounds to 4.658
+		self.assertAlmostEqual(out["gross_wt"], 4.658, places=3)
+		self.assertAlmostEqual(out["net_wt"], 2.273, places=3)
+		self.assertAlmostEqual(out["finding_wt"], 2.334, places=3)
+		self.assertAlmostEqual(out["diamond_wt_in_gram"], 0.051, places=3)
+
+	def test_no_active_rows_yields_zero_buckets(self):
+		out = self._run([])
+		self.assertEqual(out["net_wt"], 0.0)
+		self.assertEqual(out["finding_wt"], 0.0)
+		self.assertEqual(out["diamond_wt"], 0.0)
+		self.assertEqual(out["diamond_wt_in_gram"], 0.0)
+		self.assertEqual(out["gemstone_wt"], 0.0)
+		self.assertEqual(out["gross_wt"], 0.0)
+
+	def test_unknown_prefix_skipped(self):
+		# Item code with prefix outside FIELD_MAP must not crash and must not
+		# contribute to any bucket.
+		rows = [
+			_row("X-FOO", "B?", 99.0),
+			_row("M-X", "BM", 1.0),
+		]
+		out = self._run(rows)
+		self.assertAlmostEqual(out["net_wt"], 1.000, places=3)
+		self.assertAlmostEqual(out["gross_wt"], 1.000, places=3)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_stock_reservation_entry_mwo.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_stock_reservation_entry_mwo.py
@@ -17,7 +17,9 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.get_available_qty_to_reserve",
 		return_value=50.0,
 	)
-	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.get_values",
 		return_value=None,
@@ -106,7 +108,9 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.get_available_qty_to_reserve",
 		return_value=0.0,
 	)
-	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.get_values",
 		return_value=None,
@@ -171,7 +175,9 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.get_available_qty_to_reserve",
 		return_value=0.0,
 	)
-	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.get_values",
 		return_value=None,
@@ -244,7 +250,9 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.get_available_qty_to_reserve",
 		return_value=0.0,
 	)
-	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.get_values",
 		return_value=None,
@@ -333,7 +341,9 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.get_available_qty_to_reserve",
 		return_value=0.0,
 	)
-	@patch("jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value")
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.get_cached_value"
+	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.get_values",
 		return_value=None,
@@ -357,6 +367,18 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 			stock_reservation_entry_for_mwo,
 		)
 
+		# get_cached_value is invoked early to unpack 3 values from
+		# Parent Manufacturing Order; supply a 3-tuple so the function
+		# reaches the per-row loop where the gate fires.
+		def _cached(doctype, name, fields):
+			if doctype == "Parent Manufacturing Order":
+				return ("SO-1", "SOI-1", "MNF-1")
+			if doctype == "Item":
+				return (0, 0)
+			return ("X", "Y", "Z")
+
+		mock_cached.side_effect = _cached
+
 		doc = MagicMock()
 		doc.stock_entry_type = "Repack"
 		doc.manufacturing_order = "PMO-1"
@@ -378,5 +400,6 @@ class TestStockReservationEntryForMWO(FrappeTestCase):
 
 		stock_reservation_entry_for_mwo(doc)
 
-		# Must NOT create SRE — Repack not in config, no employee_ir
+		# With get_available_qty_to_reserve=0 and is_eir_injection=False,
+		# qty_to_be_reserved is 0 → the loop body continues past new_doc.
 		mock_new_doc.assert_not_called()

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_stock_reservation_entry_override.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_stock_reservation_entry_override.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+from unittest.mock import patch
+
+from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+	StockReservationEntry,
+)
+from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.customization.stock_reservation_entry.stock_reservation_entry import (
+	CustomStockReservationEntry,
+)
+
+
+def _bare_sre(**fields):
+	# Bypass Document.__init__ — we only exercise the override branch logic;
+	# no DB, no meta load, no controller hooks.
+	sre = CustomStockReservationEntry.__new__(CustomStockReservationEntry)
+	for k, v in fields.items():
+		setattr(sre, k, v)
+	sre.get = lambda key, default=None: getattr(sre, key, default)
+	return sre
+
+
+class TestCustomStockReservationEntry(FrappeTestCase):
+	def test_skips_auto_reserve_for_mwo_mop_flow(self):
+		# Override only fires for Serial-and-Batch reservations — auto-pick is
+		# a no-op for Qty-based anyway, so the gate matches production code.
+		sre = _bare_sre(
+			manufacturing_work_order="MWO-1",
+			manufacturing_operation="MOP-1",
+			reservation_based_on="Serial and Batch",
+			sb_entries=[{"batch_no": "B-PICKED", "qty": 2.0, "warehouse": "WH-Dept"}],
+		)
+
+		with patch.object(
+			StockReservationEntry, "auto_reserve_serial_and_batch"
+		) as parent_mock:
+			sre.auto_reserve_serial_and_batch("Voucher")
+
+		parent_mock.assert_not_called()
+		self.assertEqual(len(sre.sb_entries), 1)
+		self.assertEqual(sre.sb_entries[0]["batch_no"], "B-PICKED")
+
+	def test_delegates_to_super_when_only_mwo_set(self):
+		sre = _bare_sre(manufacturing_work_order="MWO-1", manufacturing_operation=None)
+
+		with patch.object(
+			StockReservationEntry, "auto_reserve_serial_and_batch"
+		) as parent_mock:
+			sre.auto_reserve_serial_and_batch("Voucher")
+
+		parent_mock.assert_called_once_with("Voucher")
+
+	def test_delegates_to_super_when_only_mop_set(self):
+		sre = _bare_sre(manufacturing_work_order=None, manufacturing_operation="MOP-1")
+
+		with patch.object(
+			StockReservationEntry, "auto_reserve_serial_and_batch"
+		) as parent_mock:
+			sre.auto_reserve_serial_and_batch("Voucher")
+
+		parent_mock.assert_called_once_with("Voucher")
+
+	def test_delegates_to_super_for_normal_flow(self):
+		sre = _bare_sre(manufacturing_work_order=None, manufacturing_operation=None)
+
+		with patch.object(
+			StockReservationEntry, "auto_reserve_serial_and_batch"
+		) as parent_mock:
+			sre.auto_reserve_serial_and_batch(None)
+
+		parent_mock.assert_called_once_with(None)


### PR DESCRIPTION
…on entry overrides

- Implemented tests for `recalculate_manufacturing_operation_weights` in `test_mop_weight_recalc.py` to cover various scenarios including multi-batch sums, D/G carat-to-gram conversion, and handling of cancelled rows.
- Created `test_mop_weight_recompute.py` to validate the aggregation logic for manufacturing operation weights, ensuring correct handling of pending rows and cancellation scenarios.
- Enhanced `test_stock_reservation_entry_mwo.py` with improved patching for `get_cached_value` to ensure accurate testing of stock reservation logic.
- Introduced `test_stock_reservation_entry_override.py` to validate custom behavior in `CustomStockReservationEntry`, ensuring proper delegation and skipping of auto-reserve logic for MWO/MOP flows.