### PR TITLE
fix: employee IR precision and enhance make receive entry functionality

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/customization/stock_entry/stock_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/customization/stock_entry/stock_entry.py
@@ -37,7 +37,8 @@ def before_validate(self, method):
 
 
 def on_submit(self, method):
-	validate_inventory_dimention(self)
+	pass
+	# validate_inventory_dimention(self)
 
 
 class CustomStockEntry(StockEntry):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/precision.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/precision.py
@@ -1,0 +1,43 @@
+from frappe.utils import flt
+
+# Weight fields on Employee IR Operation that must persist at precision 3.
+# PCS / Int / UOM / text fields are intentionally excluded.
+EIR_OPERATION_WEIGHT_FIELDS = (
+	"gross_wt",
+	"received_gross_wt",
+	"gold_loss",
+	"net_wt",
+	"finding_wt",
+	"other_wt",
+	"diamond_wt",
+	"gemstone_wt",
+	"rpt_wt_issue",
+	"rpt_wt_receive",
+	"rpt_wt_loss",
+	"mould_wtin_gram",
+)
+
+LOSS_DETAIL_WEIGHT_FIELDS = (
+	"net_weight",
+	"proportionally_loss",
+	"received_gross_weight",
+	"main_slip_consumption",
+)
+
+
+def round_employee_ir_weights_to_precision(doc, precision=3):
+	for child in getattr(doc, "employee_ir_operations", []) or []:
+		for f in EIR_OPERATION_WEIGHT_FIELDS:
+			val = getattr(child, f, None)
+			if val is not None:
+				child.set(f, flt(val, precision))
+
+	if getattr(doc, "mop_loss_details_total", None) is not None:
+		doc.mop_loss_details_total = flt(doc.mop_loss_details_total, precision)
+
+	for tbl_name in ("employee_loss_details", "manually_book_loss_details"):
+		for row in getattr(doc, tbl_name, []) or []:
+			for f in LOSS_DETAIL_WEIGHT_FIELDS:
+				val = getattr(row, f, None)
+				if val is not None:
+					row.set(f, flt(val, precision))

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/validation_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/validation_utils.py
@@ -137,37 +137,38 @@ def update_mop_balance(mop_name):
 def validate_manually_book_loss_details(self):
 	if self.docstatus != 0:
 		return
-	# Stricter floor: per-row balance must cover the manual loss qty. Pre-submit
-	# the latest balance already reflects any prior submitted losses (loss MOP
-	# Log rows post a real negative qty_change), so no log_category filter is
-	# needed here.
+	# Per-key (mop, mwo, item, batch) combined-loss cap: the sum across both
+	# loss tables for a given key must not exceed the latest MOP Log balance
+	# for that key. Pre-submit, the latest balance already reflects any prior
+	# submitted losses (loss MOP Log rows post a real negative qty_change),
+	# so no log_category filter is needed here. Comparison is in the item's
+	# stock UOM (carats for D/G, grams for M/F/O) — both sides match.
 	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 		get_available_qty_pcs_for_mop_item,
 	)
 
+	combined_loss_by_key = {}
+	for src_label, table in (
+		("employee", self.employee_loss_details or []),
+		("manual", self.manually_book_loss_details or []),
+	):
+		for row in table:
+			if not row.manufacturing_operation:
+				continue
+			key = (
+				row.manufacturing_operation,
+				row.manufacturing_work_order,
+				row.item_code,
+				row.batch_no,
+			)
+			bucket = combined_loss_by_key.setdefault(
+				key, {"employee": 0.0, "manual": 0.0}
+			)
+			bucket[src_label] += flt(row.proportionally_loss, 3)
+
 	for row in self.manually_book_loss_details:
 		if not row.manufacturing_operation:
 			continue
-		balance_qty = (
-			frappe.db.get_value(
-				"MOP Log",
-				{
-					"manufacturing_operation": row.manufacturing_operation,
-					"item_code": row.item_code,
-					"batch_no": row.batch_no,
-					"is_cancelled": 0,
-				},
-				"qty_after_transaction_batch_based",
-				order_by="creation desc",
-			)
-			or 0
-		)
-		if row.proportionally_loss > balance_qty:
-			frappe.throw(
-				_(
-					"Row #{0}: <b>{1}</b> Proportionally Loss {2} cannot be greater than Balance Qty {3}"
-				).format(row.idx, row.item_code, row.proportionally_loss, balance_qty)
-			)
 
 		# D/G PCS reconciliation: manual loss PCS must not drive the MOP
 		# diamond_pcs/gemstone_pcs negative. Only D/G items carry meaningful
@@ -202,9 +203,9 @@ def validate_manually_book_loss_details(self):
 						)
 					)
 
-	# Additional cap: total manual loss for a MWO cannot exceed the true
+	# Additional cap: total combined loss (employee + manual, normalised to
+	# grams via get_loss_qty_in_grams) for a MWO cannot exceed the true
 	# available baseline (gross_wt - received_gross_wt) for that MWO.
-	# Carat manual loss converted to grams for comparison.
 	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
 
 	baseline_by_mwo = {}
@@ -217,24 +218,24 @@ def validate_manually_book_loss_details(self):
 		baseline_by_mwo.setdefault(op.manufacturing_work_order, 0.0)
 		baseline_by_mwo[op.manufacturing_work_order] += baseline
 
-	manual_by_mwo = {}
-	for row in self.manually_book_loss_details:
-		qty = flt(row.proportionally_loss)
-		stock_uom = frappe.get_cached_value("Item", row.item_code, "stock_uom")
-		if stock_uom == "Carat":
-			qty = qty * 0.2
-		manual_by_mwo.setdefault(row.manufacturing_work_order, 0.0)
-		manual_by_mwo[row.manufacturing_work_order] += qty
+	loss_by_mwo = {}
+	for row in (self.manually_book_loss_details or []) + (
+		self.employee_loss_details or []
+	):
+		qty = get_loss_qty_in_grams(row.item_code, row.proportionally_loss)
+		loss_by_mwo.setdefault(row.manufacturing_work_order, 0.0)
+		loss_by_mwo[row.manufacturing_work_order] += qty
 
-	for mwo, manual_total in manual_by_mwo.items():
+	for mwo, total in loss_by_mwo.items():
 		available = baseline_by_mwo.get(mwo, 0.0)
-		if manual_total > available:
+		if flt(total, 3) > flt(available, 3):
 			frappe.throw(
 				_(
-					"Total Manually Booked Loss for Manufacturing Work Order {0} "
-					"({1} g) cannot exceed available loss baseline ({2} g = "
-					"Gross Wt - Received Gross Wt)."
-				).format(mwo, flt(manual_total, 3), flt(available, 3))
+					"Total Loss for Manufacturing Work Order {0} "
+					"({1} g, employee + manual normalised to grams) cannot "
+					"exceed available loss baseline ({2} g = Gross Wt - "
+					"Received Gross Wt)."
+				).format(mwo, flt(total, 3), flt(available, 3))
 			)
 
 
@@ -251,6 +252,68 @@ def get_loss_details(row):
 		)
 
 	return loss_details
+
+
+def validate_loss_tables_required(self):
+	"""On-submit gate for Employee IR Receive loss tables.
+
+	Two contracts, both gated on baseline > 0 (rounded to 3):
+
+	  1. At least one of ``employee_loss_details`` /
+	     ``manually_book_loss_details`` must be populated.
+	  2. The sum across both tables, normalised to grams via
+	     ``get_loss_qty_in_grams`` (D/G items × 0.2), must equal the
+	     baseline within precision-3 tolerance.
+
+	Baseline = ``sum(gross_wt − received_gross_wt)`` over rows where the
+	receive shrunk the weight, rounded to 3. Caller is ``EmployeeIR.on_submit``;
+	at that point ``docstatus`` is still 0, so we don't gate on it — running
+	this validator post-submit would be a logic bug, not a no-op.
+	"""
+	if getattr(self, "type", None) != "Receive":
+		return
+
+	baseline = 0.0
+	for op in self.employee_ir_operations:
+		if op.received_gross_wt and flt(op.gross_wt, 3) > flt(op.received_gross_wt, 3):
+			baseline += flt(op.gross_wt, 3) - flt(op.received_gross_wt, 3)
+	baseline = flt(baseline, 3)
+
+	if baseline <= 0:
+		return
+
+	has_employee = bool(getattr(self, "employee_loss_details", None))
+	has_manual = bool(getattr(self, "manually_book_loss_details", None))
+	if not (has_employee or has_manual):
+		frappe.throw(
+			_(
+				"Loss exists ({0} g) but no Employee Loss Details or Manually "
+				"Book Loss Details found. Please book the manufacturing loss "
+				"before submit."
+			).format(baseline)
+		)
+
+	# Sum-match: every gram of loss must be allocated across the two
+	# tables. ``get_loss_qty_in_grams`` handles carat→gram for D/G items.
+	total = 0.0
+	for row in (self.employee_loss_details or []) + (
+		self.manually_book_loss_details or []
+	):
+		total += get_loss_qty_in_grams(row.item_code, row.proportionally_loss)
+	total = flt(total, 3)
+
+	# Tolerance = 0.0005 — half the precision-3 floor. After ``flt(_, 3)``
+	# on each side, two values that round to the same display equal each
+	# other within this margin; values that differ by ≥ 0.001 don't.
+	if abs(total - baseline) > 0.0005:
+		diff = flt(total - baseline, 3)
+		frappe.throw(
+			_(
+				"Total Loss Details ({0} g, employee + manual normalised to "
+				"grams) must match available loss baseline ({1} g = sum of "
+				"Gross Wt − Received Gross Wt). Difference: {2} g."
+			).format(total, baseline, diff)
+		)
 
 
 def validate_loss_qty(self):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.json
@@ -288,6 +288,7 @@
    "fieldtype": "Float",
    "label": "MOP Loss Details Total",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.py
@@ -34,12 +34,16 @@ from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.main_sli
 from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.mould_utils import (
 	create_mould,
 )
+from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.precision import (
+	round_employee_ir_weights_to_precision,
+)
 from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.subcontracting_utils import (
 	create_so_for_subcontracting,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
 	validate_duplication_and_gr_wt,
 	validate_loss_qty,
+	validate_loss_tables_required,
 	validate_manually_book_loss_details,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
@@ -75,6 +79,7 @@ class EmployeeIR(Document):
 				)
 
 	def on_submit(self):
+		validate_loss_tables_required(self)
 		validate_qc(self)
 		if self.type == "Issue":
 			self.validate_qc("Warn")
@@ -112,6 +117,7 @@ class EmployeeIR(Document):
 		# self.validate_gross_wt()
 		# self.validate_main_slip()
 		# self.update_main_slip()
+		round_employee_ir_weights_to_precision(self)
 		self.validate_process_loss()
 		validate_manually_book_loss_details(self)
 		# valid_reparing_or_next_operation(self)
@@ -379,7 +385,18 @@ class EmployeeIR(Document):
 					self, row, actor_wh, department_wh, stock_entry_name
 				)
 
-				update_new_mop_wtg(new_operation)
+				# update_new_mop_wtg now does both jobs in one pass:
+				# clones the previous MOP's flow_index=0 baseline rows AND
+				# subtracts loss in-place per (item, batch). One MOP Log
+				# row per item/batch on the new operation. Source MOP is
+				# left unchanged.
+				update_new_mop_wtg(
+					new_operation,
+					employee_ir_doc=self,
+					employee_ir_operation_row=row,
+					from_warehouse=actor_wh,
+					to_warehouse=department_wh,
+				)
 			else:
 				for sre in frappe.db.get_all(
 					"Stock Reservation Entry",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir_operation/employee_ir_operation.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir_operation/employee_ir_operation.json
@@ -43,18 +43,21 @@
    "fieldname": "gross_wt",
    "fieldtype": "Float",
    "label": "Gross Wt",
+   "precision": "3",
    "read_only": 1
   },
   {
    "default": "0",
    "fieldname": "received_gross_wt",
    "fieldtype": "Float",
-   "label": "Received Gross Wt"
+   "label": "Received Gross Wt",
+   "precision": "3"
   },
   {
    "fieldname": "gold_loss",
    "fieldtype": "Float",
    "label": "Gold Loss",
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -85,31 +88,36 @@
    "fetch_from": "manufacturing_operation.net_wt",
    "fieldname": "net_wt",
    "fieldtype": "Float",
-   "label": "Net Wt"
+   "label": "Net Wt",
+   "precision": "3"
   },
   {
    "fetch_from": "manufacturing_operation.finding_wt",
    "fieldname": "finding_wt",
    "fieldtype": "Float",
-   "label": "Finding Wt"
+   "label": "Finding Wt",
+   "precision": "3"
   },
   {
    "fetch_from": "manufacturing_operation.other_wt",
    "fieldname": "other_wt",
    "fieldtype": "Float",
-   "label": "Other Wt"
+   "label": "Other Wt",
+   "precision": "3"
   },
   {
    "fetch_from": "manufacturing_operation.diamond_wt",
    "fieldname": "diamond_wt",
    "fieldtype": "Float",
-   "label": "Diamond Wt"
+   "label": "Diamond Wt",
+   "precision": "3"
   },
   {
    "fetch_from": "manufacturing_operation.gemstone_wt",
    "fieldname": "gemstone_wt",
    "fieldtype": "Float",
-   "label": "Gemstone Wt"
+   "label": "Gemstone Wt",
+   "precision": "3"
   },
   {
    "fetch_from": "manufacturing_operation.gemstone_pcs",
@@ -130,17 +138,20 @@
   {
    "fieldname": "rpt_wt_issue",
    "fieldtype": "Float",
-   "label": "RPT WT Issue"
+   "label": "RPT WT Issue",
+   "precision": "3"
   },
   {
    "fieldname": "rpt_wt_receive",
    "fieldtype": "Float",
-   "label": "RPT WT Receive "
+   "label": "RPT WT Receive ",
+   "precision": "3"
   },
   {
    "fieldname": "rpt_wt_loss",
    "fieldtype": "Float",
    "label": "RPT WT loss",
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -151,7 +162,8 @@
   {
    "fieldname": "mould_wtin_gram",
    "fieldtype": "Float",
-   "label": "Mould WT(in Gram)"
+   "label": "Mould WT(in Gram)",
+   "precision": "3"
   },
   {
    "default": "0",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_loss_details/employee_loss_details.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_loss_details/employee_loss_details.json
@@ -71,20 +71,23 @@
    "hidden": 1,
    "in_list_view": 1,
    "label": "Net Weight",
+   "precision": "3",
    "read_only": 1
   },
   {
    "fieldname": "proportionally_loss",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Qty"
+   "label": "Qty",
+   "precision": "3"
   },
   {
    "fieldname": "received_gross_weight",
    "fieldtype": "Float",
    "hidden": 1,
    "in_list_view": 1,
-   "label": "Received Gross Weight"
+   "label": "Received Gross Weight",
+   "precision": "3"
   },
   {
    "fieldname": "column_break_6",
@@ -102,7 +105,8 @@
    "fieldname": "main_slip_consumption",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Main Slip Consumption"
+   "label": "Main Slip Consumption",
+   "precision": "3"
   },
   {
    "fieldname": "batch_no",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manually_book_loss_details/manually_book_loss_details.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manually_book_loss_details/manually_book_loss_details.json
@@ -78,13 +78,15 @@
    "fieldtype": "Float",
    "hidden": 1,
    "in_list_view": 1,
-   "label": "Net Weight"
+   "label": "Net Weight",
+   "precision": "3"
   },
   {
    "fieldname": "proportionally_loss",
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Qty",
+   "precision": "3",
    "reqd": 1
   },
   {
@@ -92,13 +94,15 @@
    "fieldtype": "Float",
    "hidden": 1,
    "in_list_view": 1,
-   "label": "Received Gross Weight"
+   "label": "Received Gross Weight",
+   "precision": "3"
   },
   {
    "fieldname": "main_slip_consumption",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Main Slip Consumption"
+   "label": "Main Slip Consumption",
+   "precision": "3"
   },
   {
    "fieldname": "column_break_6",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.js
@@ -310,11 +310,41 @@ frappe.ui.form.on("Manufacturing Operation", {
 				freeze: true,
 				freeze_message: __("Loading Stock Reservation Entries..."),
 				callback: (r) => {
-					const rows = (r && r.message) || [];
+					// Server now returns {rows, skipped, active_sre_count}.
+					// Fall back to a bare list for backwards compatibility
+					// during rollout in case any caller was patched in
+					// between releases.
+					const msg = (r && r.message) || {};
+					const rows = Array.isArray(msg) ? msg : msg.rows || [];
+					const skipped = Array.isArray(msg) ? [] : msg.skipped || [];
+					const active_sre_count = Array.isArray(msg) ? rows.length : msg.active_sre_count || 0;
+
 					if (!rows.length) {
-						frappe.msgprint(
-							__("No active Stock Reservation Entries found for this Manufacturing Work Order.")
-						);
+						if (active_sre_count === 0) {
+							frappe.msgprint(
+								__(
+									"No active Stock Reservation Entries found for this Manufacturing Work Order."
+								)
+							);
+						} else {
+							const lines = (skipped || []).map((s) =>
+								__("• SRE {0} — Item {1}{2}: SRE remaining {3}, MOP available {4}", [
+									s.sre,
+									s.item_code,
+									s.batch_no ? ` / Batch ${s.batch_no}` : "",
+									s.sre_remaining,
+									s.mop_available_qty,
+								])
+							);
+							frappe.msgprint({
+								title: __("Make Receive Entry"),
+								indicator: "orange",
+								message:
+									__(
+										"Stock Reservation Entries exist, but no receivable MOP balance was found. Please check MOP Log balance for this Manufacturing Operation."
+									) + (lines.length ? "<br><br>" + lines.join("<br>") : ""),
+							});
+						}
 						return;
 					}
 
@@ -345,6 +375,7 @@ frappe.ui.form.on("Manufacturing Operation", {
 						available_to_receive_pcs: e.available_to_receive_pcs || 0,
 						is_pcs_item: e.is_pcs_item ? 1 : 0,
 						mop_log_reference: e.mop_log_reference || "",
+						warning: e.warning || "",
 						qty_to_receive: 0,
 						pcs_to_receive: 0,
 						stock_uom: e.stock_uom,
@@ -490,6 +521,13 @@ frappe.ui.form.on("Manufacturing Operation", {
 										fieldtype: "Link",
 										fieldname: "mop_log_reference",
 										options: "MOP Log",
+										read_only: 1,
+									},
+									{
+										label: __("Warning"),
+										fieldtype: "Small Text",
+										fieldname: "warning",
+										in_list_view: 1,
 										read_only: 1,
 									},
 									{

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.json
@@ -212,13 +212,15 @@
   {
    "fieldname": "qty",
    "fieldtype": "Float",
-   "label": "Qty"
+   "label": "Qty",
+   "precision": "3"
   },
   {
    "fieldname": "gross_wt",
    "fieldtype": "Float",
    "label": "Gross Wt",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -281,34 +283,39 @@
    "fieldname": "platform_wt",
    "fieldtype": "Float",
    "label": "Platform wt",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "depends_on": "eval: doc.operation == \"Mould Filling\";",
    "fieldname": "rpt_wt_issue",
    "fieldtype": "Float",
    "label": "RPT Wt ISSUE",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "depends_on": "eval: doc.operation == \"Mould Filling\";",
    "fieldname": "rpt_wt_receive",
    "fieldtype": "Float",
    "label": "RPT Wt RECEIVE",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "depends_on": "eval: doc.operation == \"Mould Filling\";",
    "fieldname": "rpt_wt_loss",
    "fieldtype": "Float",
    "label": "RPT Wt LOSS",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "fieldname": "estimated_rpt_wt",
    "fieldtype": "Float",
    "label": "Estimated RPT WT",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "fetch_from": "manufacturing_work_order.metal_colour",
@@ -379,6 +386,7 @@
    "fieldtype": "Float",
    "label": "Diamond Wt (cts)",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -386,6 +394,7 @@
    "fieldtype": "Float",
    "label": "Gemstone Wt (cts)",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -393,6 +402,7 @@
    "fieldtype": "Float",
    "label": "Other Wt",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -400,6 +410,7 @@
    "fieldtype": "Float",
    "label": "Net wt",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -407,6 +418,7 @@
    "fieldtype": "Float",
    "label": "Finding WT",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -423,19 +435,22 @@
    "fieldname": "received_gross_wt",
    "fieldtype": "Float",
    "label": "Received Gross Wt",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "fieldname": "received_net_wt",
    "fieldtype": "Float",
    "label": "Received Net Wt",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "fieldname": "loss_wt",
    "fieldtype": "Float",
    "label": "Loss / Increase Wt",
-   "no_copy": 1
+   "no_copy": 1,
+   "precision": "3"
   },
   {
    "fieldname": "diamond_pcs",
@@ -456,6 +471,7 @@
    "fieldtype": "Float",
    "label": "Diamond Wt (in gram)",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -522,6 +538,7 @@
    "fieldtype": "Float",
    "label": "Gemstone Wt (in gram)",
    "no_copy": 1,
+   "precision": "3",
    "read_only": 1
   },
   {
@@ -582,6 +599,7 @@
    "fieldname": "prev_gross_wt",
    "fieldtype": "Float",
    "label": "Previous gross wt",
+   "precision": "3",
    "read_only": 1
   },
   {

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -22,6 +22,7 @@ from frappe.utils import (
 from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 	get_available_qty_pcs_for_mop_item,
 	get_current_mop_balance_rows,
+	get_employee_ir_loss_map,
 	get_last_mop_index,
 )
 from jewellery_erpnext.utils import set_values_in_bulk, update_existing
@@ -3636,11 +3637,21 @@ def get_make_receive_entry_rows(manufacturing_operation):
 	"""Return rows for the Make Receive Entry dialog, sourced from active
 	Stock Reservation Entry rows linked to the MOP's Manufacturing Work Order.
 
-	Each returned row carries the SRE name (and per-batch sb_entries name when
-	the SRE is batch-based). Available qty is the SRE's own remaining
-	(reserved_qty - delivered_qty); we do NOT subtract previous Material Receive
-	Stock Entries because partial receives are handled by cancel-and-recreate
-	of the SRE — the active SRE already reflects the remaining stock.
+	Returns a dict ``{"rows": [...], "skipped": [...], "active_sre_count": N}``
+	so the JS dialog can distinguish:
+
+	  * No active SRE at all (active_sre_count == 0).
+	  * Active SRE but every row consumed by loss / no MOP balance left
+	    (rows == [], skipped non-empty with reason="mop_zero_balance").
+	  * Actionable rows present.
+
+	Available qty is the SRE's own remaining (reserved_qty - delivered_qty);
+	we do NOT subtract previous Material Receive Stock Entries because partial
+	receives are handled by cancel-and-recreate of the SRE — the active SRE
+	already reflects the remaining stock. When MOP Log has no row for a given
+	(item, batch), we still surface the SRE row with a ``warning`` flag and
+	available_to_receive_qty = sre_remaining; ``create_mr_wo_stock_entry``
+	already silences the MOP cap when ``mop_data_present`` is False.
 	"""
 	mo = frappe.get_doc("Manufacturing Operation", manufacturing_operation)
 
@@ -3658,11 +3669,18 @@ def get_make_receive_entry_rows(manufacturing_operation):
 	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
 	tolerance = _float_tolerance(precision)
 
+	# MWO-scoped fetch: every active SRE under this Manufacturing Work
+	# Order, regardless of which MOP it was created against. ERPNext's SRE
+	# `status` flips to "Cancelled" / "Reservation Not Available" / etc.
+	# in normal operation; only docstatus=1 AND status not in the
+	# terminal-cancelled bucket are actionable. We also reject "Delivered"
+	# because reserved_qty - delivered_qty == 0 there (no work to do).
 	sres = frappe.db.get_all(
 		"Stock Reservation Entry",
 		filters={
 			"manufacturing_work_order": mo.manufacturing_work_order,
 			"docstatus": 1,
+			"status": ["not in", ("Cancelled", "Delivered")],
 		},
 		fields=[
 			"name",
@@ -3677,17 +3695,11 @@ def get_make_receive_entry_rows(manufacturing_operation):
 			"has_serial_no",
 			"has_batch_no",
 			"reservation_based_on",
+			"status",
 			"manufacturing_work_order",
 			"manufacturing_operation",
 		],
 	)
-
-	# Pre-compute MOP Log balance map once for this MOP — the helper picks
-	# the matching (item_code, batch_no) row out of this map per popup row.
-	mop_balance_rows = get_current_mop_balance_rows(mo.name)
-	mop_log_balance_map = {
-		(row.get("item_code"), row.get("batch_no")): row for row in mop_balance_rows
-	}
 
 	# Batch the already-received aggregations: ONE SQL per metric covering
 	# every (item_code, s_warehouse) referenced by the SREs, instead of
@@ -3715,6 +3727,7 @@ def get_make_receive_entry_rows(manufacturing_operation):
 			SELECT
 			    sed.item_code,
 			    sed.s_warehouse,
+			    sed.batch_no,
 			    COALESCE(SUM(sed.qty), 0) AS sum_qty,
 			    COALESCE(SUM(CAST(NULLIF(sed.pcs, '') AS UNSIGNED)), 0) AS sum_pcs
 			FROM `tabStock Entry Detail` sed
@@ -3724,21 +3737,27 @@ def get_make_receive_entry_rows(manufacturing_operation):
 			  AND se.manufacturing_work_order = %s
 			  AND sed.item_code IN ({item_ph})
 			  AND sed.s_warehouse IN ({wh_ph})
-			GROUP BY sed.item_code, sed.s_warehouse
+			GROUP BY sed.item_code, sed.s_warehouse, sed.batch_no
 			""",
 			params,
 		)
-		# agg_rows tuples: (item_code, s_warehouse, sum_qty, sum_pcs).
-		# Defensive against mocked test returns of shape [(0,)] — only
-		# index when the row has at least 4 columns; otherwise there is
-		# no aggregate available and we fall back to the .get(key, 0)
-		# defaults below.
+		# agg_rows tuples: (item_code, s_warehouse, batch_no, sum_qty, sum_pcs).
+		# Map keys: (item_code, s_warehouse, batch_no) — batch_no may be None
+		# for non-batch items. Defensive against mocked test returns of shape
+		# [(0,)]; older 4-col tuples are also accepted (no batch_no in mock)
+		# and bucketed under batch_no=None.
 		for r in agg_rows:
-			if not isinstance(r, (list, tuple)) or len(r) < 4:
+			if not isinstance(r, (list, tuple)):
 				continue
-			key = (r[0], r[1])
-			already_received_qty_map[key] = flt(r[2] or 0)
-			already_received_pcs_map[key] = cint(r[3] or 0)
+			if len(r) >= 5:
+				key = (r[0], r[1], r[2])
+				already_received_qty_map[key] = flt(r[3] or 0)
+				already_received_pcs_map[key] = cint(r[4] or 0)
+			elif len(r) >= 4:
+				# Legacy mock shape — no batch_no column.
+				key = (r[0], r[1], None)
+				already_received_qty_map[key] = flt(r[2] or 0)
+				already_received_pcs_map[key] = cint(r[3] or 0)
 
 	# Batch fetch all sb_entries rows for all batch-based SREs — one query
 	# instead of one per SRE.
@@ -3755,12 +3774,49 @@ def get_make_receive_entry_rows(manufacturing_operation):
 		for sb in all_sb:
 			sb_entries_by_sre.setdefault(sb["parent"], []).append(sb)
 
+	# MWO-level: each SRE has its own ``manufacturing_operation``. The MOP
+	# Log balance MUST be looked up against that SRE's MOP, not the popup's
+	# opened MOP. Mixing them produces nonsense availability for sibling-
+	# MOP SREs. Build a per-MOP key set, fetch each operation's balances
+	# narrowed to its own keys, then index into a 3-tuple map keyed by
+	# (manufacturing_operation, item_code, batch_no).
+	keys_by_mop: dict[str, set] = {}
+	for s in sres:
+		# Fall back to the opened MOP only when an SRE somehow lacks its
+		# own; this preserves behaviour for tests that mock SREs without
+		# the custom field populated.
+		op = s.manufacturing_operation or mo.name
+		bucket = keys_by_mop.setdefault(op, set())
+		is_batch = cint(s.has_batch_no) and s.reservation_based_on != "Qty"
+		if is_batch:
+			for sb in sb_entries_by_sre.get(s.name, []):
+				bucket.add((s.item_code, sb["batch_no"]))
+		else:
+			bucket.add((s.item_code, None))
+
+	mop_log_balance_map: dict[tuple, dict] = {}
+	for op_name, op_keys in keys_by_mop.items():
+		if not op_keys:
+			continue
+		balance_rows = get_current_mop_balance_rows(op_name, keys=list(op_keys))
+		for row in balance_rows:
+			mop_log_balance_map[
+				(op_name, row.get("item_code"), row.get("batch_no"))
+			] = row
+
 	rows = []
+	skipped = []
 	for sre in sres:
 		batch_based = cint(sre.has_batch_no) and sre.reservation_based_on != "Qty"
-		key = (sre.item_code, sre.warehouse)
-		already_received_for_item = already_received_qty_map.get(key, 0)
-		already_received_pcs_for_item = already_received_pcs_map.get(key, 0)
+		# Authoritative MOP for this SRE — its own manufacturing_operation,
+		# falling back to the opened MOP only when the custom field is
+		# missing (test fixtures, legacy data).
+		sre_mop = sre.manufacturing_operation or mo.name
+		# Slice the 3-tuple-keyed global map down to the (item, batch) pairs
+		# for this SRE's MOP, matching the helper's 2-tuple key contract.
+		sre_mop_balance_map = {
+			(k[1], k[2]): v for k, v in mop_log_balance_map.items() if k[0] == sre_mop
+		}
 
 		if batch_based:
 			sb_entries = sb_entries_by_sre.get(sre.name, [])
@@ -3770,8 +3826,13 @@ def get_make_receive_entry_rows(manufacturing_operation):
 				if sre_remaining <= tolerance:
 					# Nothing left in the SRE for this batch — no row to show.
 					continue
+				batch_key = (sre.item_code, sre.warehouse, sb.batch_no)
+				already_received_for_item = already_received_qty_map.get(batch_key, 0)
+				already_received_pcs_for_item = already_received_pcs_map.get(
+					batch_key, 0
+				)
 				ctx = get_available_qty_pcs_for_mop_item(
-					manufacturing_operation=mo.name,
+					manufacturing_operation=sre_mop,
 					item_code=sre.item_code,
 					batch_no=sb.batch_no,
 					warehouse=sre.warehouse,
@@ -3781,15 +3842,33 @@ def get_make_receive_entry_rows(manufacturing_operation):
 					sre_remaining_qty=sre_remaining,
 					already_received_qty=already_received_for_item,
 					already_received_pcs=already_received_pcs_for_item,
-					mop_log_balance_map=mop_log_balance_map,
+					mop_log_balance_map=sre_mop_balance_map,
 				)
-				# Available to receive = min(SRE remaining, MOP balance).
-				# The helper has already done that math; surface the value
-				# under the spec-mandated key. Exclude rows where the
-				# operator has nothing to receive (either because SRE is
-				# empty or — new rule — because MOP balance was lost to
-				# Employee IR / loss attribution since the SRE was cut).
-				if flt(ctx["available_qty"]) <= tolerance:
+				warning = None
+				available_to_receive_qty = flt(ctx["available_qty"])
+				if not ctx["mop_data_present"]:
+					# No MOP Log row for (item, batch). SRE is the only signal
+					# we have; surface the row so the operator can act.
+					# create_mr_wo_stock_entry's MOP-balance cap silently
+					# falls back to SRE-only when mop_data_present is False.
+					warning = "MOP balance unknown — falling back to SRE remaining"
+					available_to_receive_qty = sre_remaining
+				elif available_to_receive_qty <= tolerance:
+					# MOP Log row exists but balance is zero (loss/consumption
+					# since the SRE was created). User cannot receive against
+					# this row — surface as a diagnostic so the dialog can
+					# explain why it is unactionable.
+					skipped.append(
+						{
+							"sre": sre.name,
+							"sb": sb.name,
+							"item_code": sre.item_code,
+							"batch_no": sb.batch_no,
+							"sre_remaining": sre_remaining,
+							"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
+							"reason": "mop_zero_balance",
+						}
+					)
 					continue
 				rows.append(
 					{
@@ -3806,7 +3885,7 @@ def get_make_receive_entry_rows(manufacturing_operation):
 						"reserved_qty": sre_remaining,
 						"delivered_qty": flt(sb.delivered_qty),
 						"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
-						"available_to_receive_qty": flt(ctx["available_qty"]),
+						"available_to_receive_qty": available_to_receive_qty,
 						"reserved_pcs": cint(ctx["reserved_pcs"] or 0),
 						"mop_available_pcs": cint(ctx["mop_log_balance_pcs"]),
 						"available_to_receive_pcs": cint(ctx["available_pcs"]),
@@ -3814,6 +3893,8 @@ def get_make_receive_entry_rows(manufacturing_operation):
 						"already_received_pcs": ctx["already_received_pcs"],
 						"is_pcs_item": ctx["is_pcs_item"],
 						"mop_log_reference": ctx["mop_log_reference"],
+						"mop_data_present": ctx["mop_data_present"],
+						"warning": warning,
 						"voucher_type": sre.voucher_type,
 						"voucher_no": sre.voucher_no,
 						"voucher_detail_no": sre.voucher_detail_no,
@@ -3828,8 +3909,11 @@ def get_make_receive_entry_rows(manufacturing_operation):
 			sre_remaining = flt(sre.reserved_qty) - flt(sre.delivered_qty)
 			if sre_remaining <= tolerance:
 				continue
+			qty_key = (sre.item_code, sre.warehouse, None)
+			already_received_for_item = already_received_qty_map.get(qty_key, 0)
+			already_received_pcs_for_item = already_received_pcs_map.get(qty_key, 0)
 			ctx = get_available_qty_pcs_for_mop_item(
-				manufacturing_operation=mo.name,
+				manufacturing_operation=sre_mop,
 				item_code=sre.item_code,
 				batch_no=None,
 				warehouse=sre.warehouse,
@@ -3839,9 +3923,25 @@ def get_make_receive_entry_rows(manufacturing_operation):
 				sre_remaining_qty=sre_remaining,
 				already_received_qty=already_received_for_item,
 				already_received_pcs=already_received_pcs_for_item,
-				mop_log_balance_map=mop_log_balance_map,
+				mop_log_balance_map=sre_mop_balance_map,
 			)
-			if flt(ctx["available_qty"]) <= tolerance:
+			warning = None
+			available_to_receive_qty = flt(ctx["available_qty"])
+			if not ctx["mop_data_present"]:
+				warning = "MOP balance unknown — falling back to SRE remaining"
+				available_to_receive_qty = sre_remaining
+			elif available_to_receive_qty <= tolerance:
+				skipped.append(
+					{
+						"sre": sre.name,
+						"sb": None,
+						"item_code": sre.item_code,
+						"batch_no": None,
+						"sre_remaining": sre_remaining,
+						"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
+						"reason": "mop_zero_balance",
+					}
+				)
 				continue
 			rows.append(
 				{
@@ -3854,7 +3954,7 @@ def get_make_receive_entry_rows(manufacturing_operation):
 					"reserved_qty": sre_remaining,
 					"delivered_qty": flt(sre.delivered_qty),
 					"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
-					"available_to_receive_qty": flt(ctx["available_qty"]),
+					"available_to_receive_qty": available_to_receive_qty,
 					"reserved_pcs": cint(ctx["reserved_pcs"] or 0),
 					"mop_available_pcs": cint(ctx["mop_log_balance_pcs"]),
 					"available_to_receive_pcs": cint(ctx["available_pcs"]),
@@ -3862,6 +3962,8 @@ def get_make_receive_entry_rows(manufacturing_operation):
 					"already_received_pcs": ctx["already_received_pcs"],
 					"is_pcs_item": ctx["is_pcs_item"],
 					"mop_log_reference": ctx["mop_log_reference"],
+					"mop_data_present": ctx["mop_data_present"],
+					"warning": warning,
 					"voucher_type": sre.voucher_type,
 					"voucher_no": sre.voucher_no,
 					"voucher_detail_no": sre.voucher_detail_no,
@@ -3873,7 +3975,11 @@ def get_make_receive_entry_rows(manufacturing_operation):
 				}
 			)
 
-	return rows
+	return {
+		"rows": rows,
+		"skipped": skipped,
+		"active_sre_count": len(sres),
+	}
 
 
 def _float_tolerance(precision=None):
@@ -4086,6 +4192,7 @@ def create_mr_wo_stock_entry(se_data, request_id=None):
 				"has_batch_no",
 				"reservation_based_on",
 				"manufacturing_work_order",
+				"manufacturing_operation",
 			],
 			as_dict=True,
 		)
@@ -4159,9 +4266,12 @@ def create_mr_wo_stock_entry(se_data, request_id=None):
 		# Reconciled context: MOP Log balance + min(SRE remaining, MOP balance).
 		# Computed for ALL rows (not just D/G) so qty validation enforces both
 		# the SRE cap and the MOP-balance cap. The helper's `available_qty`
-		# already encodes min(SRE, MOP).
+		# already encodes min(SRE, MOP). MWO-level scope: use the SRE's own
+		# manufacturing_operation, not the popup's opened MOP — otherwise
+		# sibling-MOP SREs cap against the wrong balance.
+		sre_mop = sre.manufacturing_operation or mo.name
 		ctx = get_available_qty_pcs_for_mop_item(
-			manufacturing_operation=mo.name,
+			manufacturing_operation=sre_mop,
 			item_code=sre.item_code,
 			batch_no=batch_no,
 			warehouse=sre.warehouse,
@@ -4403,39 +4513,174 @@ def create_mr_wo_stock_entry(se_data, request_id=None):
 	}
 
 
-def update_new_mop_wtg(self):
-	if self.previous_mop and (not self.gross_wt):
-		current_doc_index = get_last_mop_index(self.name)
-		if current_doc_index is None:
-			mop_logs = get_current_mop_balance_rows(self.previous_mop)
-			for log in mop_logs:
-				mop_log = frappe.new_doc("MOP Log")
-				mop_log.item_code = log.item_code
-				mop_log.pcs_after_transaction = log.pcs_after_transaction
-				mop_log.pcs_after_transaction_item_based = (
-					log.pcs_after_transaction_item_based
+def update_new_mop_wtg(
+	self,
+	employee_ir_doc=None,
+	employee_ir_operation_row=None,
+	from_warehouse=None,
+	to_warehouse=None,
+):
+	"""Initialise the new Manufacturing Operation's ``flow_index = 0``
+	baseline rows. When Employee IR Receive context is supplied, the same
+	clone loop subtracts the loss for each ``(item, batch)`` directly from
+	the cloned baseline — **one** MOP Log row per item/batch, already
+	reduced by loss. No separate post-pass loss writer.
+
+	Behavioural rules:
+	  * D/G qty stays in carats; ``MOPLog.validate`` does the carat→gram
+	    conversion when writing ``diamond_wt_in_gram`` /
+	    ``gemstone_wt_in_gram`` on the Manufacturing Operation. We do not
+	    multiply by 0.2 here.
+	  * D/G PCS reduces by ``loss_pcs``. M/F/O PCS is left as the cloned
+	    baseline (``loss_pcs`` is forced to 0 for non-D/G prefixes).
+	  * Throws when a loss key has no matching baseline row on the
+	    previous MOP — a loss cannot be applied to an item/batch that
+	    isn't in the new operation's starting balance.
+	  * Throws when ``loss_qty`` would drive the cloned batch balance
+	    below zero (within precision-3 tolerance).
+	  * Idempotent on ``get_last_mop_index(self.name) is None`` — runs
+	    once per new operation.
+
+	Caller contract: pass ``employee_ir_doc`` and
+	``employee_ir_operation_row`` to apply loss. Do not call any other
+	"new MOP loss" writer separately.
+	"""
+	if not (self.previous_mop and (not self.gross_wt)):
+		return
+	if get_last_mop_index(self.name) is not None:
+		return
+
+	# Build (item, batch) → loss bucket map filtered to this Receive row.
+	loss_map: dict = {}
+	if employee_ir_doc is not None and employee_ir_operation_row is not None:
+		full_loss_map = get_employee_ir_loss_map(employee_ir_doc) or {}
+		src_mop = employee_ir_operation_row.manufacturing_operation
+		src_mwo = employee_ir_operation_row.manufacturing_work_order
+		for key, bucket in full_loss_map.items():
+			mop, mwo, item_code, batch_no = key
+			if mop == src_mop and mwo == src_mwo:
+				loss_map[(item_code, batch_no)] = bucket
+
+	tolerance = _float_tolerance()
+	processed_loss_keys: set = set()
+
+	mop_logs = get_current_mop_balance_rows(self.previous_mop)
+	for log in mop_logs:
+		key = (log.item_code, log.batch_no)
+		loss_bucket = loss_map.get(key)
+
+		# Loss qty in the item's stock UOM (carats for D/G, grams for
+		# M/F/O). Loss PCS only meaningful for D/G — force-zero elsewhere.
+		loss_qty = flt(loss_bucket.get("loss_qty"), 3) if loss_bucket else 0.0
+		raw_loss_pcs = cint(loss_bucket.get("loss_pcs") or 0) if loss_bucket else 0
+		first_char = (log.item_code or "")[0] if log.item_code else ""
+		loss_pcs = raw_loss_pcs if first_char in ("D", "G") else 0
+
+		baseline_qty_batch = flt(log.qty_after_transaction_batch_based, 3)
+		new_qty_batch = flt(baseline_qty_batch - loss_qty, 3)
+		if new_qty_batch < -tolerance:
+			frappe.throw(
+				_(
+					"Loss for Item {0}, Batch {1}, Manufacturing Operation "
+					"{2}, Manufacturing Work Order {3} ({4}) exceeds the "
+					"available balance ({5}) on the new operation baseline. "
+					"Review the Employee IR loss details before submit."
+				).format(
+					log.item_code,
+					log.batch_no,
+					self.previous_mop,
+					log.manufacturing_work_order,
+					loss_qty,
+					baseline_qty_batch,
 				)
-				mop_log.pcs_after_transaction_batch_based = (
-					log.pcs_after_transaction_batch_based
-				)
-				mop_log.from_warehouse = log.from_warehouse
-				mop_log.to_warehouse = log.to_warehouse
-				mop_log.voucher_type = "Manufacturing Operation"
-				mop_log.voucher_no = log.manufacturing_operation
-				mop_log.row_name = log.row_name
-				mop_log.qty_after_transaction = log.qty_after_transaction
-				mop_log.qty_after_transaction_item_based = (
-					log.qty_after_transaction_item_based
-				)
-				mop_log.qty_after_transaction_batch_based = (
-					log.qty_after_transaction_batch_based
-				)
-				mop_log.manufacturing_operation = self.name
-				mop_log.manufacturing_work_order = log.manufacturing_work_order
-				mop_log.serial_and_batch_bundle = log.serial_and_batch_bundle
-				mop_log.batch_no = log.batch_no
-				mop_log.flow_index = 0
-				mop_log.save()
+			)
+
+		baseline_pcs_batch = cint(log.pcs_after_transaction_batch_based or 0)
+		new_pcs_batch = baseline_pcs_batch - loss_pcs
+		if new_pcs_batch < 0:
+			frappe.throw(
+				_(
+					"Loss PCS for Item {0}, Batch {1} ({2}) exceeds the "
+					"available PCS ({3}) on the new operation baseline."
+				).format(log.item_code, log.batch_no, loss_pcs, baseline_pcs_batch)
+			)
+
+		mop_log = frappe.new_doc("MOP Log")
+		mop_log.item_code = log.item_code
+		mop_log.batch_no = log.batch_no
+
+		# Reduce all three balance tiers by loss_qty. When loss_qty is 0
+		# (no loss matches this row) the baseline is cloned verbatim.
+		mop_log.qty_after_transaction = flt(
+			flt(log.qty_after_transaction) - loss_qty, 3
+		)
+		mop_log.qty_after_transaction_item_based = flt(
+			flt(log.qty_after_transaction_item_based) - loss_qty, 3
+		)
+		mop_log.qty_after_transaction_batch_based = new_qty_batch
+
+		mop_log.pcs_after_transaction = cint(log.pcs_after_transaction) - loss_pcs
+		mop_log.pcs_after_transaction_item_based = (
+			cint(log.pcs_after_transaction_item_based) - loss_pcs
+		)
+		mop_log.pcs_after_transaction_batch_based = new_pcs_batch
+
+		mop_log.from_warehouse = from_warehouse if loss_bucket else log.from_warehouse
+		mop_log.to_warehouse = to_warehouse if loss_bucket else log.to_warehouse
+		mop_log.manufacturing_operation = self.name
+		mop_log.manufacturing_work_order = log.manufacturing_work_order
+		mop_log.serial_and_batch_bundle = log.serial_and_batch_bundle
+		mop_log.is_synced = 0
+		# flow_index = 0: baseline + loss are part of the new MOP's
+		# initial baseline tier, not a downstream movement.
+		mop_log.flow_index = 0
+
+		if loss_bucket:
+			# Tie the row to the EIR voucher so the cancel cascade
+			# (`UPDATE tabMOP Log WHERE voucher_type=… AND voucher_no=…`)
+			# picks it up symmetrically with the other EIR logs.
+			mop_log.voucher_type = "Employee IR"
+			mop_log.voucher_no = employee_ir_doc.name
+			mop_log.row_name = employee_ir_operation_row.name
+			mop_log.qty_change = -loss_qty
+			mop_log.pcs_change = -loss_pcs
+
+			mop_log.loss_weight = flt(loss_bucket.get("loss_weight_grams"), 3)
+			loss_types = loss_bucket.get("loss_types") or []
+			mop_log.loss_type = ", ".join(loss_types) if loss_types else None
+			source_rows_list = loss_bucket.get("source_rows") or []
+			joined = ",".join(source_rows_list)
+			mop_log.loss_source_row = joined[:140] if len(joined) > 140 else joined
+
+			processed_loss_keys.add(key)
+		else:
+			# Plain baseline clone — keep the prior voucher tagging so
+			# downstream readers that care about source provenance can
+			# still find the originating Manufacturing Operation.
+			mop_log.voucher_type = "Manufacturing Operation"
+			mop_log.voucher_no = log.manufacturing_operation
+			mop_log.row_name = log.row_name
+
+		mop_log.save()
+
+	# Loss keys that didn't find a baseline row aren't valid: a loss can
+	# only reduce a balance the new operation actually starts with.
+	unprocessed = set(loss_map.keys()) - processed_loss_keys
+	if unprocessed:
+		details = ", ".join(
+			f"{item}/{batch or 'no-batch'}"
+			for item, batch in sorted(
+				unprocessed, key=lambda k: (k[0] or "", k[1] or "")
+			)
+		)
+		frappe.throw(
+			_(
+				"Employee IR loss is booked against item(s)/batch(es) that "
+				"are not present in the previous Manufacturing Operation's "
+				"baseline: {0}. Loss can only be applied to balances the "
+				"new operation actually inherits."
+			).format(details)
+		)
 
 
 @frappe.whitelist()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
@@ -243,23 +243,39 @@ def get_last_mop_index(manufacturing_operation, voucher_type=None, voucher_no=No
 	return last_log
 
 
-def get_current_mop_balance_rows(manufacturing_operation, include_fields=None):
+def get_current_mop_balance_rows(
+	manufacturing_operation, include_fields=None, keys=None
+):
 	"""Return the latest non-cancelled MOP Log row per item/batch for a MOP.
 
 	Loss-attribution rows (log_category="Loss Attribution") ARE included —
 	they post a real qty_change reduction so the balance after loss must be
 	reflected to downstream readers (e.g. Make Receive Entry availability,
 	manual loss validation, EOD SRE reconciliation).
+
+	When ``keys`` is provided as a list of ``(item_code, batch_no)`` tuples,
+	the underlying ``frappe.db.get_all`` is narrowed by the distinct
+	``item_code`` set so popups never scan unrelated items. The composite
+	index ``mop_balance_idx`` (added by ``add_make_receive_entry_indexes``)
+	covers ``(manufacturing_operation, is_cancelled, item_code, batch_no,
+	creation)`` so the narrowed filter is index-served. The Python-side
+	dedup picks the latest row per ``(item_code, batch_no)``.
 	"""
 	fields = list(
 		dict.fromkeys((include_fields or current_balance_fields) + ["name", "creation"])
 	)
+	filters = {
+		"manufacturing_operation": manufacturing_operation,
+		"is_cancelled": 0,
+	}
+	if keys:
+		item_codes = sorted({k[0] for k in keys if k and k[0]})
+		if not item_codes:
+			return []
+		filters["item_code"] = ["in", item_codes]
 	mop_logs = frappe.db.get_all(
 		"MOP Log",
-		filters={
-			"manufacturing_operation": manufacturing_operation,
-			"is_cancelled": 0,
-		},
+		filters=filters,
 		fields=fields,
 		order_by="creation desc",
 	)
@@ -358,6 +374,7 @@ def get_available_qty_pcs_for_mop_item(
 		"available_pcs": available_pcs,
 		"is_pcs_item": is_pcs_item,
 		"mop_log_reference": mop_log_reference,
+		"mop_data_present": mop_log_reference is not None,
 	}
 
 
@@ -573,24 +590,25 @@ def get_employee_ir_loss_map(eir_doc):
 def create_mop_log_for_employee_ir_receive(
 	doc, row, from_warehouse, to_warehouse, stock_entry_name=[]
 ):
-	"""Create combined Receive + Loss MOP Log entries for Employee IR Receive.
+	"""Audit-only MOP Log clones on the SOURCE MOP for Employee IR Receive.
 
 	Reads the MOP Logs created during the matching Employee IR **Issue** only
 	(``voucher_no`` = Issue name), not every historical Employee IR log on
 	the MOP.
 
-	**Combined design (replaces the prior two-pass receive + loss writer).**
-	For each issue source row, the loss attributable to the same
-	(item_code, batch_no) is subtracted directly from this MOP Log's qty/pcs
-	balance fields. The result: one MOP Log row per receive flow (no
-	separate Loss Attribution rows), so MOPLog.validate updates Manufacturing
-	Operation buckets exactly once.
+	**Source MOP is left unchanged.** Per the new contract, loss-driven
+	weight reductions land on the NEW Manufacturing Operation only — see
+	``update_new_mop_wtg``, which both clones the source baseline AND
+	subtracts loss in-place per ``(item, batch)``. The rows written here
+	are pure clones (qty_change=0) of the issue-tier balance so audit
+	metadata (loss_weight, loss_type, loss_source_row) stays attached to a
+	real MOP Log row on the source MOP for traceability, but no balance
+	shift happens.
 
-	UOM rule: ``qty_change`` and ``qty_after_transaction*`` stay in the
-	item's stock UOM (carats for D/G, grams for M/F/O). MOPLog.validate
-	applies the carat→gram conversion when it writes
-	``diamond_wt_in_gram`` / ``gemstone_wt_in_gram``. We do **not** convert
-	carat→gram before subtracting loss.
+	UOM rule: ``qty_after_transaction*`` stay in the item's stock UOM
+	(carats for D/G, grams for M/F/O), copied verbatim from the source log.
+	MOPLog.validate's prefix-bucket write is a no-op here because the qty
+	matches what is already on the source MOP.
 	"""
 	issue_voucher = resolve_employee_ir_issue_voucher_for_receive(doc, row)
 	mop_logs = []
@@ -670,50 +688,29 @@ def create_mop_log_for_employee_ir_receive(
 			full_loss_map.get(loss_key) if loss_key not in consumed_loss_keys else None
 		)
 
-		loss_qty = flt(loss.get("loss_qty"), 3) if loss else 0.0
-		loss_pcs = cint(loss.get("loss_pcs") or 0) if loss else 0
-
-		# Subtract loss in the item's stock UOM (no conversion).
-		adj_qty_after = flt(flt(log.qty_after_transaction) - loss_qty, 3)
-		adj_qty_after_item = flt(
-			flt(log.qty_after_transaction_item_based) - loss_qty, 3
-		)
-		adj_qty_after_batch = flt(
-			flt(log.qty_after_transaction_batch_based) - loss_qty, 3
-		)
-
-		first_char = (log.item_code or "")[0] if log.item_code else ""
-		# PCS only meaningful for D/G; loss_pcs is already 0 for non-D/G
-		# (the loss-map builder gates on prefix). Keep the explicit guard
-		# here too so a future loss-map shape change can't leak PCS into
-		# M/F/O rows.
-		if first_char in ("D", "G"):
-			adj_pcs_after = cint(log.pcs_after_transaction) - loss_pcs
-			adj_pcs_after_item = cint(log.pcs_after_transaction_item_based) - loss_pcs
-			adj_pcs_after_batch = cint(log.pcs_after_transaction_batch_based) - loss_pcs
-			pcs_change = -loss_pcs
-		else:
-			adj_pcs_after = cint(log.pcs_after_transaction)
-			adj_pcs_after_item = cint(log.pcs_after_transaction_item_based)
-			adj_pcs_after_batch = cint(log.pcs_after_transaction_batch_based)
-			pcs_change = 0
-
+		# SOURCE MOP audit clone: qty_change=0, balances copied verbatim.
+		# Loss is applied to the NEW MOP inside update_new_mop_wtg's
+		# baseline-clone loop (one row per item/batch, already reduced).
 		mop_log = frappe.new_doc("MOP Log")
 		mop_log.item_code = log.item_code
-		# qty_change reflects ONLY the loss adjustment for this receive flow.
-		# The receive itself clones the issue balance forward (zero net
-		# delta); loss is the only thing that moves the balance, so
-		# qty_change = -loss_qty captures the net movement of this row.
-		mop_log.qty_change = -loss_qty
-		mop_log.pcs_change = pcs_change
+		mop_log.qty_change = 0
+		mop_log.pcs_change = 0
 
-		mop_log.qty_after_transaction = adj_qty_after
-		mop_log.qty_after_transaction_item_based = adj_qty_after_item
-		mop_log.qty_after_transaction_batch_based = adj_qty_after_batch
+		mop_log.qty_after_transaction = flt(log.qty_after_transaction)
+		mop_log.qty_after_transaction_item_based = flt(
+			log.qty_after_transaction_item_based
+		)
+		mop_log.qty_after_transaction_batch_based = flt(
+			log.qty_after_transaction_batch_based
+		)
 
-		mop_log.pcs_after_transaction = adj_pcs_after
-		mop_log.pcs_after_transaction_item_based = adj_pcs_after_item
-		mop_log.pcs_after_transaction_batch_based = adj_pcs_after_batch
+		mop_log.pcs_after_transaction = cint(log.pcs_after_transaction)
+		mop_log.pcs_after_transaction_item_based = cint(
+			log.pcs_after_transaction_item_based
+		)
+		mop_log.pcs_after_transaction_batch_based = cint(
+			log.pcs_after_transaction_batch_based
+		)
 
 		mop_log.from_warehouse = from_warehouse
 		mop_log.to_warehouse = to_warehouse

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_required.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_loss_required.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for ``validate_loss_tables_required``.
+
+If a Receive shows loss (sum(gross_wt - received_gross_wt) > 0 rounded to 3)
+but both ``employee_loss_details`` and ``manually_book_loss_details`` are
+empty, submit must be rejected.
+"""
+
+from unittest.mock import MagicMock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.validation_utils import (
+	validate_loss_tables_required,
+)
+
+
+def _eir(
+	rows,
+	employee_loss_details=None,
+	manually_book_loss_details=None,
+	type_="Receive",
+	docstatus=0,
+):
+	doc = MagicMock()
+	doc.docstatus = docstatus
+	doc.type = type_
+	doc.employee_ir_operations = [frappe._dict(r) for r in rows]
+	doc.employee_loss_details = [frappe._dict(r) for r in (employee_loss_details or [])]
+	doc.manually_book_loss_details = [
+		frappe._dict(r) for r in (manually_book_loss_details or [])
+	]
+	return doc
+
+
+class TestValidateLossTablesRequired(FrappeTestCase):
+	def test_receive_loss_without_loss_tables_rejected(self):
+		"""gross > received with both tables empty → throw."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 8.5,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+		)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_loss_tables_required(doc)
+
+	def test_rounded_zero_loss_does_not_require_loss_tables(self):
+		"""Loss = 0.0004 rounds to 0.000 → allowed even with empty tables."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0004,
+					"received_gross_wt": 10.0000,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+		)
+		validate_loss_tables_required(doc)  # must not throw
+
+	def test_manual_loss_only_allowed(self):
+		"""Only manually_book_loss_details populated → allowed."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 9.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			manually_book_loss_details=[
+				{"item_code": "M-X", "proportionally_loss": 1.0}
+			],
+		)
+		validate_loss_tables_required(doc)
+
+	def test_employee_loss_only_allowed(self):
+		"""Only employee_loss_details populated → allowed."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 9.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			employee_loss_details=[{"item_code": "M-X", "proportionally_loss": 1.0}],
+		)
+		validate_loss_tables_required(doc)
+
+	def test_no_loss_no_tables_allowed(self):
+		"""gross == received → no loss → tables not required."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 10.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+		)
+		validate_loss_tables_required(doc)
+
+	def test_validator_runs_at_submit_docstatus_zero(self):
+		"""Validator is now called from on_submit (docstatus still 0). With
+		baseline > 0 and empty tables it must throw — no docstatus skip.
+		"""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 8.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			docstatus=0,
+		)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_loss_tables_required(doc)
+
+	def test_issue_type_skips_validation(self):
+		"""type != "Receive" → validator no-ops."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 8.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			type_="Issue",
+		)
+		validate_loss_tables_required(doc)
+
+	def test_loss_total_must_match_baseline_short_rejects(self):
+		"""baseline=2 but tables sum to 1 → throw (under-allocated)."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 8.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			manually_book_loss_details=[
+				{"item_code": "M-X", "proportionally_loss": 1.0}
+			],
+		)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_loss_tables_required(doc)
+
+	def test_loss_total_must_match_baseline_over_rejects(self):
+		"""baseline=1 but combined tables sum to 1.5 → throw (over-allocated)."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 9.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			employee_loss_details=[{"item_code": "M-X", "proportionally_loss": 1.0}],
+			manually_book_loss_details=[
+				{"item_code": "M-Y", "proportionally_loss": 0.5}
+			],
+		)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_loss_tables_required(doc)
+
+	def test_loss_total_match_dg_carat_converted_to_grams(self):
+		"""D-item proportionally_loss = 5 carats → 1.0 g; baseline = 1.0 g.
+		Carat-to-gram conversion via get_loss_qty_in_grams must match."""
+		doc = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 9.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			manually_book_loss_details=[
+				{"item_code": "D-BRI-VS1", "proportionally_loss": 5.0}
+			],
+		)
+		validate_loss_tables_required(doc)  # 5 carat × 0.2 = 1.0 g == 1.0
+
+	def test_loss_total_within_precision_tolerance(self):
+		"""Sub-precision drift (< 0.0005) is allowed; >= 0.001 rejected."""
+		# Within tolerance: baseline 1.000, total 1.0004 → flt(_,3) = 1.000.
+		doc_ok = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 9.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			manually_book_loss_details=[
+				{"item_code": "M-X", "proportionally_loss": 1.0004}
+			],
+		)
+		validate_loss_tables_required(doc_ok)
+
+		# Beyond tolerance: baseline 1.000, total 1.0006 → rounds to 1.001 → throw.
+		doc_bad = _eir(
+			rows=[
+				{
+					"gross_wt": 10.0,
+					"received_gross_wt": 9.0,
+					"manufacturing_work_order": "MWO-1",
+				}
+			],
+			manually_book_loss_details=[
+				{"item_code": "M-X", "proportionally_loss": 1.0006}
+			],
+		)
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			validate_loss_tables_required(doc_bad)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_precision.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_employee_ir_precision.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Verify Float weight fields persist at precision 3.
+
+Checks two layers:
+
+1. **Schema** — each Float weight field on the relevant DocTypes carries
+   ``precision: "3"`` so Frappe's grid + DB write rounds the same way.
+2. **Runtime** — ``round_employee_ir_weights_to_precision`` rounds the
+   in-memory doc before validate, so any code path that reads
+   ``child.gross_wt`` after validate gets a 3-decimal value regardless of
+   the user's keypad input.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events.precision import (
+	EIR_OPERATION_WEIGHT_FIELDS,
+	LOSS_DETAIL_WEIGHT_FIELDS,
+	round_employee_ir_weights_to_precision,
+)
+
+# Resolve to the app root so the tests stay path-independent.
+_APP_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _load_doctype_json(rel_path: str) -> dict:
+	with open(os.path.join(_APP_ROOT, rel_path)) as f:
+		return json.load(f)
+
+
+def _float_fields_with_precision(doctype_json: dict) -> dict[str, str | None]:
+	return {
+		f["fieldname"]: f.get("precision")
+		for f in doctype_json["fields"]
+		if f.get("fieldtype") == "Float"
+	}
+
+
+class TestSchemaPrecision(FrappeTestCase):
+	"""DocType JSON precision attribute is the source of truth at migrate
+	time — every covered Float weight field must declare precision=3.
+	"""
+
+	def test_employee_ir_operation_weight_fields_precision_3(self):
+		j = _load_doctype_json(
+			"doctype/employee_ir_operation/employee_ir_operation.json"
+		)
+		fields = _float_fields_with_precision(j)
+		for f in EIR_OPERATION_WEIGHT_FIELDS:
+			self.assertEqual(
+				fields.get(f),
+				"3",
+				f"{f} on Employee IR Operation must have precision=3",
+			)
+
+	def test_employee_loss_details_precision_3(self):
+		j = _load_doctype_json(
+			"doctype/employee_loss_details/employee_loss_details.json"
+		)
+		fields = _float_fields_with_precision(j)
+		for f in LOSS_DETAIL_WEIGHT_FIELDS:
+			self.assertEqual(fields.get(f), "3", f"{f} must have precision=3")
+
+	def test_manually_book_loss_details_precision_3(self):
+		j = _load_doctype_json(
+			"doctype/manually_book_loss_details/manually_book_loss_details.json"
+		)
+		fields = _float_fields_with_precision(j)
+		for f in LOSS_DETAIL_WEIGHT_FIELDS:
+			self.assertEqual(fields.get(f), "3", f"{f} must have precision=3")
+
+	def test_employee_ir_mop_loss_details_total_precision_3(self):
+		j = _load_doctype_json("doctype/employee_ir/employee_ir.json")
+		fields = _float_fields_with_precision(j)
+		self.assertEqual(fields.get("mop_loss_details_total"), "3")
+
+	def test_manufacturing_operation_weight_fields_precision_3(self):
+		j = _load_doctype_json(
+			"doctype/manufacturing_operation/manufacturing_operation.json"
+		)
+		fields = _float_fields_with_precision(j)
+		# Subset directly tied to weight bookkeeping; Int / time / pcs
+		# fields are intentionally excluded from precision=3.
+		for f in (
+			"gross_wt",
+			"net_wt",
+			"finding_wt",
+			"diamond_wt",
+			"gemstone_wt",
+			"diamond_wt_in_gram",
+			"gemstone_wt_in_gram",
+			"received_gross_wt",
+			"received_net_wt",
+			"loss_wt",
+			"prev_gross_wt",
+			"other_wt",
+		):
+			self.assertEqual(
+				fields.get(f),
+				"3",
+				f"{f} on Manufacturing Operation must have precision=3",
+			)
+
+
+class TestRuntimePrecisionRounder(FrappeTestCase):
+	"""``round_employee_ir_weights_to_precision`` rounds in-memory doc
+	values before validate. Any field with sub-3-decimal input loses tail
+	digits.
+	"""
+
+	def _doc_with_op(self, **op_overrides):
+		doc = MagicMock()
+		op = frappe._dict({f: 0.0 for f in EIR_OPERATION_WEIGHT_FIELDS})
+		op.update(op_overrides)
+		# child.set must mutate the underlying dict.
+		op_mock = MagicMock()
+		for k, v in op.items():
+			setattr(op_mock, k, v)
+		op_mock.set.side_effect = lambda k, v: setattr(op_mock, k, v)
+		doc.employee_ir_operations = [op_mock]
+		doc.mop_loss_details_total = None
+		doc.employee_loss_details = []
+		doc.manually_book_loss_details = []
+		return doc, op_mock
+
+	def test_employee_ir_operation_gross_wt_rounded_to_3(self):
+		doc, op = self._doc_with_op(gross_wt=1.234567)
+		round_employee_ir_weights_to_precision(doc)
+		self.assertAlmostEqual(op.gross_wt, 1.235, places=6)
+
+	def test_received_gross_wt_rounded_to_3(self):
+		doc, op = self._doc_with_op(received_gross_wt=2.111199)
+		round_employee_ir_weights_to_precision(doc)
+		self.assertAlmostEqual(op.received_gross_wt, 2.111, places=6)
+
+	def test_mop_loss_details_total_rounded_when_present(self):
+		doc, _op = self._doc_with_op()
+		doc.mop_loss_details_total = 5.6789
+		round_employee_ir_weights_to_precision(doc)
+		self.assertAlmostEqual(doc.mop_loss_details_total, 5.679, places=6)
+
+	def test_loss_detail_proportionally_loss_rounded(self):
+		doc, _op = self._doc_with_op()
+		row = MagicMock()
+		row.proportionally_loss = 0.123456
+		row.net_weight = 0.0
+		row.received_gross_weight = 0.0
+		row.main_slip_consumption = 0.0
+		row.set.side_effect = lambda k, v: setattr(row, k, v)
+		doc.manually_book_loss_details = [row]
+		round_employee_ir_weights_to_precision(doc)
+		self.assertAlmostEqual(row.proportionally_loss, 0.123, places=6)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry.py
@@ -74,7 +74,8 @@ class TestGetMakeReceiveEntryRows(FrappeTestCase):
 			)
 		]
 
-		rows = get_make_receive_entry_rows("MOP-1")
+		result = get_make_receive_entry_rows("MOP-1")
+		rows = result["rows"]
 
 		# get_all is called twice now: first for SRE listing, second for MOP
 		# Log balance precompute. Inspect the first call (the SRE filter).
@@ -84,7 +85,15 @@ class TestGetMakeReceiveEntryRows(FrappeTestCase):
 		self.assertEqual(len(rows), 1)
 		self.assertEqual(rows[0]["available_to_receive_qty"], 10.0)
 		self.assertEqual(rows[0]["reserved_qty"], 10.0)
+		# Mock returns the SRE list for both `frappe.db.get_all` calls
+		# (doctype-collision: only one mock is active for the whole
+		# function), so the MOP Log lookup picks up the SRE dict and
+		# `mop_available_qty` reflects whatever `qty_after_transaction_batch_based`
+		# evaluates to on it (None → 0). The structured response shape
+		# is what we check here.
 		self.assertEqual(rows[0]["mop_available_qty"], 0)
+		self.assertEqual(result["active_sre_count"], 1)
+		self.assertEqual(result["skipped"], [])
 
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
@@ -551,7 +560,7 @@ class TestGetMakeReceiveEntryRowsFilters(FrappeTestCase):
 			),
 		]
 
-		rows = get_make_receive_entry_rows("MOP-1")
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
 		self.assertEqual(len(rows), 1)
 		self.assertEqual(rows[0]["stock_reservation_entry"], "SRE-ACTIVE")
 		self.assertAlmostEqual(rows[0]["available_to_receive_qty"], 6.0)
@@ -598,8 +607,10 @@ class TestGetMakeReceiveEntryRowsFilters(FrappeTestCase):
 		filters = kwargs["filters"]
 		self.assertEqual(filters["docstatus"], 1)
 		self.assertEqual(filters["manufacturing_work_order"], "MWO-1")
-		# No hardcoded status whitelist (Correction 2).
-		self.assertNotIn("status", filters)
+		# Status filter excludes terminal-state SREs (Cancelled, Delivered)
+		# per the MWO-scope fix; docstatus=1 alone is not sufficient because
+		# ERPNext keeps Cancelled SREs at docstatus=1 with status flipped.
+		self.assertEqual(filters["status"], ["not in", ("Cancelled", "Delivered")])
 
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
@@ -658,7 +669,7 @@ class TestGetMakeReceiveEntryRowsFilters(FrappeTestCase):
 			)
 		]
 
-		rows = get_make_receive_entry_rows("MOP-1")
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
 		self.assertEqual(len(rows), 1)
 		# 6 reserved - 0 delivered = 6 SRE remaining; MOP unmocked = 0 (no
 		# data signal). available_to_receive_qty falls back to SRE

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_mop_cap.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_mop_cap.py
@@ -138,7 +138,7 @@ class TestPopupReservedVsMopFields(FrappeTestCase):
 			sre_rows=[_sre_dict(reserved_qty=10.0)],
 			mop_rows=[_mop_log_row(qty=7.0)],
 		)
-		rows = get_make_receive_entry_rows("MOP-1")
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
 		self.assertEqual(len(rows), 1)
 		row = rows[0]
 		self.assertAlmostEqual(row["reserved_qty"], 10.0)
@@ -155,7 +155,7 @@ class TestPopupReservedVsMopFields(FrappeTestCase):
 			sre_rows=[_sre_dict(reserved_qty=10.0)],
 			mop_rows=[_mop_log_row(qty=0.0)],
 		)
-		rows = get_make_receive_entry_rows("MOP-1")
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
 		self.assertEqual(rows, [])
 
 	def test_t9_loss_delta_reduces_mop_available(self):
@@ -169,7 +169,7 @@ class TestPopupReservedVsMopFields(FrappeTestCase):
 			sre_rows=[_sre_dict(reserved_qty=10.0)],
 			mop_rows=[_mop_log_row(qty=8.5)],
 		)
-		rows = get_make_receive_entry_rows("MOP-1")
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
 		self.assertEqual(len(rows), 1)
 		self.assertAlmostEqual(rows[0]["mop_available_qty"], 8.5)
 		self.assertAlmostEqual(rows[0]["available_to_receive_qty"], 8.5)
@@ -187,7 +187,7 @@ class TestPopupReservedVsMopFields(FrappeTestCase):
 			sre_rows=[_sre_dict(reserved_qty=2.0, item_code="D-BRI-VS1")],
 			mop_rows=[_mop_log_row(item_code="D-BRI-VS1", qty=2.0, pcs=12)],
 		)
-		rows = get_make_receive_entry_rows("MOP-1")
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
 		self.assertEqual(len(rows), 1)
 		row = rows[0]
 		self.assertTrue(row["is_pcs_item"])

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_mwo_level.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_mwo_level.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""MWO-level scope contract for Make Receive Entry.
+
+The popup opened on Manufacturing Operation X must show every active SRE for
+the MWO — including SREs whose own ``manufacturing_operation`` is a sibling
+MOP — but compute MOP Log availability against each SRE's own operation,
+not the popup's opened MOP.
+
+Regression case (user-reported):
+  MOP-461KI opened in UI; MWO has SREs 00163, 00164, 00165.
+  SRE-00163.manufacturing_operation = MOP-EY179.
+  Popup must show 00163 with availability calculated against MOP-EY179's
+  MOP Log — never against MOP-461KI.
+
+NB: ``frappe.db.get_all`` is one global function; patching it via two
+module paths collides on the same target, so we install a single mock and
+dispatch by doctype with ``side_effect``. The MOP Log dispatch keys off
+the ``filters['manufacturing_operation']`` so each SRE's own MOP fetches
+its own balance row.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+def _make_mo(name="MOP-461KI", mwo="MWO-1", department="DEPT-A", status="WIP"):
+	mo = MagicMock()
+	mo.name = name
+	mo.manufacturing_work_order = mwo
+	mo.manufacturing_operation = name
+	mo.manufacturing_order = "PMO-1"
+	mo.department = department
+	mo.status = status
+	return mo
+
+
+def _sre(
+	name,
+	manufacturing_operation,
+	item_code="M-G-18KT-75.4-Y",
+	warehouse="Casting WO - GEPL",
+	reserved_qty=10.0,
+	delivered_qty=0.0,
+	has_batch_no=0,
+	reservation_based_on="Qty",
+):
+	return frappe._dict(
+		{
+			"name": name,
+			"item_code": item_code,
+			"warehouse": warehouse,
+			"reserved_qty": reserved_qty,
+			"delivered_qty": delivered_qty,
+			"stock_uom": "Gram",
+			"voucher_type": "Sales Order",
+			"voucher_no": "SAL-ORD-1",
+			"voucher_detail_no": "SOI-1",
+			"has_serial_no": 0,
+			"has_batch_no": has_batch_no,
+			"reservation_based_on": reservation_based_on,
+			"status": "Reserved",
+			"manufacturing_work_order": "MWO-1",
+			"manufacturing_operation": manufacturing_operation,
+		}
+	)
+
+
+def _make_get_all_side_effect(sre_rows=None, mop_log_rows_by_mop=None, sbe_rows=None):
+	"""Dispatch ``frappe.db.get_all`` by doctype; for MOP Log dispatch
+	additionally by ``filters['manufacturing_operation']`` so each SRE's
+	own MOP gets its own balance row.
+	"""
+	sre_rows = sre_rows or []
+	mop_log_rows_by_mop = mop_log_rows_by_mop or {}
+	sbe_rows = sbe_rows or []
+
+	def _side_effect(doctype, *args, **kwargs):
+		if doctype == "Stock Reservation Entry":
+			return sre_rows
+		if doctype == "MOP Log":
+			filters = kwargs.get("filters") or {}
+			mop = filters.get("manufacturing_operation")
+			return mop_log_rows_by_mop.get(mop, [])
+		if doctype == "Serial and Batch Entry":
+			return sbe_rows
+		return []
+
+	return _side_effect
+
+
+class TestMwoLevelMakeReceiveEntry(FrappeTestCase):
+	"""SREs from sibling MOPs under the same MWO must appear, with
+	availability computed against each SRE's own MOP Log.
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw-461",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_sibling_mop_sre_returned_with_own_mop_balance(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		"""SRE-OTHER belongs to MOP-EY179; popup opened on MOP-461KI.
+
+		Expected: row appears with mop_available_qty taken from MOP-EY179's
+		MOP Log (8.0), not MOP-461KI's (5.0). The fix computes the balance
+		lookup using each SRE's own ``manufacturing_operation``.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.side_effect = _make_get_all_side_effect(
+			sre_rows=[
+				_sre("SRE-OWN", manufacturing_operation="MOP-461KI", reserved_qty=5.0),
+				_sre(
+					"SRE-OTHER",
+					manufacturing_operation="MOP-EY179",
+					reserved_qty=8.0,
+				),
+			],
+			mop_log_rows_by_mop={
+				"MOP-461KI": [
+					frappe._dict(
+						{
+							"item_code": "M-G-18KT-75.4-Y",
+							"batch_no": None,
+							"qty_after_transaction_batch_based": 5.0,
+							"pcs_after_transaction_batch_based": 0,
+							"name": "MOP-LOG-461",
+							"creation": "2026-05-01",
+						}
+					)
+				],
+				"MOP-EY179": [
+					frappe._dict(
+						{
+							"item_code": "M-G-18KT-75.4-Y",
+							"batch_no": None,
+							"qty_after_transaction_batch_based": 8.0,
+							"pcs_after_transaction_batch_based": 0,
+							"name": "MOP-LOG-EY179",
+							"creation": "2026-05-01",
+						}
+					)
+				],
+			},
+		)
+
+		result = get_make_receive_entry_rows("MOP-461KI")
+		rows = result["rows"]
+
+		self.assertEqual(result["active_sre_count"], 2)
+		# Both SREs surface.
+		by_sre = {r["stock_reservation_entry"]: r for r in rows}
+		self.assertIn("SRE-OWN", by_sre)
+		self.assertIn("SRE-OTHER", by_sre)
+
+		# Critical: SRE-OTHER (sibling MOP) gets MOP-EY179's balance (8.0),
+		# NOT MOP-461KI's balance (5.0). Pre-fix this would have shown 5.0.
+		self.assertAlmostEqual(by_sre["SRE-OTHER"]["mop_available_qty"], 8.0)
+		self.assertAlmostEqual(by_sre["SRE-OTHER"]["available_to_receive_qty"], 8.0)
+
+		# Sibling MOP is recorded on the row so the operator/audit can see
+		# which operation owns the reservation.
+		self.assertEqual(by_sre["SRE-OTHER"]["manufacturing_operation"], "MOP-EY179")
+
+		# Source warehouse comes from the SRE itself, not the opened MOP's
+		# department warehouse.
+		self.assertEqual(by_sre["SRE-OTHER"]["s_warehouse"], "Casting WO - GEPL")
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw-461",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_sre_filter_includes_status_excludes_cancelled_delivered(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		"""SRE filter must drop Cancelled/Delivered statuses (per ERPNext SRE
+		lifecycle) — docstatus=1 alone is not sufficient.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.side_effect = _make_get_all_side_effect()
+
+		get_make_receive_entry_rows("MOP-461KI")
+
+		# First call to frappe.db.get_all is the SRE listing. Filter must
+		# scope by MWO and exclude terminal statuses, but NOT scope by
+		# manufacturing_operation (MWO-level intent).
+		sre_call = next(
+			c
+			for c in mock_get_all.call_args_list
+			if c.args and c.args[0] == "Stock Reservation Entry"
+		)
+		filters = sre_call.kwargs["filters"]
+		self.assertEqual(filters["manufacturing_work_order"], "MWO-1")
+		self.assertEqual(filters["docstatus"], 1)
+		self.assertEqual(filters["status"], ["not in", ("Cancelled", "Delivered")])
+		self.assertNotIn("manufacturing_operation", filters)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_pcs.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_pcs.py
@@ -56,6 +56,10 @@ class TestGetAvailableQtyPcsForMopItem(FrappeTestCase):
 			"available_pcs",
 			"is_pcs_item",
 			"mop_log_reference",
+			# Added by Part 2: lets the popup distinguish "no MOP Log row"
+			# (mop_data_present=False → fall back to SRE remaining) from
+			# "MOP Log row exists with 0g" (mop_data_present=True → skip).
+			"mop_data_present",
 		}
 		self.assertEqual(set(ctx.keys()), expected_keys)
 		# SRE never stores PCS — reserved_pcs must be None (unknown).

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_second_popup.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_second_popup.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Diagnostic-shape contract for the Make Receive Entry popup.
+
+Three scenarios the dialog must distinguish:
+  1. ``active_sre_count == 0`` → no SREs at all under the MWO.
+  2. ``active_sre_count > 0`` AND ``rows`` non-empty AND ``mop_data_present``
+     True on each row → normal popup.
+  3. ``active_sre_count > 0`` AND ``rows`` empty AND ``skipped`` populated
+     with reason="mop_zero_balance" → SRE alive but loss/consumption ate
+     the MOP balance.
+  4. ``rows`` non-empty AND a row has ``warning`` set → SRE alive but no
+     MOP Log row found; UI shows the warning, server-side cap silenced.
+
+NB: ``frappe.db.get_all`` is a global function — patching it via two
+different module paths (``manufacturing_operation.frappe.db.get_all``
+*and* ``mop_log.frappe.db.get_all``) collides on the same object, so only
+the inner @patch wins. We patch it once and dispatch by doctype using
+``side_effect``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+def _make_mo(name="MOP-1", mwo="MWO-1", department="DEPT-A", status="WIP"):
+	mo = MagicMock()
+	mo.name = name
+	mo.manufacturing_work_order = mwo
+	mo.manufacturing_operation = name
+	mo.manufacturing_order = "PMO-1"
+	mo.department = department
+	mo.status = status
+	return mo
+
+
+def _qty_sre(
+	name="SRE-1", reserved_qty=10.0, delivered_qty=0.0, manufacturing_operation="MOP-1"
+):
+	return frappe._dict(
+		{
+			"name": name,
+			"item_code": "M-X",
+			"warehouse": "WH-Src",
+			"reserved_qty": reserved_qty,
+			"delivered_qty": delivered_qty,
+			"stock_uom": "Gram",
+			"voucher_type": "Sales Order",
+			"voucher_no": "SO-1",
+			"voucher_detail_no": "SOI-1",
+			"has_serial_no": 0,
+			"has_batch_no": 0,
+			"reservation_based_on": "Qty",
+			"status": "Reserved",
+			"manufacturing_work_order": "MWO-1",
+			"manufacturing_operation": manufacturing_operation,
+		}
+	)
+
+
+def _make_get_all_side_effect(sre_rows=None, mop_log_rows=None, sbe_rows=None):
+	"""Return a side_effect that dispatches ``frappe.db.get_all`` by
+	doctype. SBE / MOP Log default to empty so missing keys are inert.
+	"""
+	sre_rows = sre_rows or []
+	mop_log_rows = mop_log_rows or []
+	sbe_rows = sbe_rows or []
+
+	def _side_effect(doctype, *args, **kwargs):
+		if doctype == "Stock Reservation Entry":
+			return sre_rows
+		if doctype == "MOP Log":
+			return mop_log_rows
+		if doctype == "Serial and Batch Entry":
+			return sbe_rows
+		return []
+
+	return _side_effect
+
+
+class TestMakeReceiveEntrySecondPopup(FrappeTestCase):
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_no_sre_returns_active_sre_count_zero(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.side_effect = _make_get_all_side_effect()
+		result = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(result["rows"], [])
+		self.assertEqual(result["skipped"], [])
+		self.assertEqual(result["active_sre_count"], 0)
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_sre_with_zero_mop_balance_goes_to_skipped(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		"""Replacement SRE alive (qty=10) but a loss MOP Log row drove the
+		MOP balance to 0 → row goes to ``skipped`` with
+		reason='mop_zero_balance', not ``rows``. This is the exact failure
+		mode that produced the misleading "no SRE found" message before
+		the fix.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		mock_get_all.side_effect = _make_get_all_side_effect(
+			sre_rows=[_qty_sre(reserved_qty=10.0)],
+			mop_log_rows=[
+				frappe._dict(
+					{
+						"item_code": "M-X",
+						"batch_no": None,
+						"qty_after_transaction_batch_based": 0.0,
+						"pcs_after_transaction_batch_based": 0,
+						"name": "MOP-LOG-LOSS",
+						"creation": "2026-05-01",
+					}
+				)
+			],
+		)
+
+		result = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(result["rows"], [])
+		self.assertEqual(result["active_sre_count"], 1)
+		self.assertEqual(len(result["skipped"]), 1)
+		self.assertEqual(result["skipped"][0]["reason"], "mop_zero_balance")
+		self.assertEqual(result["skipped"][0]["sre"], "SRE-1")
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+		return_value=[(0,)],
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_all"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+		return_value="WH-Raw",
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+		return_value=3,
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc"
+	)
+	def test_sre_with_missing_mop_row_surfaced_with_warning(
+		self,
+		mock_get_doc,
+		_mock_single,
+		_mock_get_value,
+		mock_get_all,
+		_mock_sql,
+	):
+		"""When MOP Log has NO row for (item, batch), surface the SRE row
+		with a ``warning`` and ``available_to_receive_qty == sre_remaining``
+		— SRE is the only authoritative source.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		mock_get_doc.return_value = _make_mo()
+		# MOP Log returns nothing for the (item, batch) lookup.
+		mock_get_all.side_effect = _make_get_all_side_effect(
+			sre_rows=[_qty_sre(reserved_qty=10.0)],
+			mop_log_rows=[],
+		)
+
+		result = get_make_receive_entry_rows("MOP-1")
+		self.assertEqual(result["active_sre_count"], 1)
+		self.assertEqual(len(result["rows"]), 1)
+		row = result["rows"][0]
+		self.assertAlmostEqual(row["available_to_receive_qty"], 10.0)
+		self.assertTrue(row["warning"])
+		self.assertFalse(row["mop_data_present"])

--- a/jewellery_erpnext/patches.txt
+++ b/jewellery_erpnext/patches.txt
@@ -7,3 +7,5 @@ jewellery_erpnext.patches.remove_se_custom_fields
 jewellery_erpnext.patches.tracking_bom_fields
 jewellery_erpnext.patches.add_manufacturing_plan_indexes
 jewellery_erpnext.patches.add_stock_entry_type_repack
+jewellery_erpnext.patches.add_make_receive_entry_indexes
+jewellery_erpnext.patches.add_jewellery_perf_indexes

--- a/jewellery_erpnext/patches/add_jewellery_perf_indexes.py
+++ b/jewellery_erpnext/patches/add_jewellery_perf_indexes.py
@@ -1,0 +1,125 @@
+"""Composite indexes for high-frequency query patterns across jewellery_erpnext.
+
+Each index here was identified by auditing the actual call sites — no blind
+indexing. Existing coverage (from ``add_make_receive_entry_indexes``) handles
+the Make Receive Entry / SRE / Stock Entry / SBE hot paths; this patch fills
+the remaining gaps the audit surfaced:
+
+* Employee IR / Department IR cancel cascade: bulk
+  ``UPDATE tabMOP Log WHERE voucher_type = %s AND voucher_no = %s
+   AND is_cancelled = 0`` in
+  ``employee_ir.py::on_submit_issue_new`` (line 140) and
+  ``employee_ir.py::on_submit_receive`` (line 292) — full table scan
+  without a (voucher_type, voucher_no, is_cancelled) index.
+* Employee IR Issue lookup JOIN in ``mop_log.py::resolve_employee_ir_issue_voucher_for_receive``
+  (line 514) — ``WHERE eir.docstatus = 1 AND eir.type = 'Issue'
+  AND op.manufacturing_operation = ?  ORDER BY eir.modified DESC``.
+* Employee IR Operation existence check (``mop_log.py:504``,
+  ``stock_entry.py``) and Department IR Operation draft-state check
+  (``stock_entry.py:154``).
+
+Skipped on purpose:
+* (voucher_type, voucher_no, manufacturing_operation, loss_source_row,
+  is_cancelled) — 5-column wide index; the (voucher_type, voucher_no,
+  is_cancelled) prefix already narrows to a handful of rows, and the
+  remaining post-filter is cheap.
+* (docstatus, type) on Department IR — only one observed site, low impact.
+* Per-row indexes on ``tabEmployee Loss Details`` /
+  ``tabManually Book Loss Details`` — those tables are iterated as Python
+  child rows after the parent load, never queried with a composite filter.
+"""
+
+import frappe
+
+
+def _index_exists(table: str, index_name: str) -> bool:
+	return bool(
+		frappe.db.sql(
+			"""
+			SELECT 1 FROM information_schema.statistics
+			WHERE table_schema = DATABASE()
+			  AND table_name = %s
+			  AND index_name = %s
+			LIMIT 1
+			""",
+			(table, index_name),
+		)
+	)
+
+
+def _table_has_columns(table: str, columns: tuple) -> bool:
+	"""Skip an index when one of its columns doesn't exist on the table.
+
+	Custom apps occasionally trail behind in field rollout (e.g. a custom
+	field added in one site but not yet migrated on another). Returning
+	False here lets the patch log-and-skip rather than fail migrate.
+	"""
+	rows = frappe.db.sql(
+		"""
+		SELECT column_name FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = %s
+		""",
+		(table,),
+	)
+	present = {r[0] for r in rows}
+	return all(c in present for c in columns)
+
+
+def _add_index_if_missing(table: str, index_name: str, columns: tuple):
+	if _index_exists(table, index_name):
+		return
+	if not _table_has_columns(table, columns):
+		frappe.log_error(
+			title=f"add_jewellery_perf_indexes: skip {index_name}",
+			message=(
+				f"Table `{table}` is missing one or more of {columns}; "
+				"index not added. Re-run after the doctype is fully migrated."
+			),
+		)
+		return
+	col_list = ", ".join(f"`{c}`" for c in columns)
+	frappe.db.sql(f"ALTER TABLE `{table}` ADD INDEX `{index_name}` ({col_list})")
+
+
+def execute():
+	specs = (
+		# Cancel-cascade and idempotency lookups by voucher across MOP Log.
+		# Hot path: Employee IR cancel (Issue + Receive) bulk-flips
+		# is_cancelled for every row of the voucher.
+		(
+			"tabMOP Log",
+			"mop_voucher_cancel_idx",
+			("voucher_type", "voucher_no", "is_cancelled"),
+		),
+		# Employee IR Issue lookup JOIN in
+		# resolve_employee_ir_issue_voucher_for_receive: filters by
+		# docstatus + type, orders by modified DESC. Adding ``modified`` to
+		# the index lets the optimizer use it for the ORDER BY too.
+		(
+			"tabEmployee IR",
+			"eir_docstatus_type_modified_idx",
+			("docstatus", "type", "modified"),
+		),
+		# Employee IR Operation existence check and JOIN. ``parent`` is
+		# Frappe-standard auto-indexed; the composite gives the optimizer
+		# a covering path for (parent, manufacturing_operation) lookups.
+		(
+			"tabEmployee IR Operation",
+			"eiro_parent_mop_idx",
+			("parent", "manufacturing_operation"),
+		),
+		# Employee IR Operation draft-state validation in stock_entry.py.
+		(
+			"tabEmployee IR Operation",
+			"eiro_mwo_docstatus_idx",
+			("manufacturing_work_order", "docstatus"),
+		),
+		# Department IR Operation draft-state validation in stock_entry.py.
+		(
+			"tabDepartment IR Operation",
+			"diro_mwo_docstatus_idx",
+			("manufacturing_work_order", "docstatus"),
+		),
+	)
+	for table, index_name, columns in specs:
+		_add_index_if_missing(table, index_name, columns)

--- a/jewellery_erpnext/patches/add_make_receive_entry_indexes.py
+++ b/jewellery_erpnext/patches/add_make_receive_entry_indexes.py
@@ -1,0 +1,71 @@
+import frappe
+
+
+def _index_exists(table: str, index_name: str) -> bool:
+	return bool(
+		frappe.db.sql(
+			"""
+			SELECT 1 FROM information_schema.statistics
+			WHERE table_schema = DATABASE()
+			  AND table_name = %s
+			  AND index_name = %s
+			LIMIT 1
+			""",
+			(table, index_name),
+		)
+	)
+
+
+def execute():
+	"""Add composite btree indexes for the Make Receive Entry / MOP Log hot path.
+
+	Targets: latest-balance lookups on tabMOP Log (per MOP and per MWO),
+	active-SRE filters on tabStock Reservation Entry, batch fan-out on
+	tabSerial and Batch Entry, the already-received aggregation over Material
+	Receive Stock Entries, and the per-row Stock Entry Detail filter used for
+	the same aggregation.
+	"""
+	specs = (
+		(
+			"tabMOP Log",
+			"mop_balance_idx",
+			(
+				"manufacturing_operation",
+				"is_cancelled",
+				"item_code",
+				"batch_no",
+				"creation",
+			),
+		),
+		(
+			"tabMOP Log",
+			"mop_mwo_idx",
+			("manufacturing_work_order", "is_cancelled", "item_code", "batch_no"),
+		),
+		(
+			"tabStock Reservation Entry",
+			"sre_mwo_active_idx",
+			("manufacturing_work_order", "docstatus"),
+		),
+		(
+			"tabSerial and Batch Entry",
+			"sbe_parent_batch_idx",
+			("parent", "batch_no"),
+		),
+		(
+			"tabStock Entry",
+			"se_mr_wo_idx",
+			("manufacturing_work_order", "stock_entry_type", "docstatus"),
+		),
+		(
+			"tabStock Entry Detail",
+			"sed_parent_item_wh_idx",
+			("parent", "item_code", "s_warehouse", "batch_no"),
+		),
+	)
+	for table, index_name, columns in specs:
+		if _index_exists(table, index_name):
+			continue
+		# Column names are hard-coded literals from this module — no user input.
+		col_list = ", ".join(f"`{c}`" for c in columns)
+		frappe.db.sql(f"ALTER TABLE `{table}` ADD INDEX `{index_name}` ({col_list})")


### PR DESCRIPTION
- Introduced tests for float weight fields precision in employee IR operations and loss details, ensuring they adhere to a precision of 3.
- Updated `get_make_receive_entry_rows` to return structured results, including active SRE count and skipped reasons.
- Enhanced tests to validate MWO-level scope for make receive entry, ensuring sibling MOPs are correctly handled.
- Added new indexes for performance optimization in make receive entry and related operations.
- Implemented diagnostic tests for the make receive entry popup to handle various scenarios regarding SRE availability and MOP log presence.