### PR TITLE
feat: Add tests for Stock Entry Detail precision and validate PCS bat…

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/customization/stock_entry/doc_events/se_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/customization/stock_entry/doc_events/se_utils.py
@@ -112,8 +112,15 @@ def validate_inventory_dimention(self):
 							)
 
 
-def get_fifo_batches(self, row):
+def get_fifo_batches(self, row, consumed=None):
 	rows_to_append = []
+	# `consumed` tracks how much has already been allocated per (warehouse, batch)
+	# across all rows of the same document. Callers that process multiple rows for
+	# the same item must pass a shared dict so a batch is not double-booked (which
+	# would otherwise push it negative on submit). Defaults to a fresh dict so
+	# single-row callers behave exactly as before.
+	if consumed is None:
+		consumed = {}
 	row.batch_no = None
 	total_qty = row.qty
 	existing_updated = False
@@ -128,6 +135,11 @@ def get_fifo_batches(self, row):
 		main_slip = self.main_slip or self.to_main_slip
 		batch_data = get_batch_data_from_msl(row.item_code, main_slip, row.s_warehouse)
 	else:
+		# NOTE: do not pass "qty" here. get_auto_batch_nos truncates the result to
+		# just enough FIFO batches to cover the requested qty, which can drop the
+		# Customer Goods / customer-specific batches before the inventory-type and
+		# customer filtering below runs. Fetch all available batches and let the
+		# loop pick the matching ones up to total_qty.
 		batch_data = get_auto_batch_nos(
 			frappe._dict(
 				{
@@ -135,7 +147,6 @@ def get_fifo_batches(self, row):
 					"posting_date": self.get("posting_date"),
 					"item_code": row.item_code,
 					"warehouse": warehouse,
-					"qty": row.qty,
 				}
 			)
 		)
@@ -183,6 +194,11 @@ def get_fifo_batches(self, row):
 	if not row.inventory_type:
 		row.inventory_type = "Regular Stock"
 	for batch in batch_data:
+		# reduce this batch's availability by what earlier rows already took
+		batch_key = (warehouse, batch.batch_no)
+		batch.qty = flt(batch.qty - consumed.get(batch_key, 0), 4)
+		if batch.qty <= 0:
+			continue
 		if (
 			row.inventory_type in ["Customer Goods", "Customer Stock"]
 			and frappe.db.get_value("Batch", batch.batch_no, "custom_inventory_type")
@@ -198,17 +214,23 @@ def get_fifo_batches(self, row):
 					else:
 						row.db_set("transfer_qty", row.qty)
 						row.db_set("batch_no", batch.batch_no)
+					consumed[batch_key] = consumed.get(batch_key, 0) + min(
+						total_qty, batch.qty
+					)
 					total_qty -= batch.qty
 					existing_updated = True
-					rows_to_append.append(row.__dict__)
+					rows_to_append.append(row.as_dict())
 				else:
-					temp_row = copy.deepcopy(row.__dict__)
+					temp_row = copy.deepcopy(row.as_dict())
 					temp_row["name"] = None
 					temp_row["idx"] = None
 					temp_row["batch_no"] = batch.batch_no
 					temp_row["transfer_qty"] = 0
 					temp_row["qty"] = flt(min(total_qty, batch.qty), 4)
 					rows_to_append.append(temp_row)
+					consumed[batch_key] = consumed.get(batch_key, 0) + min(
+						total_qty, batch.qty
+					)
 					total_qty -= batch.qty
 
 		elif (
@@ -225,17 +247,23 @@ def get_fifo_batches(self, row):
 					else:
 						row.db_set("transfer_qty", row.qty)
 						row.db_set("batch_no", batch.batch_no)
+					consumed[batch_key] = consumed.get(batch_key, 0) + min(
+						total_qty, batch.qty
+					)
 					total_qty -= batch.qty
 					existing_updated = True
-					rows_to_append.append(row.__dict__)
+					rows_to_append.append(row.as_dict())
 				else:
-					temp_row = copy.deepcopy(row.__dict__)
+					temp_row = copy.deepcopy(row.as_dict())
 					temp_row["name"] = None
 					temp_row["idx"] = None
 					temp_row["batch_no"] = batch.batch_no
 					temp_row["transfer_qty"] = 0
 					temp_row["qty"] = flt(min(total_qty, batch.qty), 4)
 					rows_to_append.append(temp_row)
+					consumed[batch_key] = consumed.get(batch_key, 0) + min(
+						total_qty, batch.qty
+					)
 					total_qty -= batch.qty
 
 		elif row.inventory_type not in ["Customer Goods", "Customer Stock"]:
@@ -252,6 +280,9 @@ def get_fifo_batches(self, row):
 					else:
 						row.db_set("transfer_qty", row.qty)
 						row.db_set("batch_no", batch.batch_no)
+					consumed[batch_key] = consumed.get(batch_key, 0) + min(
+						total_qty, batch.qty
+					)
 					total_qty -= batch.qty
 					existing_updated = True
 					rows_to_append.append(row.as_dict())
@@ -263,6 +294,9 @@ def get_fifo_batches(self, row):
 					temp_row["transfer_qty"] = 0
 					temp_row["qty"] = flt(min(total_qty, batch.qty), 4)
 					rows_to_append.append(temp_row)
+					consumed[batch_key] = consumed.get(batch_key, 0) + min(
+						total_qty, batch.qty
+					)
 					total_qty -= batch.qty
 
 	if round(total_qty, 3) > 0:
@@ -328,7 +362,7 @@ def create_repack_for_subcontracting(self, subcontractor, main_slip=None):
 	repack_raws = []
 	receive = False
 	for row in self.items:
-		temp_raw = copy.deepcopy(row.__dict__)
+		temp_raw = copy.deepcopy(row.as_dict())
 		if row.t_warehouse == raw_warehouse:
 			receive = True
 			temp_raw["name"] = None

--- a/jewellery_erpnext/jewellery_erpnext/customization/stock_entry/stock_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/customization/stock_entry/stock_entry.py
@@ -55,6 +55,9 @@ class CustomStockEntry(StockEntry):
 	def update_batches(self):
 		if not self.auto_created:
 			rows_to_append = []
+			# shared across rows so the same batch is not double-allocated when
+			# multiple rows draw from the same item/warehouse (see get_fifo_batches)
+			consumed = {}
 			for row in self.items:
 				if (
 					row.get("department")
@@ -81,7 +84,7 @@ class CustomStockEntry(StockEntry):
 							temp_row = copy.deepcopy(row)
 							rows_to_append += [temp_row]
 						else:
-							rows_to_append += get_fifo_batches(self, row)
+							rows_to_append += get_fifo_batches(self, row, consumed)
 					elif row.t_warehouse:
 						rows_to_append += [row.__dict__]
 				else:

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/stock_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/stock_entry.py
@@ -185,13 +185,43 @@ def validate_ir(self):
 
 
 def validate_pcs(self):
-	pcs_data = {}
+	# A single Material Request Item's qty can be split across several batch
+	# rows (see get_fifo_batches). The MR Item's PCS is the authoritative total
+	# for that item; it must be carried by exactly one row's worth of count so
+	# the per-item PCS is not multiplied by the number of batches.
+	#
+	# Historically every row after the first was zeroed — but a batch row that
+	# physically holds stock should never read 0 PCS. So each extra batch row
+	# now defaults to 1, and the first row absorbs the deduction. The per-item
+	# total is preserved: e.g. 71 split across two batches → 70 + 1 (not 71 + 0).
+	#
+	# The total is read from the MR Item (not the rows) so this stays idempotent
+	# when re-run on already-split rows — e.g. the MOP Stock Entry is a copy of
+	# the reserve Stock Entry and runs before_validate again.
+	rows_by_mri = {}
 	for row in self.items:
 		if row.material_request_item:
-			if pcs_data.get(row.material_request_item):
-				row.pcs = 0
-			else:
-				pcs_data[row.material_request_item] = row.pcs
+			rows_by_mri.setdefault(row.material_request_item, []).append(row)
+
+	for mri, rows in rows_by_mri.items():
+		if len(rows) <= 1:
+			continue
+		total = cint(frappe.db.get_value("Material Request Item", mri, "pcs"))
+		if total <= 0:
+			# No authoritative total — leave the rows untouched.
+			continue
+		first, extras = rows[0], rows[1:]
+		if total > len(extras):
+			# Enough to keep at least 1 on every row.
+			for r in extras:
+				r.pcs = 1
+			first.pcs = total - len(extras)
+		else:
+			# Not enough PCS to spread one-each; keep the whole count on the
+			# first row (prior behaviour) rather than driving it below 1.
+			for r in extras:
+				r.pcs = 0
+			first.pcs = total
 	self.flags.ignore_mandatory = True
 
 
@@ -1488,7 +1518,7 @@ def group_se_items_and_update_mop_items(doc, method):
 	doc.set("custom_mop_items", [])
 
 	for row in doc.items:
-		mop_row = copy.deepcopy(row.__dict__)
+		mop_row = copy.deepcopy(row.as_dict())
 		mop_row["name"] = None
 		mop_row["idx"] = None
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/loss_stock_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/loss_stock_entry.py
@@ -474,6 +474,9 @@ def _build_combined_loss_se(eir, pending):
 		qty = entry["qty"]
 		entry_mwo = entry["mwo"]
 		mop = getattr(row, "manufacturing_operation", None)
+		# Carry the loss row's pcs onto both SE rows; fall back to "1" so a
+		# missing value preserves the field default and stays valid (reqd).
+		pcs = getattr(row, "pcs", None) or "1"
 
 		# Consume row: source item out of SRE warehouse.
 		se.append(
@@ -482,6 +485,7 @@ def _build_combined_loss_se(eir, pending):
 				"item_code": row.item_code,
 				"qty": qty,
 				"transfer_qty": qty,
+				"pcs": pcs,
 				"s_warehouse": entry["s_warehouse"],
 				"t_warehouse": None,
 				"batch_no": row.batch_no,
@@ -502,6 +506,7 @@ def _build_combined_loss_se(eir, pending):
 				"item_code": entry["loss_item"],
 				"qty": qty,
 				"transfer_qty": qty,
+				"pcs": pcs,
 				"s_warehouse": None,
 				"t_warehouse": entry["t_warehouse"],
 				"uom": row.stock_uom or "Gram",
@@ -521,6 +526,36 @@ def _build_combined_loss_se(eir, pending):
 # ---------------------------------------------------------------------------
 # SRE reduction and restoration
 # ---------------------------------------------------------------------------
+
+
+def _reservation_voucher_qty(sre_doc, reserved_qty):
+	"""voucher_qty that lets reserved_qty clear validate_with_allowed_qty.
+
+	SO lines are routinely over-reserved by sibling MWO reservations, so
+	recreating even a reduced reservation trips ERPNext's allowed-qty guard.
+	Mirror stock_reservation_entry_for_mwo (doc_events/stock_entry.py): lift
+	voucher_qty to cover already-reserved qty + this entry's qty.
+	"""
+	base = flt(sre_doc.voucher_qty)
+	if (
+		sre_doc.voucher_type != "Sales Order"
+		or not sre_doc.voucher_no
+		or not sre_doc.voucher_detail_no
+	):
+		return base
+
+	from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+		get_sre_reserved_qty_for_voucher_detail_no,
+	)
+
+	total_so_reserved = get_sre_reserved_qty_for_voucher_detail_no(
+		sre_doc.item_code,
+		"Sales Order",
+		sre_doc.voucher_no,
+		sre_doc.voucher_detail_no,
+		ignore_sre=sre_doc.name,
+	)
+	return max(base, flt(total_so_reserved) + flt(reserved_qty))
 
 
 def _reduce_sre(eir, row, sre_doc, loss_qty, table_name):
@@ -544,6 +579,7 @@ def _reduce_sre(eir, row, sre_doc, loss_qty, table_name):
 	new_sre.amended_from = None
 	new_sre.status = "Draft"
 	new_sre.reserved_qty = new_qty
+	new_sre.voucher_qty = _reservation_voucher_qty(sre_doc, new_qty)
 	new_sre.available_qty = max(flt(sre_doc.available_qty), new_qty)
 	new_sre.custom_replaced_sre_snapshot = json.dumps(
 		{
@@ -597,6 +633,7 @@ def _restore_reduced_sres(eir):
 		restored.amended_from = None
 		restored.status = "Draft"
 		restored.reserved_qty = orig_qty
+		restored.voucher_qty = _reservation_voucher_qty(sre_doc, orig_qty)
 		restored.available_qty = max(flt(sre_doc.available_qty), orig_qty)
 		restored.custom_replaced_sre_snapshot = None
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/main_slip_inject.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/doc_events/main_slip_inject.py
@@ -51,6 +51,7 @@ runs for SE types listed in **MOP Settings → Stock Entry Type To Reservation**
 from __future__ import annotations
 
 import frappe
+from erpnext.stock.doctype.batch.batch import get_batch_qty
 from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
 	get_auto_batch_nos,
 )
@@ -122,6 +123,21 @@ def _expand_source_rows_for_fifo(se, row):
 		consider_negative_batches=False,
 	)
 	batches = get_auto_batch_nos(kwargs) or []
+
+	# Transfer rows land in a MOP department warehouse where the EIR injection then
+	# creates a Stock Reservation Entry. ERPNext's SRE before_submit independently
+	# re-checks batch availability, so a plain FIFO pick can choose a batch that is
+	# already over-reserved at the destination and blow up with "Stock not available
+	# to reserve ... against Batch ...". Prefer source batches that are reservable at
+	# the destination; fall back to the plain FIFO result if none can cover `need`.
+	t_wh = row.get("t_warehouse") if isinstance(row, dict) else row.t_warehouse
+	if t_wh:
+		reservable = _select_fifo_batches_reservable_at_dest(
+			se, item_code, s_wh, t_wh, need
+		)
+		if reservable is not None:
+			batches = reservable
+
 	got = 0.0
 	positive = []
 	positive_batches = []
@@ -164,6 +180,97 @@ def _expand_source_rows_for_fifo(se, row):
 			line["customer"] = inv["custom_customer"]
 		out.append(line)
 	return out
+
+
+def _select_fifo_batches_reservable_at_dest(se, item_code, s_wh, t_wh, need):
+	"""Pick FIFO source batches that can also be *reserved* at the destination.
+
+	Walks the source warehouse batches in FIFO order, skips any batch that is
+	already over-reserved at ``t_wh`` (existing Stock Reservation Entries exceed
+	the batch's actual qty there), and allocates ``need`` across the rest. Returns
+	a list of ``frappe._dict(batch_no, qty)`` that covers ``need``, or ``None``
+	when the reservable batches cannot cover it (caller falls back to plain FIFO).
+	"""
+	all_batches = (
+		get_auto_batch_nos(
+			frappe._dict(
+				posting_date=se.posting_date,
+				posting_time=se.posting_time,
+				item_code=item_code,
+				warehouse=s_wh,
+				for_stock_levels=False,
+				consider_negative_batches=False,
+			)
+		)
+		or []
+	)
+	candidates = [b for b in all_batches if flt(b.get("qty")) > 0]
+	if not candidates:
+		return None
+
+	# Deterministic FIFO order by Batch creation, then batch name.
+	creation = {
+		b["name"]: b.get("creation")
+		for b in frappe.db.get_all(
+			"Batch",
+			filters={"name": ["in", [c.batch_no for c in candidates]]},
+			fields=["name", "creation"],
+		)
+	}
+	candidates.sort(key=lambda c: (creation.get(c.batch_no) or "", c.batch_no))
+
+	# Destination actual qty (ignoring reservations) and active reserved qty,
+	# per batch — one round-trip each.
+	dest_actual = {
+		d["batch_no"]: flt(d.get("qty"))
+		for d in (
+			get_batch_qty(
+				item_code=item_code, warehouse=t_wh, ignore_reserved_stock=True
+			)
+			or []
+		)
+	}
+	dest_reserved = {
+		r["batch_no"]: flt(r["qty"])
+		for r in frappe.db.sql(
+			"""
+			SELECT sbe.batch_no AS batch_no,
+			       SUM(sbe.qty - IFNULL(sbe.delivered_qty, 0)) AS qty
+			FROM `tabSerial and Batch Entry` sbe
+			JOIN `tabStock Reservation Entry` sre ON sbe.parent = sre.name
+			WHERE sre.docstatus = 1
+			  AND sre.item_code = %s
+			  AND sbe.warehouse = %s
+			GROUP BY sbe.batch_no
+			""",
+			(item_code, t_wh),
+			as_dict=True,
+		)
+	}
+
+	eps = 1e-6
+	allocation = []
+	remaining = need
+	for b in candidates:
+		if remaining <= eps:
+			break
+		# Over-reserved at the destination: even after the transfer adds qty, the
+		# batch's available-to-reserve would stay <= 0, so ERPNext would reject it.
+		if (
+			flt(dest_actual.get(b.batch_no, 0.0))
+			- flt(dest_reserved.get(b.batch_no, 0.0))
+			< -eps
+		):
+			continue
+		take = min(flt(b.qty), remaining)
+		if take <= eps:
+			continue
+		allocation.append(frappe._dict(batch_no=b.batch_no, qty=round(take, 6)))
+		remaining = round(remaining - take, 6)
+
+	if remaining > eps:
+		return None
+	return allocation
 
 
 def _apply_fifo_batches_to_stock_entry(se):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/employee_ir.py
@@ -58,6 +58,10 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 	create_mop_log_for_employee_ir_receive,
 	creste_mop_log_for_employee_ir,
 )
+from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+	_get_t_warehouse_from_logs,
+	_resolve_department_warehouse,
+)
 from jewellery_erpnext.utils import (
 	get_item_from_attribute_full,
 )
@@ -390,8 +394,32 @@ class EmployeeIR(Document):
 				# metadata (loss_weight, loss_source_row, loss_type) lives on
 				# the combined receive row itself, and MOPLog.validate updates
 				# Manufacturing Operation buckets exactly once.
+				# The receive audit clones land on the SOURCE MOP, which may
+				# belong to a different department than the EIR header. Resolve
+				# a guaranteed destination so to_warehouse is never blank:
+				# header department WH -> row MOP's department WH -> latest
+				# non-null to_warehouse already on the MWO's logs. Fallback only;
+				# we never block the submit (see _resolve_department_warehouse /
+				# _get_t_warehouse_from_logs in mop_eod_sync).
+				row_to_wh = department_wh
+				if not row_to_wh:
+					row_to_wh = _resolve_department_warehouse(
+						frappe.get_cached_doc(
+							"Manufacturing Operation", row.manufacturing_operation
+						)
+					) or _get_t_warehouse_from_logs(
+						frappe.get_all(
+							"MOP Log",
+							filters={
+								"manufacturing_work_order": row.manufacturing_work_order,
+								"is_cancelled": 0,
+							},
+							fields=["to_warehouse", "flow_index", "creation"],
+						)
+					)
+
 				create_mop_log_for_employee_ir_receive(
-					self, row, actor_wh, department_wh, stock_entry_name
+					self, row, actor_wh, row_to_wh, stock_entry_name
 				)
 
 				# update_new_mop_wtg now does both jobs in one pass:
@@ -404,7 +432,7 @@ class EmployeeIR(Document):
 					employee_ir_doc=self,
 					employee_ir_operation_row=row,
 					from_warehouse=actor_wh,
-					to_warehouse=department_wh,
+					to_warehouse=row_to_wh,
 				)
 			else:
 				for sre in frappe.db.get_all(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/test_main_slip_inject.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/employee_ir/test_main_slip_inject.py
@@ -70,7 +70,9 @@ class TestMainSlipInjectIdempotency(FrappeTestCase):
 	def test_existing_repack_se_short_circuits(self):
 		eir = _eir()
 		row = _row()
-		with patch.object(msi, "_resolve_department_warehouse", return_value="WH-Dept"), patch.object(
+		with patch.object(
+			msi, "_resolve_department_warehouse", return_value="WH-Dept"
+		), patch.object(
 			msi, "_existing_injection_se", return_value=True
 		) as mock_exists, patch.object(
 			msi, "_resolve_inject_metal_items"
@@ -123,7 +125,9 @@ class TestMainSlipInjectMetalResolution(FrappeTestCase):
 		mock_get_item.side_effect = _item_for
 		items = msi._resolve_inject_metal_items("MWO-1", 3.0)
 		self.assertEqual(len(items), 3)
-		self.assertEqual([i["item_code"] for i in items], ["M-G-18KT-Y", "M-G-18KT-W", "M-G-18KT-R"])
+		self.assertEqual(
+			[i["item_code"] for i in items], ["M-G-18KT-Y", "M-G-18KT-W", "M-G-18KT-R"]
+		)
 		for i in items:
 			self.assertAlmostEqual(i["qty"], 1.0)
 
@@ -203,7 +207,9 @@ class TestFallbackInjectSegments(FrappeTestCase):
 			"multicolour": 0,
 			"allowed_colours": "",
 		}
-		segs = msi._resolve_fallback_inject_segments(_eir(main_slip=None), "MWO-1", 2.0, "WH-Dept")
+		segs = msi._resolve_fallback_inject_segments(
+			_eir(main_slip=None), "MWO-1", 2.0, "WH-Dept"
+		)
 		self.assertEqual(len(segs), 1)
 		self.assertEqual(segs[0]["mode"], "transfer")
 		self.assertEqual(segs[0]["item_code"], "M-G-18KT-Y")
@@ -232,13 +238,17 @@ class TestFallbackInjectSegments(FrappeTestCase):
 
 		mock_purity.side_effect = lambda ic: _purity(ic)
 
-		segs = msi._resolve_fallback_inject_segments(_eir(main_slip=None), "MWO-1", 2.0, "WH-Dept")
+		segs = msi._resolve_fallback_inject_segments(
+			_eir(main_slip=None), "MWO-1", 2.0, "WH-Dept"
+		)
 		self.assertEqual(len(segs), 1)
 		self.assertEqual(segs[0]["mode"], "purity")
 		self.assertEqual(segs[0]["source_item"], "M-G-24KT")
 		self.assertEqual(segs[0]["target_item"], "M-G-18KT-Y")
 		self.assertEqual(segs[0]["produce_qty"], 2.0)
-		self.assertAlmostEqual(segs[0]["consume_qty"], round(2.0 * 75.4 / 99.9, 3), places=3)
+		self.assertAlmostEqual(
+			segs[0]["consume_qty"], round(2.0 * 75.4 / 99.9, 3), places=3
+		)
 
 	@patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Emp")
 	def test_partial_alloy_emits_transfer_plus_purity(self, mock_src_wh):
@@ -266,7 +276,9 @@ class TestFallbackInjectSegments(FrappeTestCase):
 				return {"M-G-24KT": 99.9, "M-G-18KT-Y": 75.4}.get(item)
 
 			mock_purity.side_effect = lambda ic: _purity(ic)
-			segs = msi._resolve_fallback_inject_segments(_eir(main_slip=None), "MWO-1", 2.0, "WH-Dept")
+			segs = msi._resolve_fallback_inject_segments(
+				_eir(main_slip=None), "MWO-1", 2.0, "WH-Dept"
+			)
 
 		self.assertEqual(len(segs), 2)
 		self.assertEqual(segs[0]["mode"], "transfer")
@@ -278,7 +290,9 @@ class TestFallbackInjectSegments(FrappeTestCase):
 class TestBuildStockEntryFromFallbackSegments(FrappeTestCase):
 	@patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1")
 	@patch(f"{_MSI_PATH}.frappe.new_doc")
-	def test_material_transfer_segments_stamped_to_mop(self, mock_new_doc, mock_get_value):
+	def test_material_transfer_segments_stamped_to_mop(
+		self, mock_new_doc, mock_get_value
+	):
 		se = MagicMock()
 		se.items = []
 		se.append.side_effect = lambda _, payload: se.items.append(payload)
@@ -295,7 +309,9 @@ class TestBuildStockEntryFromFallbackSegments(FrappeTestCase):
 				"t_warehouse": "WH-Dept",
 			}
 		]
-		msi._build_material_transfer_from_segments(eir, row, segments, "WH-Emp", "WH-Dept")
+		msi._build_material_transfer_from_segments(
+			eir, row, segments, "WH-Emp", "WH-Dept"
+		)
 
 		self.assertEqual(se.stock_entry_type, "Material Transfer (WORK ORDER)")
 		self.assertEqual(se.employee_ir, "EIR-R-001")
@@ -306,7 +322,9 @@ class TestBuildStockEntryFromFallbackSegments(FrappeTestCase):
 
 	@patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1")
 	@patch(f"{_MSI_PATH}.frappe.new_doc")
-	def test_repack_purity_segments_consume_produce_stamped_to_mop(self, mock_new_doc, mock_get_value):
+	def test_repack_purity_segments_consume_produce_stamped_to_mop(
+		self, mock_new_doc, mock_get_value
+	):
 		se = MagicMock()
 		se.items = []
 		se.append.side_effect = lambda _, payload: se.items.append(payload)
@@ -381,9 +399,21 @@ class TestMainSlipBatchIterator(FrappeTestCase):
 	@patch(f"{_MSI_PATH}.frappe.db.get_all")
 	def test_priority_order_regular_then_customer_then_pure(self, mock_get_all):
 		mock_get_all.return_value = [
-			_batch_row(name="B-PURE", inventory_type="Pure Metal", creation="2026-04-01 00:00:00"),
-			_batch_row(name="B-REG", inventory_type="Regular Stock", creation="2026-04-02 00:00:00"),
-			_batch_row(name="B-CUST", inventory_type="Customer Goods", creation="2026-04-03 00:00:00"),
+			_batch_row(
+				name="B-PURE",
+				inventory_type="Pure Metal",
+				creation="2026-04-01 00:00:00",
+			),
+			_batch_row(
+				name="B-REG",
+				inventory_type="Regular Stock",
+				creation="2026-04-02 00:00:00",
+			),
+			_batch_row(
+				name="B-CUST",
+				inventory_type="Customer Goods",
+				creation="2026-04-03 00:00:00",
+			),
 		]
 		ordered = [r["name"] for r in msi._iter_main_slip_batches("MS-001")]
 		self.assertEqual(ordered, ["B-REG", "B-CUST", "B-PURE"])
@@ -414,30 +444,49 @@ class TestMainSlipInjectViaBatches(FrappeTestCase):
 
 		# inject_extra_metal_for_eir_receive resolves target items and dept wh
 		stack.append(
-			patch(f"{_MSI_PATH}._resolve_inject_metal_items", return_value=[{"item_code": target_item, "qty": 2.0}])
+			patch(
+				f"{_MSI_PATH}._resolve_inject_metal_items",
+				return_value=[{"item_code": target_item, "qty": 2.0}],
+			)
 		)
-		stack.append(patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"))
-		stack.append(patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"))
+		stack.append(
+			patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept")
+		)
+		stack.append(
+			patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src")
+		)
 		stack.append(patch(f"{_MSI_PATH}._existing_injection_se", return_value=False))
 		return submitted
 
 	@patch(f"{_MSI_PATH}.frappe.new_doc")
 	@patch(f"{_MSI_PATH}._iter_main_slip_batches")
 	def test_regular_stock_emits_material_transfer(self, mock_iter, mock_new_doc):
-		mock_iter.return_value = iter([
-			_batch_row(item_code="M-G-18KT-Y", inventory_type="Regular Stock", qty=3.0, consume_qty=0.0) | {"available_qty": 3.0},
-		])
+		mock_iter.return_value = iter(
+			[
+				_batch_row(
+					item_code="M-G-18KT-Y",
+					inventory_type="Regular Stock",
+					qty=3.0,
+					consume_qty=0.0,
+				)
+				| {"available_qty": 3.0},
+			]
+		)
 		se = MagicMock()
 		se.items = []
 		se.append.side_effect = lambda _, payload: se.items.append(payload)
 		mock_new_doc.return_value = se
 
-		with patch(f"{_MSI_PATH}._resolve_inject_metal_items", return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}]), \
-			 patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"), \
-			 patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"), \
-			 patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), \
-			 patch(f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"), \
-			 patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
+		with patch(
+			f"{_MSI_PATH}._resolve_inject_metal_items",
+			return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}],
+		), patch(
+			f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"
+		), patch(
+			f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"
+		), patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), patch(
+			f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"
+		), patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
 			out = msi.inject_extra_metal_for_eir_receive(_eir(main_slip="MS-1"), _row())
 
 		self.assertEqual(len(out), 1)
@@ -446,15 +495,27 @@ class TestMainSlipInjectViaBatches(FrappeTestCase):
 		self.assertEqual(len(se.items), 1)
 		self.assertEqual(se.items[0]["qty"], 2.0)
 		self.assertEqual(se.items[0]["t_warehouse"], "WH-Dept")
-		self.assertEqual(se.items[0]["manufacturing_operation"], _row().manufacturing_operation)
+		self.assertEqual(
+			se.items[0]["manufacturing_operation"], _row().manufacturing_operation
+		)
 
 	@patch(f"{_MSI_PATH}.frappe.new_doc")
 	@patch(f"{_MSI_PATH}._iter_main_slip_batches")
-	def test_subcontracting_pure_metal_emits_repack_with_purity_conversion(self, mock_iter, mock_new_doc):
+	def test_subcontracting_pure_metal_emits_repack_with_purity_conversion(
+		self, mock_iter, mock_new_doc
+	):
 		# Source 24KT pure, target 18KT (75%) alloy.
-		mock_iter.return_value = iter([
-			_batch_row(item_code="M-G-24KT", inventory_type="Pure Metal", qty=5.0, consume_qty=0.0) | {"available_qty": 5.0},
-		])
+		mock_iter.return_value = iter(
+			[
+				_batch_row(
+					item_code="M-G-24KT",
+					inventory_type="Pure Metal",
+					qty=5.0,
+					consume_qty=0.0,
+				)
+				| {"available_qty": 5.0},
+			]
+		)
 		se = MagicMock()
 		se.items = []
 		se.append.side_effect = lambda _, payload: se.items.append(payload)
@@ -468,14 +529,23 @@ class TestMainSlipInjectViaBatches(FrappeTestCase):
 					return "75.4"
 			return "PMO-1"
 
-		with patch(f"{_MSI_PATH}._resolve_inject_metal_items", return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}]), \
-			 patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"), \
-			 patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Sub"), \
-			 patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), \
-			 patch(f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"), \
-			 patch(f"{_MSI_PATH}.frappe.db.get_value", side_effect=_fake_get_value):
+		with patch(
+			f"{_MSI_PATH}._resolve_inject_metal_items",
+			return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}],
+		), patch(
+			f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"
+		), patch(
+			f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Sub"
+		), patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), patch(
+			f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"
+		), patch(f"{_MSI_PATH}.frappe.db.get_value", side_effect=_fake_get_value):
 			out = msi.inject_extra_metal_for_eir_receive(
-				_eir(main_slip="MS-1", subcontracting="Yes", subcontractor="SUB-1", employee=None),
+				_eir(
+					main_slip="MS-1",
+					subcontracting="Yes",
+					subcontractor="SUB-1",
+					employee=None,
+				),
 				_row(),
 			)
 
@@ -488,7 +558,9 @@ class TestMainSlipInjectViaBatches(FrappeTestCase):
 		self.assertEqual(consume["s_warehouse"], "WH-Sub")
 		self.assertEqual(produce["item_code"], "M-G-18KT-Y")
 		self.assertEqual(produce["t_warehouse"], "WH-Dept")
-		self.assertEqual(produce["manufacturing_operation"], _row().manufacturing_operation)
+		self.assertEqual(
+			produce["manufacturing_operation"], _row().manufacturing_operation
+		)
 		# produce_qty = consume_qty * 75.4 / 99.9 -> we requested 2.0 produced
 		# so consume should be 2.0 * 75.4 / 99.9
 		self.assertAlmostEqual(produce["qty"], 2.0, places=3)
@@ -498,20 +570,32 @@ class TestMainSlipInjectViaBatches(FrappeTestCase):
 	@patch(f"{_MSI_PATH}._iter_main_slip_batches")
 	def test_insufficient_batches_throws(self, mock_iter, mock_new_doc):
 		# Only 1g available but we need 2g.
-		mock_iter.return_value = iter([
-			_batch_row(item_code="M-G-18KT-Y", inventory_type="Regular Stock", qty=1.0, consume_qty=0.0) | {"available_qty": 1.0},
-		])
+		mock_iter.return_value = iter(
+			[
+				_batch_row(
+					item_code="M-G-18KT-Y",
+					inventory_type="Regular Stock",
+					qty=1.0,
+					consume_qty=0.0,
+				)
+				| {"available_qty": 1.0},
+			]
+		)
 		se = MagicMock()
 		se.items = []
 		se.append.side_effect = lambda _, payload: se.items.append(payload)
 		mock_new_doc.return_value = se
 
-		with patch(f"{_MSI_PATH}._resolve_inject_metal_items", return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}]), \
-			 patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"), \
-			 patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"), \
-			 patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), \
-			 patch(f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"), \
-			 patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
+		with patch(
+			f"{_MSI_PATH}._resolve_inject_metal_items",
+			return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}],
+		), patch(
+			f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"
+		), patch(
+			f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"
+		), patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), patch(
+			f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"
+		), patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
 			with self.assertRaises(frappe.ValidationError):
 				msi.inject_extra_metal_for_eir_receive(_eir(main_slip="MS-1"), _row())
 
@@ -519,40 +603,226 @@ class TestMainSlipInjectViaBatches(FrappeTestCase):
 	@patch(f"{_MSI_PATH}._iter_main_slip_batches")
 	def test_batch_item_mismatch_skips_non_pure_batches(self, mock_iter, mock_new_doc):
 		# Wrong alloy in Main Slip and nothing matching -> throws short.
-		mock_iter.return_value = iter([
-			_batch_row(item_code="M-G-22KT-Y", inventory_type="Regular Stock", qty=5.0, consume_qty=0.0) | {"available_qty": 5.0},
-		])
+		mock_iter.return_value = iter(
+			[
+				_batch_row(
+					item_code="M-G-22KT-Y",
+					inventory_type="Regular Stock",
+					qty=5.0,
+					consume_qty=0.0,
+				)
+				| {"available_qty": 5.0},
+			]
+		)
 		se = MagicMock()
 		mock_new_doc.return_value = se
-		with patch(f"{_MSI_PATH}._resolve_inject_metal_items", return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}]), \
-			 patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"), \
-			 patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"), \
-			 patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), \
-			 patch(f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"), \
-			 patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
+		with patch(
+			f"{_MSI_PATH}._resolve_inject_metal_items",
+			return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}],
+		), patch(
+			f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"
+		), patch(
+			f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Src"
+		), patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), patch(
+			f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"
+		), patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
 			with self.assertRaises(frappe.ValidationError):
 				msi.inject_extra_metal_for_eir_receive(_eir(main_slip="MS-1"), _row())
 
 	@patch(f"{_MSI_PATH}.frappe.new_doc")
 	@patch(f"{_MSI_PATH}._iter_main_slip_batches")
-	def test_non_subcontracting_pure_metal_falls_to_material_transfer(self, mock_iter, mock_new_doc):
+	def test_non_subcontracting_pure_metal_falls_to_material_transfer(
+		self, mock_iter, mock_new_doc
+	):
 		# Non-subcontracting: Pure Metal is treated as a direct Material Transfer
 		# (no purity conversion). Pure Metal item MUST match target item; if it
 		# does not, the batch is skipped and the helper throws short.
-		mock_iter.return_value = iter([
-			_batch_row(item_code="M-G-18KT-Y", inventory_type="Pure Metal", qty=3.0, consume_qty=0.0) | {"available_qty": 3.0},
-		])
+		mock_iter.return_value = iter(
+			[
+				_batch_row(
+					item_code="M-G-18KT-Y",
+					inventory_type="Pure Metal",
+					qty=3.0,
+					consume_qty=0.0,
+				)
+				| {"available_qty": 3.0},
+			]
+		)
 		se = MagicMock()
 		se.items = []
 		se.append.side_effect = lambda _, payload: se.items.append(payload)
 		mock_new_doc.return_value = se
 
-		with patch(f"{_MSI_PATH}._resolve_inject_metal_items", return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}]), \
-			 patch(f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"), \
-			 patch(f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Emp"), \
-			 patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), \
-			 patch(f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"), \
-			 patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
-			out = msi.inject_extra_metal_for_eir_receive(_eir(main_slip="MS-1", subcontracting="No"), _row())
+		with patch(
+			f"{_MSI_PATH}._resolve_inject_metal_items",
+			return_value=[{"item_code": "M-G-18KT-Y", "qty": 2.0}],
+		), patch(
+			f"{_MSI_PATH}._resolve_department_warehouse", return_value="WH-Dept"
+		), patch(
+			f"{_MSI_PATH}._resolve_source_warehouse", return_value="WH-Emp"
+		), patch(f"{_MSI_PATH}._existing_injection_se", return_value=False), patch(
+			f"{_MSI_PATH}._apply_fifo_batches_to_stock_entry"
+		), patch(f"{_MSI_PATH}.frappe.db.get_value", return_value="PMO-1"):
+			out = msi.inject_extra_metal_for_eir_receive(
+				_eir(main_slip="MS-1", subcontracting="No"), _row()
+			)
 		self.assertEqual(len(out), 1)
 		self.assertEqual(se.stock_entry_type, "Material Transfer (WORK ORDER)")
+
+
+# ---------------------------------------------------------------------------
+# Destination-reservable FIFO batch selection
+# ---------------------------------------------------------------------------
+
+
+class TestSelectFifoBatchesReservableAtDest(FrappeTestCase):
+	def _se(self):
+		return SimpleNamespace(posting_date="2026-06-04", posting_time="10:00:00")
+
+	@patch(f"{_MSI_PATH}.frappe.db.sql")
+	@patch(f"{_MSI_PATH}.get_batch_qty")
+	@patch(f"{_MSI_PATH}.frappe.db.get_all")
+	@patch(f"{_MSI_PATH}.get_auto_batch_nos")
+	def test_skips_over_reserved_batch_and_picks_safe(
+		self, mock_auto, mock_get_all, mock_batch_qty, mock_sql
+	):
+		# FIFO-first batch (oldest) holds the bulk of the source stock but is
+		# over-reserved at the destination; the next batches are reservable.
+		mock_auto.return_value = [
+			frappe._dict(batch_no="B-OLD", qty=37.0),
+			frappe._dict(batch_no="B-SAFE1", qty=0.5),
+			frappe._dict(batch_no="B-SAFE2", qty=0.5),
+		]
+		mock_get_all.return_value = [
+			{"name": "B-OLD", "creation": "2026-01-01 00:00:00"},
+			{"name": "B-SAFE1", "creation": "2026-02-01 00:00:00"},
+			{"name": "B-SAFE2", "creation": "2026-03-01 00:00:00"},
+		]
+		mock_batch_qty.return_value = []  # nothing of this item physically at dest
+		mock_sql.return_value = [{"batch_no": "B-OLD", "qty": 3.8}]  # over-reserved
+
+		out = msi._select_fifo_batches_reservable_at_dest(
+			self._se(), "ITEM-1", "WH-Src", "WH-Dest", 0.035
+		)
+		self.assertIsNotNone(out)
+		self.assertEqual([a.batch_no for a in out], ["B-SAFE1"])
+		self.assertAlmostEqual(out[0].qty, 0.035)
+		# Destination actual was queried ignoring reservations.
+		self.assertEqual(mock_batch_qty.call_args[1]["warehouse"], "WH-Dest")
+		self.assertTrue(mock_batch_qty.call_args[1]["ignore_reserved_stock"])
+
+	@patch(f"{_MSI_PATH}.frappe.db.sql")
+	@patch(f"{_MSI_PATH}.get_batch_qty")
+	@patch(f"{_MSI_PATH}.frappe.db.get_all")
+	@patch(f"{_MSI_PATH}.get_auto_batch_nos")
+	def test_spills_across_multiple_safe_batches(
+		self, mock_auto, mock_get_all, mock_batch_qty, mock_sql
+	):
+		mock_auto.return_value = [
+			frappe._dict(batch_no="B-SAFE1", qty=0.02),
+			frappe._dict(batch_no="B-SAFE2", qty=0.05),
+		]
+		mock_get_all.return_value = [
+			{"name": "B-SAFE1", "creation": "2026-02-01 00:00:00"},
+			{"name": "B-SAFE2", "creation": "2026-03-01 00:00:00"},
+		]
+		mock_batch_qty.return_value = []
+		mock_sql.return_value = []
+
+		out = msi._select_fifo_batches_reservable_at_dest(
+			self._se(), "ITEM-1", "WH-Src", "WH-Dest", 0.035
+		)
+		self.assertEqual([a.batch_no for a in out], ["B-SAFE1", "B-SAFE2"])
+		self.assertAlmostEqual(out[0].qty, 0.02)
+		self.assertAlmostEqual(out[1].qty, 0.015)
+
+	@patch(f"{_MSI_PATH}.frappe.db.sql")
+	@patch(f"{_MSI_PATH}.get_batch_qty")
+	@patch(f"{_MSI_PATH}.frappe.db.get_all")
+	@patch(f"{_MSI_PATH}.get_auto_batch_nos")
+	def test_returns_none_when_no_safe_batch_covers_need(
+		self, mock_auto, mock_get_all, mock_batch_qty, mock_sql
+	):
+		mock_auto.return_value = [frappe._dict(batch_no="B-OLD", qty=37.0)]
+		mock_get_all.return_value = [
+			{"name": "B-OLD", "creation": "2026-01-01 00:00:00"}
+		]
+		mock_batch_qty.return_value = []
+		mock_sql.return_value = [{"batch_no": "B-OLD", "qty": 3.8}]
+
+		out = msi._select_fifo_batches_reservable_at_dest(
+			self._se(), "ITEM-1", "WH-Src", "WH-Dest", 0.035
+		)
+		self.assertIsNone(out)
+
+	@patch(f"{_MSI_PATH}.get_auto_batch_nos", return_value=[])
+	def test_returns_none_when_no_source_batches(self, _mock_auto):
+		out = msi._select_fifo_batches_reservable_at_dest(
+			self._se(), "ITEM-1", "WH-Src", "WH-Dest", 0.035
+		)
+		self.assertIsNone(out)
+
+
+class TestExpandSourceRowsPrefersReservableBatch(FrappeTestCase):
+	@patch(f"{_MSI_PATH}._select_fifo_batches_reservable_at_dest")
+	@patch(f"{_MSI_PATH}.frappe.db.get_all")
+	@patch(f"{_MSI_PATH}.get_auto_batch_nos")
+	@patch(f"{_MSI_PATH}.frappe.get_cached_value", return_value=1)
+	def test_transfer_row_uses_dest_reservable_selection(
+		self, _mock_item, mock_auto, mock_get_all, mock_select
+	):
+		# Plain FIFO would pick the over-reserved batch; the dest-aware selector
+		# overrides it with a reservable one.
+		mock_auto.return_value = [frappe._dict(batch_no="B-OLD", qty=0.035)]
+		mock_select.return_value = [frappe._dict(batch_no="B-SAFE1", qty=0.035)]
+		mock_get_all.return_value = [
+			{
+				"name": "B-SAFE1",
+				"custom_inventory_type": "Regular Stock",
+				"custom_customer": None,
+			}
+		]
+
+		se = SimpleNamespace(posting_date="2026-06-04", posting_time="10:00:00")
+		row = {
+			"item_code": "ITEM-1",
+			"s_warehouse": "WH-Src",
+			"t_warehouse": "WH-Dest",
+			"qty": 0.035,
+			"serial_no": None,
+			"batch_no": None,
+		}
+		out = msi._expand_source_rows_for_fifo(se, row)
+		self.assertEqual([r["batch_no"] for r in out], ["B-SAFE1"])
+		self.assertEqual(out[0]["qty"], 0.035)
+		mock_select.assert_called_once()
+
+	@patch(f"{_MSI_PATH}._select_fifo_batches_reservable_at_dest")
+	@patch(f"{_MSI_PATH}.frappe.db.get_all")
+	@patch(f"{_MSI_PATH}.get_auto_batch_nos")
+	@patch(f"{_MSI_PATH}.frappe.get_cached_value", return_value=1)
+	def test_falls_back_to_plain_fifo_when_selector_returns_none(
+		self, _mock_item, mock_auto, mock_get_all, mock_select
+	):
+		mock_auto.return_value = [frappe._dict(batch_no="B-OLD", qty=0.035)]
+		mock_select.return_value = None  # no reservable allocation -> fall back
+		mock_get_all.return_value = [
+			{
+				"name": "B-OLD",
+				"custom_inventory_type": "Regular Stock",
+				"custom_customer": None,
+			}
+		]
+
+		se = SimpleNamespace(posting_date="2026-06-04", posting_time="10:00:00")
+		row = {
+			"item_code": "ITEM-1",
+			"s_warehouse": "WH-Src",
+			"t_warehouse": "WH-Dest",
+			"qty": 0.035,
+			"serial_no": None,
+			"batch_no": None,
+		}
+		out = msi._expand_source_rows_for_fifo(se, row)
+		self.assertEqual([r["batch_no"] for r in out], ["B-OLD"])
+		mock_select.assert_called_once()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/gemstone_conversion/gemstone_conversion.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/gemstone_conversion/gemstone_conversion.py
@@ -21,9 +21,6 @@ class GemstoneConversion(Document):
 		update_fifo_batch(self)
 		self.validate_gemstone_type()
 		self.validate_target_item()
-		loss_type = ["Burn", "Broken", "Loss", "Missing"]
-		for loss in loss_type:
-			get_loss_item(self.company, self.g_source_item, loss)
 
 	def on_submit(self):
 		make_gemstone_stock_entry(self)

--- a/jewellery_erpnext/jewellery_erpnext/doctype/gemstone_conversion/test_gemstone_conversion.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/gemstone_conversion/test_gemstone_conversion.py
@@ -1,9 +1,54 @@
 # Copyright (c) 2024, Nirali and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import MagicMock, patch
+
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.doctype.main_slip.main_slip import (
+	get_item_loss_item,
+)
+from jewellery_erpnext.utils import set_items_from_attribute
 
 
 class TestGemstoneConversion(FrappeTestCase):
-	pass
+	def test_set_items_from_attribute_is_idempotent(self):
+		"""When the loss/target variant already exists but get_variant() fails to
+		match it (template has fewer attributes than the source item), the helper
+		must return the existing Item instead of re-inserting it and raising
+		DuplicateEntryError."""
+		attributes = [
+			{"item_attribute": "Gemstone Type", "attribute_value": "Synthetic"}
+		]
+		existing = frappe.get_doc({"doctype": "Item", "item_code": "GL-EXISTING-TEST"})
+
+		created_variant = MagicMock()
+		created_variant.item_code = "GL-EXISTING-TEST"
+		created_variant.attributes = []
+
+		with patch("jewellery_erpnext.utils.get_variant", return_value=None), patch(
+			"jewellery_erpnext.utils.create_variant", return_value=created_variant
+		), patch("frappe.db.exists", return_value="GL-EXISTING-TEST"), patch(
+			"frappe.get_doc", return_value=existing
+		):
+			result = set_items_from_attribute("GL", attributes)
+
+		self.assertIs(result, existing)
+		created_variant.save.assert_not_called()
+
+	def test_unconfigured_loss_type_raises_instead_of_source_item(self):
+		"""When the selected loss type has no Variant Loss Table mapping for the
+		variant, get_item_loss_item must raise a clear error rather than silently
+		falling back to the source's own template (which resolves to the source
+		item and trips 'Same Item should not allow')."""
+		with patch("frappe.db.get_value", return_value=None) as mock_get_value:
+			with self.assertRaises(frappe.ValidationError):
+				get_item_loss_item(
+					"Test Company",
+					"G-BUS-SQR-SYN-AD-5.00*5.00 MM-FC-35-PC",
+					"G",
+					"Missing",
+				)
+		# It must fail at the Variant Loss Table lookup, never reaching item creation.
+		mock_get_value.assert_called_once()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/main_slip/main_slip.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/main_slip/main_slip.py
@@ -765,12 +765,23 @@ def get_item_loss_item(company, item, variant_of="M", loss_type=None):
 			{"variant": variant_of, "loss_type": loss_type},
 			"loss_variant",
 		)
+		# Resolve strictly by loss type: when no loss variant is configured for
+		# this variant + loss type, do NOT fall back to the source's own template
+		# (that would resolve to the source item itself). Surface a clear error so
+		# the mapping can be configured in the Variant Loss Table.
+		if not variant_name:
+			frappe.throw(
+				_(
+					"No Loss Variant is configured for variant <b>{0}</b> and Loss Type "
+					"<b>{1}</b>. Please configure it in the Variant Loss Table."
+				).format(variant_of, loss_type)
+			)
 	else:
 		variant_name = frappe.db.get_value(
 			"Variant Loss Table", {"variant": variant_of}, "loss_variant"
 		)
-	if not variant_name:
-		variant_name = variant_of
+		if not variant_name:
+			variant_name = variant_of
 
 	item_attr_dict = {}
 	for row in frappe.db.get_all(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manually_book_loss_details/manually_book_loss_details.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manually_book_loss_details/manually_book_loss_details.json
@@ -144,7 +144,8 @@
    "fieldname": "manufacturing_operation",
    "fieldtype": "Link",
    "label": "Manufacturing Operation",
-   "options": "Manufacturing Operation"
+   "options": "Manufacturing Operation",
+   "reqd": 1
   },
   {
    "fetch_from": "item_code.variant_of",
@@ -164,13 +165,14 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-20 15:31:10.612099",
+ "modified": "2026-06-04 20:59:46.863770",
  "modified_by": "Administrator",
  "module": "Jewellery Erpnext",
  "name": "Manually Book Loss Details",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -27,6 +27,7 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 	get_current_mop_balance_rows,
 	get_employee_ir_loss_map,
 	get_last_mop_index,
+	get_mop_transfer_pcs_rows,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.serial_number_creator.serial_number_creator import (
 	resolve_and_validate,
@@ -3860,6 +3861,128 @@ def get_make_receive_entry_rows(manufacturing_operation):
 		mop_log_balance_map[
 			(manufacturing_operation, row.get("item_code"), row.get("batch_no"))
 		] = row
+
+	# Per-(item, batch) incoming-transfer PCS rows. Each reserved batch line
+	# maps 1:1 to a Material Transfer row, so we surface that row's OWN pcs
+	# instead of the batch-wide running balance (which is identical for every
+	# line sharing an item+batch and made the popup show the summed total).
+	all_keys: set = set()
+	for s in sres:
+		is_batch = cint(s.has_batch_no) and s.reservation_based_on != "Qty"
+		if is_batch:
+			for sb in sb_entries_by_sre.get(s.name, []):
+				all_keys.add((s.item_code, sb["batch_no"]))
+		else:
+			all_keys.add((s.item_code, None))
+	# MWO-scoped (not MOP-scoped): the per-row transfer PCS is logged once at the
+	# operation that first received the material; downstream operations carry only
+	# balance clones (pcs_change=0). The MWO is constant across operations, so this
+	# recovers the per-line breakdown no matter which operation opens the popup.
+	transfer_by_key = get_mop_transfer_pcs_rows(
+		mo.manufacturing_work_order, keys=all_keys
+	)
+
+	# Collect every reserved line that will become a popup row, grouped by
+	# (item, batch). PCS is allocated per group in one deterministic pass below
+	# so each line's displayed pcs never depends on the order the popup happens
+	# to iterate sibling lines sharing the same item+batch.
+	lines_by_key: dict[tuple, list] = {}
+	for s in sres:
+		is_batch = cint(s.has_batch_no) and s.reservation_based_on != "Qty"
+		if is_batch:
+			for sb in sb_entries_by_sre.get(s.name, []):
+				rem = flt(sb["qty"]) - flt(sb["delivered_qty"])
+				if rem <= tolerance:
+					continue
+				lines_by_key.setdefault((s.item_code, sb["batch_no"]), []).append(
+					(("sb", sb["name"]), rem)
+				)
+		else:
+			rem = flt(s.reserved_qty) - flt(s.delivered_qty)
+			if rem <= tolerance:
+				continue
+			lines_by_key.setdefault((s.item_code, None), []).append(
+				(("sre", s.name), rem)
+			)
+
+	def _allocate_key_pcs(lines, transfers, balance_pcs, is_pcs_item):
+		"""Distribute one (item, batch) group's available PCS across its
+		reserved lines, independent of iteration order.
+
+		Each reserved line maps 1:1 to an incoming Material Transfer row. A line
+		whose remaining qty still equals its transfer qty took no loss / partial
+		receive, so it keeps that transfer's full PCS. Lines that shrank (loss
+		booked, or partially received) are "lossy" and share whatever PCS is left
+		in ``balance_pcs`` — the live MOP-Log batch balance — so the per-group
+		sum never exceeds what actually remains. Example: transfers of 47 and 15
+		pcs with a 5-pcs loss on the larger line (balance 57) → the untouched 15
+		line keeps 15 and the lossy line gets 57 - 15 = 42.
+
+		``transfers`` empty (legacy / single-line data with no per-row MOP Log
+		rows) → every line falls back to the batch aggregate, preserving prior
+		behaviour. Non-D/G items carry no PCS.
+		"""
+		if not is_pcs_item:
+			return {tok: 0 for tok, _ in lines}
+		if not transfers:
+			return {tok: cint(balance_pcs) for tok, _ in lines}
+
+		pending = list(transfers)
+		matched: dict = {}
+		# Exact-qty match first: an untouched (no-loss) line claims its own row,
+		# regardless of where it sits in the iteration order.
+		for tok, rem in lines:
+			i = next(
+				(
+					j
+					for j, t in enumerate(pending)
+					if abs(flt(t["qty_change"]) - flt(rem)) <= tolerance
+				),
+				None,
+			)
+			if i is not None:
+				matched[tok] = pending.pop(i)
+		# Lossy / partial lines take the leftover transfers, oldest-first.
+		for tok, rem in lines:
+			if tok not in matched:
+				matched[tok] = pending.pop(0) if pending else None
+
+		out: dict = {}
+		clean_total = 0
+		lossy = []
+		for tok, rem in lines:
+			t = matched.get(tok)
+			if t and abs(flt(t["qty_change"]) - flt(rem)) <= tolerance:
+				out[tok] = cint(t["pcs_change"])
+				clean_total += out[tok]
+			else:
+				lossy.append((tok, t))
+		# Balance left after the untouched lines is shared by the lossy lines,
+		# each still capped by its own originally-transferred pcs.
+		remaining = max(0, cint(balance_pcs) - clean_total)
+		for tok, t in lossy:
+			cap = cint(t["pcs_change"]) if t else remaining
+			give = max(0, min(cap, remaining))
+			out[tok] = give
+			remaining -= give
+		return out
+
+	pcs_by_token: dict = {}
+	for key, lines in lines_by_key.items():
+		item_code, batch_no = key
+		is_pcs_item = bool(item_code) and item_code[0] in ("D", "G")
+		bal_row = mop_log_balance_map.get(
+			(manufacturing_operation, item_code, batch_no)
+		)
+		balance_pcs = (
+			cint(bal_row.get("pcs_after_transaction_batch_based")) if bal_row else 0
+		)
+		pcs_by_token.update(
+			_allocate_key_pcs(
+				lines, transfer_by_key.get(key) or [], balance_pcs, is_pcs_item
+			)
+		)
+
 	rows = []
 	skipped = []
 	for sre in sres:
@@ -3925,6 +4048,9 @@ def get_make_receive_entry_rows(manufacturing_operation):
 							"reason": "mop_zero_balance",
 						}
 					)
+				row_available_pcs = (
+					pcs_by_token.get(("sb", sb.name), 0) if ctx["is_pcs_item"] else 0
+				)
 				rows.append(
 					{
 						"stock_reservation_entry": sre.name,
@@ -3951,9 +4077,11 @@ def get_make_receive_entry_rows(manufacturing_operation):
 						"delivered_qty": flt(sb.delivered_qty),
 						"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
 						"available_to_receive_qty": available_to_receive_qty,
-						"reserved_pcs": cint(ctx["reserved_pcs"] or 0),
+						"reserved_pcs": row_available_pcs
+						if ctx["is_pcs_item"]
+						else cint(ctx["reserved_pcs"] or 0),
 						"mop_available_pcs": cint(ctx["mop_log_balance_pcs"]),
-						"available_to_receive_pcs": cint(ctx["available_pcs"]),
+						"available_to_receive_pcs": row_available_pcs,
 						"already_received_qty": already_received_for_item,
 						"already_received_pcs": ctx["already_received_pcs"],
 						"is_pcs_item": ctx["is_pcs_item"],
@@ -4008,6 +4136,9 @@ def get_make_receive_entry_rows(manufacturing_operation):
 					}
 				)
 				continue
+			row_available_pcs = (
+				pcs_by_token.get(("sre", sre.name), 0) if ctx["is_pcs_item"] else 0
+			)
 			rows.append(
 				{
 					"stock_reservation_entry": sre.name,
@@ -4030,9 +4161,11 @@ def get_make_receive_entry_rows(manufacturing_operation):
 					"delivered_qty": flt(sre.delivered_qty),
 					"mop_available_qty": flt(ctx["mop_log_balance_qty"]),
 					"available_to_receive_qty": available_to_receive_qty,
-					"reserved_pcs": cint(ctx["reserved_pcs"] or 0),
+					"reserved_pcs": row_available_pcs
+					if ctx["is_pcs_item"]
+					else cint(ctx["reserved_pcs"] or 0),
 					"mop_available_pcs": cint(ctx["mop_log_balance_pcs"]),
-					"available_to_receive_pcs": cint(ctx["available_pcs"]),
+					"available_to_receive_pcs": row_available_pcs,
 					"already_received_qty": already_received_for_item,
 					"already_received_pcs": ctx["already_received_pcs"],
 					"is_pcs_item": ctx["is_pcs_item"],

--- a/jewellery_erpnext/jewellery_erpnext/doctype/metal_conversions/doc_events/utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/metal_conversions/doc_events/utils.py
@@ -22,6 +22,9 @@ def update_batch_details(self):
 	else:
 		child_table = self.mc_source_table
 
+	# shared across rows so the same batch is not double-allocated when multiple
+	# rows draw from the same item/warehouse (see get_fifo_batches)
+	consumed = {}
 	for row in child_table:
 		warehouse = row.get("s_warehouse") or self.get("source_warehouse")
 		if row.get("batch") and get_batch_qty(row.batch, warehouse) >= row.qty:
@@ -29,7 +32,7 @@ def update_batch_details(self):
 			temp_row.batch_no = temp_row.batch
 			rows_to_append += [temp_row]
 		else:
-			rows_to_append += get_fifo_batches(self, row)
+			rows_to_append += get_fifo_batches(self, row, consumed)
 
 	if rows_to_append:
 		if self.doctype == "Diamond Conversion":

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
@@ -282,8 +282,11 @@ def create_mop_log_for_stock_transfer_to_mo(doc, row, is_synced=False):
 	mop_log.pcs_after_transaction_item_based = pcs_after_item
 	mop_log.pcs_after_transaction_batch_based = pcs_after_batch
 
-	mop_log.from_warehouse = row.get("s_warehouse")
-	mop_log.to_warehouse = row.get("t_warehouse")
+	# Stock Entry Detail rows use s_warehouse/t_warehouse; MOP-Log-shaped dicts
+	# (e.g. from update_new_mop_wtg) use from_warehouse/to_warehouse. Accept both
+	# so next-operation baseline rows keep their warehouses.
+	mop_log.from_warehouse = row.get("s_warehouse") or row.get("from_warehouse")
+	mop_log.to_warehouse = row.get("t_warehouse") or row.get("to_warehouse")
 	mop_log.voucher_type = doc.doctype
 	mop_log.voucher_no = doc.name
 	mop_log.manufacturing_work_order = mwo
@@ -367,6 +370,72 @@ def get_current_mop_balance_rows(
 		if key not in latest_by_key:
 			latest_by_key[key] = log
 	return list(reversed(list(latest_by_key.values())))
+
+
+def get_mop_transfer_pcs_rows(manufacturing_work_order, keys=None):
+	"""Return per-row incoming-transfer PCS rows for a MWO, grouped by item/batch.
+
+	Unlike :func:`get_current_mop_balance_rows` (which dedups to the single
+	latest *running balance* per ``(item_code, batch_no)``), this keeps EVERY
+	incoming Material Transfer row so the Make Receive Entry popup can show the
+	PCS that belongs to each individual reserved batch line instead of the
+	batch-wide aggregate. Each Material Transfer (WORK ORDER) row posts one MOP
+	Log row carrying that row's own ``pcs_change``/``qty_change``; receiving and
+	loss rows post ``pcs_change <= 0`` and are excluded here.
+
+	Scoped to the **Manufacturing Work Order**, not a single MOP: the original
+	per-row transfer (with ``pcs_change > 0``) is logged once at the operation
+	that first received the material (e.g. Diamond Bagging). When work hands off
+	to the next operation, MOP Log carries only a balance *clone* with
+	``pcs_change = 0`` (qty/pcs change attributable to a handoff is zero), so a
+	MOP-scoped query at a downstream operation would find no per-row rows and the
+	popup would fall back to the batch aggregate. The MWO is constant across all
+	its operations, so this recovers the original 24/8 style breakdown regardless
+	of which operation opens the popup.
+
+	Returns ``{(item_code, batch_no): [{"qty_change", "pcs_change", "name"}, ...]}``
+	ordered oldest-first within each key. Rows missing ``pcs_change``/``qty_change``
+	(e.g. unit-test fixtures that mock unrelated docs through the same patched
+	``frappe.db.get_all``) are skipped so callers degrade to their own fallback.
+	"""
+	filters = {
+		"manufacturing_work_order": manufacturing_work_order,
+		"is_cancelled": 0,
+		"pcs_change": [">", 0],
+	}
+	if keys:
+		item_codes = sorted({k[0] for k in keys if k and k[0]})
+		if not item_codes:
+			return {}
+		filters["item_code"] = ["in", item_codes]
+	rows = frappe.db.get_all(
+		"MOP Log",
+		filters=filters,
+		fields=[
+			"item_code",
+			"batch_no",
+			"qty_change",
+			"pcs_change",
+			"name",
+			"creation",
+		],
+		order_by="creation asc",
+	)
+	transfer_by_key: dict[tuple, list] = {}
+	for row in rows:
+		# Defensive: the unit tests patch frappe.db.get_all globally and feed
+		# back SRE dicts; those lack pcs_change/qty_change, so skip them.
+		if row.get("pcs_change") is None or row.get("qty_change") is None:
+			continue
+		key = (row.get("item_code"), row.get("batch_no"))
+		transfer_by_key.setdefault(key, []).append(
+			{
+				"qty_change": flt(row.get("qty_change")),
+				"pcs_change": cint(row.get("pcs_change")),
+				"name": row.get("name"),
+			}
+		)
+	return transfer_by_key
 
 
 def get_available_qty_pcs_for_mop_item(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
@@ -413,10 +413,20 @@ def _process_mwo_group(
 				},
 			)
 
+	# Any unresolved (Missing SRE) row means the MWO's stock can't be fully
+	# transferred. Do NOT mark its MOP Logs synced — that buries them as done
+	# (is_synced=1 excludes them from future runs) while nothing moved. Count the
+	# MWO as failed so it stays retryable after the SRE is fixed. Per-row failures
+	# and child "Failed" rows were already recorded in the skipped loop above.
+	if skipped_rows:
+		stats["failed_mwos"] += 1
+		return
+
 	if not items:
+		# Genuine no-op: every row was same-warehouse or non-positive qty — nothing
+		# to move. Safe to mark the MWO's logs synced.
 		frappe.logger().info(
-			"MOP EOD Sync MWO %s: no SE rows to create (same WH or all SRE missing); "
-			"marking logs synced.",
+			"MOP EOD Sync MWO %s: no SE rows to create (same WH); marking logs synced.",
 			mwo,
 		)
 		_mark_all_mwo_mop_logs_synced([mwo], selective=selective)
@@ -517,7 +527,7 @@ def _process_mwo_group(
 		sre_snapshots = _snapshot_mwo_sres_for_relocation(mwo, items, t_warehouse)
 		_cancel_sre_snapshots(sre_snapshots)
 		frappe.get_doc("Stock Entry", draft_se_name).submit()
-		_recreate_sres_at(sre_snapshots, t_warehouse)
+		_recreate_sres_at(sre_snapshots, t_warehouse, target_operation=last_mop_name)
 		_mark_all_mwo_mop_logs_synced([mwo], selective=selective)
 		_stamp_last_eod_sync(mop_data_list)
 		frappe.db.release_savepoint("eod_submit_phase")
@@ -1141,12 +1151,19 @@ def _cancel_sre_snapshots(snapshots):
 			doc.cancel()
 
 
-def _recreate_sres_at(snapshots, new_warehouse):
-	"""Recreate the snapshotted SREs at ``new_warehouse`` (same voucher/qty/batches)."""
+def _recreate_sres_at(snapshots, new_warehouse, target_operation=None):
+	"""Recreate the snapshotted SREs at ``new_warehouse`` (same voucher/qty/batches).
+
+	The new SRE is tagged with ``target_operation`` — the latest operation, whose
+	warehouse the stock was just moved to — so downstream processes (e.g. Make
+	Receive Entry, which reads MWO-scoped active SREs) see the reservation against
+	the current operation. Falls back to the original SRE's operation if not given.
+	"""
 	if not snapshots:
 		return
 	from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
 		get_available_qty_to_reserve,
+		get_sre_reserved_qty_for_voucher_detail_no,
 	)
 
 	for snap in snapshots:
@@ -1154,31 +1171,71 @@ def _recreate_sres_at(snapshots, new_warehouse):
 		# Batch-tracked SRE with no remaining batch qty → nothing to re-reserve.
 		if snap["has_batch_no"] and not snap["sb_entries"]:
 			continue
+
+		# Clamp to what is actually free at the target, mirroring
+		# stock_reservation_entry_for_mwo. The stock was just transferred here, but part
+		# of a batch may already be reserved — never reserve more than is free, and skip
+		# entirely when nothing is free (rather than letting ERPNext throw).
 		if snap["sb_entries"]:
-			available = get_available_qty_to_reserve(
-				sre.item_code, new_warehouse, batch_no=snap["sb_entries"][0]["batch_no"]
-			)
+			clamped_sb = []
+			for sb in snap["sb_entries"]:
+				free = get_available_qty_to_reserve(
+					sre.item_code, new_warehouse, batch_no=sb["batch_no"]
+				)
+				qty = min(flt(sb["qty"]), flt(free))
+				if qty > 1e-9:
+					clamped_sb.append({"batch_no": sb["batch_no"], "qty": qty})
+			if not clamped_sb:
+				continue
+			reserved_qty = sum(flt(s["qty"]) for s in clamped_sb)
+			available = reserved_qty
 		else:
+			clamped_sb = None
 			available = get_available_qty_to_reserve(sre.item_code, new_warehouse)
+			reserved_qty = min(flt(snap["remaining"]), flt(available))
+			if reserved_qty <= 1e-9:
+				continue
+
+		# Lift the Sales Order demand cap exactly like the original creator: the SO line
+		# is intentionally over-reserved across components, so size voucher_qty to cover
+		# the current reservation (EIR-injection pattern in stock_reservation_entry_for_mwo).
+		# The source SRE was already cancelled, so it is excluded from this global sum.
+		total_so_reserved = get_sre_reserved_qty_for_voucher_detail_no(
+			sre.item_code, sre.voucher_type, sre.voucher_no, sre.voucher_detail_no
+		)
+		effective_voucher_qty = max(
+			flt(sre.voucher_qty), flt(total_so_reserved) + reserved_qty
+		)
 
 		new_sre = frappe.new_doc("Stock Reservation Entry")
 		new_sre.voucher_type = sre.voucher_type
 		new_sre.voucher_no = sre.voucher_no
 		new_sre.voucher_detail_no = sre.voucher_detail_no
-		new_sre.voucher_qty = sre.voucher_qty
+		new_sre.voucher_qty = effective_voucher_qty
 		new_sre.item_code = sre.item_code
 		new_sre.warehouse = new_warehouse
-		new_sre.reserved_qty = snap["remaining"]
+		new_sre.reserved_qty = reserved_qty
 		new_sre.company = sre.company
 		new_sre.stock_uom = sre.stock_uom
 		new_sre.reservation_based_on = sre.reservation_based_on
 		new_sre.has_batch_no = snap["has_batch_no"]
 		new_sre.has_serial_no = snap["has_serial_no"]
-		new_sre.available_qty = max(flt(available), snap["remaining"])
+		new_sre.available_qty = max(flt(available), reserved_qty)
 		new_sre.manufacturing_work_order = sre.manufacturing_work_order
-		new_sre.manufacturing_operation = sre.manufacturing_operation
-		for sb in snap["sb_entries"]:
-			new_sre.append("sb_entries", {"batch_no": sb["batch_no"], "qty": sb["qty"]})
+		new_sre.manufacturing_operation = (
+			target_operation or sre.manufacturing_operation
+		)
+		for sb in clamped_sb or []:
+			# Mirror stock_reservation_entry_for_mwo: the batch entry must carry the
+			# (new) warehouse so the reservation binds to the relocated stock.
+			new_sre.append(
+				"sb_entries",
+				{
+					"batch_no": sb["batch_no"],
+					"warehouse": new_warehouse,
+					"qty": sb["qty"],
+				},
+			)
 		new_sre.flags.ignore_permissions = True
 		new_sre.insert(ignore_links=1)
 		new_sre.submit()
@@ -1269,9 +1326,11 @@ def _mark_all_mwo_mop_logs_synced(manufacturing_work_orders, selective=False):
 		},
 	)
 
+
 # ---------------------------------------------------------------------------
 # MOP Log sync-marking (today-only safety net)
 # ---------------------------------------------------------------------------
+
 
 def _mwo_realized_by_artifact(mwo):
 	"""Return the submitted Manufacture Stock Entry name for this MWO, else None.

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_eod_sync.py
@@ -205,20 +205,6 @@ class TestGetUnsyncedMopGroupsByMwo(FrappeTestCase):
 
 		self.assertEqual(out, {})
 
-	@patch(
-		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.get_all",
-		return_value=[],
-	)
-	@patch(
-		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.db.sql",
-		return_value=[{"cnt": 0, "qty": 0}],
-	)
-	def test_empty_logs_returns_empty_dict(self, _mock_sql, _mock_get_all):
-		"""No unsynced logs → empty dict returned immediately without querying MOPs."""
-		out = _get_unsynced_mop_groups()
-
-		self.assertEqual(out, {})
-
 
 # ---------------------------------------------------------------------------
 # TestFindLastOperation (4 cases)
@@ -572,6 +558,60 @@ class TestProcessMwoGroupHappyPath(FrappeTestCase):
 		self.assertEqual(stats["processed_mwos"], 1)
 		mock_mark_synced.assert_called_once_with(["MWO-1"], selective=False)
 		self.assertTrue(submitted_se.submitted)
+
+
+class TestProcessMwoGroupMissingSreNotSynced(FrappeTestCase):
+	"""A row with no resolvable SRE warehouse must fail the MWO, never mark it synced.
+
+	Regression for the silent data-loss bug: when every row is skipped for Missing
+	SRE, ``items`` is empty — the old code marked the MWO's MOP Logs ``is_synced=1``
+	and counted it as processed, burying them as done while nothing moved.
+	"""
+
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.frappe.new_doc"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mark_all_mwo_mop_logs_synced"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._preload_sre_warehouse_map",
+		return_value={},
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mwo_realized_by_artifact",
+		return_value=None,
+	)
+	def test_missing_sre_fails_mwo_without_marking_synced(
+		self, _mock_artifact, _mock_sre_map, mock_mark_synced, mock_new_doc
+	):
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				qty_after_transaction_batch_based=3.0,
+				to_warehouse="WH-DEPT",
+				creation="2026-01-01 10:00:00",
+			)
+		]
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}]
+		failures = []
+		stats = {"processed_mwos": 0, "failed_mwos": 0, "submitted_ses": []}
+
+		_process_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+
+		# MWO counted as failed, never as synced/processed
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertEqual(stats["processed_mwos"], 0)
+		# Logs left retryable — not marked synced
+		mock_mark_synced.assert_not_called()
+		# No Stock Entry created
+		mock_new_doc.assert_not_called()
+		# The skipped row was recorded as a failure for the consolidated error log
+		self.assertEqual(len(failures), 1)
+		self.assertEqual(failures[0]["step"], "no_sre_warehouse")
 
 
 # ---------------------------------------------------------------------------
@@ -1048,11 +1088,214 @@ class TestSreRelocation(FrappeTestCase):
 			"has_serial_no": 0,
 			"sb_entries": [],
 		}
-		_recreate_sres_at([snap], "WH-DEPT")
+		_recreate_sres_at([snap], "WH-DEPT", target_operation="MOP-LAST")
 		self.assertEqual(new_sre.warehouse, "WH-DEPT")
 		self.assertEqual(new_sre.reserved_qty, 5.0)
+		# New SRE is tagged with the latest operation (where the stock now sits)
+		self.assertEqual(new_sre.manufacturing_operation, "MOP-LAST")
 		new_sre.insert.assert_called_once()
 		new_sre.submit.assert_called_once()
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_available_qty_to_reserve",
+		return_value=10.0,
+	)
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_recreate_falls_back_to_original_operation(self, mock_new_doc, _mock_avail):
+		new_sre = MagicMock()
+		mock_new_doc.return_value = new_sre
+		snap = {
+			"sre": FrappeDict(
+				{
+					"item_code": "M-1",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "row1",
+					"voucher_qty": 5.0,
+					"company": "Test Co",
+					"stock_uom": "Nos",
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-ORIG",
+				}
+			),
+			"remaining": 5.0,
+			"has_batch_no": 0,
+			"has_serial_no": 0,
+			"sb_entries": [],
+		}
+		_recreate_sres_at([snap], "WH-DEPT")  # no target_operation
+		self.assertEqual(new_sre.manufacturing_operation, "MOP-ORIG")
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_available_qty_to_reserve",
+		return_value=10.0,
+	)
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_recreate_batch_sre_sets_warehouse_on_sb_entry(
+		self, mock_new_doc, _mock_avail
+	):
+		new_sre = MagicMock()
+		mock_new_doc.return_value = new_sre
+		snap = {
+			"sre": FrappeDict(
+				{
+					"item_code": "D-1",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "row1",
+					"voucher_qty": 2.0,
+					"company": "Test Co",
+					"stock_uom": "Nos",
+					"reservation_based_on": "Serial and Batch",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-A",
+				}
+			),
+			"remaining": 2.0,
+			"has_batch_no": 1,
+			"has_serial_no": 0,
+			"sb_entries": [{"batch_no": "B1", "qty": 2.0}],
+		}
+		_recreate_sres_at([snap], "WH-DEPT", target_operation="MOP-LAST")
+		sb_calls = [
+			c
+			for c in new_sre.append.call_args_list
+			if c.args and c.args[0] == "sb_entries"
+		]
+		self.assertEqual(len(sb_calls), 1)
+		sb_row = sb_calls[0].args[1]
+		# The relocated batch entry must carry the new warehouse (matches canonical)
+		self.assertEqual(sb_row["warehouse"], "WH-DEPT")
+		self.assertEqual(sb_row["batch_no"], "B1")
+		self.assertEqual(sb_row["qty"], 2.0)
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_sre_reserved_qty_for_voucher_detail_no",
+		return_value=8.0,
+	)
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_available_qty_to_reserve",
+		return_value=10.0,
+	)
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_recreate_inflates_voucher_qty_when_so_overreserved(
+		self, mock_new_doc, _mock_avail, _mock_so_reserved
+	):
+		# SO line is over-reserved (total_so_reserved=8.0) and the copied voucher_qty
+		# (5.0) is smaller than reserved+others — the recreate must lift voucher_qty so
+		# ERPNext's allowed-qty cap does not reject the relocation.
+		new_sre = MagicMock()
+		mock_new_doc.return_value = new_sre
+		snap = {
+			"sre": FrappeDict(
+				{
+					"item_code": "M-1",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "row1",
+					"voucher_qty": 5.0,
+					"company": "Test Co",
+					"stock_uom": "Nos",
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-A",
+				}
+			),
+			"remaining": 3.0,
+			"has_batch_no": 0,
+			"has_serial_no": 0,
+			"sb_entries": [],
+		}
+		_recreate_sres_at([snap], "WH-DEPT", target_operation="MOP-LAST")
+		self.assertEqual(new_sre.reserved_qty, 3.0)
+		# max(orig 5.0, total_so_reserved 8.0 + reserved 3.0) = 11.0
+		self.assertEqual(new_sre.voucher_qty, 11.0)
+		new_sre.submit.assert_called_once()
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_sre_reserved_qty_for_voucher_detail_no",
+		return_value=0.0,
+	)
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_available_qty_to_reserve",
+		return_value=2.0,
+	)
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_recreate_clamps_reserved_to_available(
+		self, mock_new_doc, _mock_avail, _mock_so_reserved
+	):
+		# Only 2.0 free at the target though 5.0 was reserved at source → reserve 2.0,
+		# never throw "Stock not available to reserve".
+		new_sre = MagicMock()
+		mock_new_doc.return_value = new_sre
+		snap = {
+			"sre": FrappeDict(
+				{
+					"item_code": "M-1",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "row1",
+					"voucher_qty": 5.0,
+					"company": "Test Co",
+					"stock_uom": "Nos",
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-A",
+				}
+			),
+			"remaining": 5.0,
+			"has_batch_no": 0,
+			"has_serial_no": 0,
+			"sb_entries": [],
+		}
+		_recreate_sres_at([snap], "WH-DEPT")
+		self.assertEqual(new_sre.reserved_qty, 2.0)
+		new_sre.submit.assert_called_once()
+
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_sre_reserved_qty_for_voucher_detail_no",
+		return_value=0.0,
+	)
+	@patch(
+		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		"get_available_qty_to_reserve",
+		return_value=0.0,
+	)
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_recreate_skips_when_nothing_free(
+		self, mock_new_doc, _mock_avail, _mock_so_reserved
+	):
+		# Nothing free at the target → skip the SRE entirely (no throw, no doc created).
+		snap = {
+			"sre": FrappeDict(
+				{
+					"item_code": "M-1",
+					"voucher_type": "Sales Order",
+					"voucher_no": "SO-1",
+					"voucher_detail_no": "row1",
+					"voucher_qty": 5.0,
+					"company": "Test Co",
+					"stock_uom": "Nos",
+					"reservation_based_on": "Qty",
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": "MOP-A",
+				}
+			),
+			"remaining": 5.0,
+			"has_batch_no": 0,
+			"has_serial_no": 0,
+			"sb_entries": [],
+		}
+		_recreate_sres_at([snap], "WH-DEPT")
+		mock_new_doc.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/jewellery_erpnext/jewellery_erpnext/doctype/product_certification/product_certification.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/product_certification/product_certification.py
@@ -441,7 +441,9 @@ class ProductCertification(Document):
 					as_dict=1,
 				)
 
-				# Calculate diamond_pcs from Manufacturing Work Order, Parent Manufacturing Order or BOM
+				# Diamond / stone pcs come from the latest Manufacturing Operation when a
+				# Manufacturing Work Order is linked; otherwise (serial-no or PMO rows) fall
+				# back to the BOM totals (total_diamond_pcs / total_gemstone_pcs).
 				diamond_pcs = 0
 				stone_pcs = 0
 				if row.manufacturing_work_order:
@@ -458,73 +460,19 @@ class ProductCertification(Document):
 					if latest_operation:
 						diamond_pcs = latest_operation[0].diamond_pcs
 						stone_pcs = latest_operation[0].gemstone_pcs
-					if (
-						not diamond_pcs
-						and bom_weights
-						and bom_weights.get("total_diamond_pcs")
-					):
-						diamond_pcs = bom_weights.get("total_diamond_pcs")
-					if (
-						not stone_pcs
-						and bom_weights
-						and bom_weights.get("total_gemstone_pcs")
-					):
-						stone_pcs = bom_weights.get("total_gemstone_pcs")
 
-				# elif row.parent_manufacturing_order:
-				# 	diamond_pcs = (
-				# 		frappe.db.sql(
-				# 			"""
-				# 		SELECT SUM(diamond_pcs)
-				# 		FROM `tabManufacturing Work Order`
-				# 		WHERE manufacturing_order = %s
-				# 		  AND docstatus != 2
-				# 	""",
-				# 			(row.parent_manufacturing_order,),
-				# 		)[0][0]
-				# 		or 0
-				# 	)
-				# 	if (
-				# 		not diamond_pcs
-				# 		and bom_weights
-				# 		and bom_weights.get("total_diamond_pcs")
-				# 	):
-				# 		diamond_pcs = bom_weights.get("total_diamond_pcs")
-				# elif bom_weights and bom_weights.get("total_diamond_pcs"):
-				# 	diamond_pcs = bom_weights.get("total_diamond_pcs")
-
-				# Calculate stone_pcs from Manufacturing Work Order, Parent Manufacturing Order or BOM
-				# stone_pcs = 0
-				# if row.manufacturing_work_order:
-				# 	stone_pcs = (
-				# 		frappe.db.get_value(
-				# 			"Manufacturing Work Order",
-				# 			row.manufacturing_work_order,
-				# 			"gemstone_pcs",
-				# 		)
-				# 		or 0
-				# 	)
-				# elif row.parent_manufacturing_order:
-				# 	stone_pcs = (
-				# 		frappe.db.sql(
-				# 			"""
-				# 		SELECT SUM(gemstone_pcs)
-				# 		FROM `tabManufacturing Work Order`
-				# 		WHERE manufacturing_order = %s
-				# 		  AND docstatus != 2
-				# 	""",
-				# 			(row.parent_manufacturing_order,),
-				# 		)[0][0]
-				# 		or 0
-				# # 	)
-				# 	if (
-				# 		not stone_pcs
-				# 		and bom_weights
-				# 		and bom_weights.get("total_gemstone_pcs")
-				# 	):
-				# # 		stone_pcs = bom_weights.get("total_gemstone_pcs")
-				# elif bom_weights and bom_weights.get("total_gemstone_pcs"):
-				# 	stone_pcs = bom_weights.get("total_gemstone_pcs")
+				if (
+					not diamond_pcs
+					and bom_weights
+					and bom_weights.get("total_diamond_pcs")
+				):
+					diamond_pcs = bom_weights.get("total_diamond_pcs")
+				if (
+					not stone_pcs
+					and bom_weights
+					and bom_weights.get("total_gemstone_pcs")
+				):
+					stone_pcs = bom_weights.get("total_gemstone_pcs")
 
 				for i in range(0, count):
 					if metal_det:
@@ -1114,24 +1062,33 @@ def get_stock_item_against_mwo(se_doc, doc, row, s_warehouse, t_warehouse):
 				or s_warehouse
 			)
 
-			se_doc.append(
-				"items",
-				{
-					"item_code": item_code,
-					"qty": qty,
-					"s_warehouse": item_s_warehouse,
-					"t_warehouse": t_warehouse,
-					"Inventory_type": "Regular Stock",
-					"reference_doctype": "Manufacturing Work Order"
-					if row.manufacturing_work_order
-					else "Parent Manufacturing Order",
-					"reference_docname": row.manufacturing_work_order
-					if row.manufacturing_work_order
-					else row.parent_manufacturing_order,
-					"use_serial_batch_fields": True,
-					"batch_no": batch_no,
-				},
+			# pcs is a stone count: carry the batch-based balance for
+			# diamond/gemstone items only (prefix D/G, per FIELD_MAP in mop_log)
+			# so metal/finding rows keep the meaningful default of 1.
+			pcs = (
+				cint(balance_row.get("pcs_after_transaction_batch_based") or 0)
+				if item_code and item_code[0] in ("D", "G")
+				else 0
 			)
+
+			item_row = {
+				"item_code": item_code,
+				"qty": qty,
+				"s_warehouse": item_s_warehouse,
+				"t_warehouse": t_warehouse,
+				"Inventory_type": "Regular Stock",
+				"reference_doctype": "Manufacturing Work Order"
+				if row.manufacturing_work_order
+				else "Parent Manufacturing Order",
+				"reference_docname": row.manufacturing_work_order
+				if row.manufacturing_work_order
+				else row.parent_manufacturing_order,
+				"use_serial_batch_fields": True,
+				"batch_no": batch_no,
+			}
+			if pcs:
+				item_row["pcs"] = pcs
+			se_doc.append("items", item_row)
 
 		# --- Cancel the SREs ---
 		for sre in sre_list:
@@ -1169,28 +1126,36 @@ def get_stock_item_against_mwo(se_doc, doc, row, s_warehouse, t_warehouse):
 		issue_items = frappe.db.get_all(
 			"Stock Entry Detail",
 			filters={"parent": issue_se},
-			fields=["item_code", "qty", "batch_no", "s_warehouse", "t_warehouse"],
+			fields=[
+				"item_code",
+				"qty",
+				"pcs",
+				"batch_no",
+				"s_warehouse",
+				"t_warehouse",
+			],
 		)
 
 		for item in issue_items:
-			se_doc.append(
-				"items",
-				{
-					"item_code": item.item_code,
-					"qty": item.qty,
-					"s_warehouse": item.t_warehouse,  # Issue's target becomes Receive's source
-					"t_warehouse": s_warehouse,  # Department warehouse as target for receive
-					"Inventory_type": "Regular Stock",
-					"reference_doctype": "Manufacturing Work Order"
-					if row.manufacturing_work_order
-					else "Parent Manufacturing Order",
-					"reference_docname": row.manufacturing_work_order
-					if row.manufacturing_work_order
-					else row.parent_manufacturing_order,
-					"use_serial_batch_fields": True,
-					"batch_no": item.get("batch_no"),
-				},
-			)
+			item_row = {
+				"item_code": item.item_code,
+				"qty": item.qty,
+				"s_warehouse": item.t_warehouse,  # Issue's target becomes Receive's source
+				"t_warehouse": s_warehouse,  # Department warehouse as target for receive
+				"Inventory_type": "Regular Stock",
+				"reference_doctype": "Manufacturing Work Order"
+				if row.manufacturing_work_order
+				else "Parent Manufacturing Order",
+				"reference_docname": row.manufacturing_work_order
+				if row.manufacturing_work_order
+				else row.parent_manufacturing_order,
+				"use_serial_batch_fields": True,
+				"batch_no": item.get("batch_no"),
+			}
+			# Carry the corrected pcs from the Issue SE (diamond/gemstone rows).
+			if item.get("pcs"):
+				item_row["pcs"] = item.get("pcs")
+			se_doc.append("items", item_row)
 
 
 @frappe.whitelist()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/product_certification/test_product_certification.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/product_certification/test_product_certification.py
@@ -1,11 +1,17 @@
 # Copyright (c) 2023, Nirali and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe import ValidationError
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import cint
 
 from jewellery_erpnext.create_test_data import create_test_data
+from jewellery_erpnext.jewellery_erpnext.doctype.product_certification.product_certification import (
+	get_stock_item_against_mwo,
+)
 from jewellery_erpnext.jewellery_erpnext.doctype.serial_number_creator.test_serial_number_creator import (
 	create_snc,
 )
@@ -26,6 +32,16 @@ class TestProductCertification(FrappeTestCase):
 		certification_issue.supplier = "Test_Supplier"
 		fetch_sn(certification_issue, serial_no.name)
 		certification_issue.save()
+
+		# Serial-no-only rows (no MWO/PMO) take diamond_pcs from the BOM total.
+		bom_diamond_pcs = frappe.db.get_value(
+			"BOM", certification_issue.product_details[0].bom, "total_diamond_pcs"
+		)
+		self.assertEqual(
+			cint(certification_issue.exploded_product_details[0].diamond_pcs),
+			cint(bom_diamond_pcs),
+		)
+
 		certification_issue.submit()
 
 		se = frappe.get_doc(
@@ -281,6 +297,74 @@ class TestProductCertification(FrappeTestCase):
 
 	def tearDown(self):
 		return super().tearDown()
+
+
+class TestHallmarkingStockEntryPcs(FrappeTestCase):
+	"""Unit coverage for pcs propagation in get_stock_item_against_mwo.
+
+	Kept separate from TestProductCertification so it does not depend on the
+	heavy create_test_data() fixture: the MWO/MOP/warehouse machinery is mocked
+	and only the pcs-assignment logic is exercised.
+	"""
+
+	def test_hallmarking_issue_se_carries_pcs_for_diamond(self):
+		"""Diamond/gemstone rows take their batch-based pcs from the MOP balance;
+		metal rows are left untouched (default 1)."""
+		se_doc = frappe.new_doc("Stock Entry")
+		se_doc.stock_entry_type = "Material Issue for Hallmarking"
+
+		doc = frappe._dict(type="Issue")
+		row = frappe._dict(
+			idx=1,
+			manufacturing_work_order="FAKE-MWO",
+			parent_manufacturing_order="FAKE-PMO",
+		)
+
+		balance_rows = [
+			{
+				"item_code": "D-NT-RO-TEST-01",
+				"qty_after_transaction_batch_based": 0.664,
+				"pcs_after_transaction_batch_based": 395,
+				"batch_no": "BATCH-D-01",
+			},
+			{
+				"item_code": "M-G-18KT-TEST",
+				"qty_after_transaction_batch_based": 5.211,
+				"pcs_after_transaction_batch_based": 0,
+				"batch_no": "BATCH-M-01",
+			},
+		]
+
+		orig_get_value = frappe.db.get_value
+
+		def fake_get_value(doctype, filters=None, fieldname=None, *args, **kwargs):
+			# Make latest_mop resolve so the balance loop runs; delegate every
+			# other lookup (incl. meta loading) to the real implementation.
+			if (
+				doctype == "Manufacturing Work Order"
+				and fieldname == "manufacturing_operation"
+			):
+				return "FAKE-MOP"
+			return orig_get_value(doctype, filters, fieldname, *args, **kwargs)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.get_current_mop_balance_rows",
+			return_value=balance_rows,
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.product_certification."
+			"product_certification.resolve_and_validate",
+			return_value="Test - WH",
+		), patch.object(frappe.db, "get_value", side_effect=fake_get_value):
+			get_stock_item_against_mwo(se_doc, doc, row, "Source - WH", "Target - WH")
+
+		items_by_code = {it.item_code: it for it in se_doc.items}
+		self.assertIn("D-NT-RO-TEST-01", items_by_code)
+		self.assertIn("M-G-18KT-TEST", items_by_code)
+		# Diamond row carries the real stone count from the MOP balance.
+		self.assertEqual(cint(items_by_code["D-NT-RO-TEST-01"].pcs), 395)
+		# Metal row is left untouched by our code (no stone count attached); the
+		# DB default of "1" is applied later on save, not on append.
+		self.assertFalse(items_by_code["M-G-18KT-TEST"].get("pcs"))
 
 
 def serial_no_creation(self):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
@@ -182,6 +182,44 @@ class SerialNumberCreator(Document):
 			)
 
 
+def _warehouse_has_batch_stock(item_code, batch_no, warehouse):
+	"""Return True if ``batch_no`` of ``item_code`` physically has stock in ``warehouse``.
+
+	Used when adopting a warehouse from a Stock Reservation Entry / Product
+	Certification Receive. Multiple reservations can exist for the same item in
+	different warehouses, and a later Stock Entry may have physically moved the
+	batch elsewhere. Adopting a warehouse where the batch has no stock causes
+	``BatchNegativeStockError`` when the auto-created Manufacture entry is
+	submitted. A row without a batch has nothing to validate, so it is allowed.
+
+	``ignore_reserved_stock=True`` is required: the negative-stock validator
+	checks *physical* batch qty, while ``get_batch_qty`` subtracts reserved stock
+	by default — and the batch we are about to consume is itself reserved by the
+	SRE being processed, so the default would report 0 for the correct warehouse.
+	"""
+	if not batch_no:
+		return True
+	return (
+		flt(get_batch_qty(batch_no, warehouse, item_code, ignore_reserved_stock=True))
+		> 0
+	)
+
+
+def _sre_reserves_batch(sre_name, batch_no):
+	"""Whether the Stock Reservation Entry reserves ``batch_no``.
+
+	SREs reserve specific (item, batch) lots in their Serial and Batch Entry
+	children. A Qty-based SRE has no batch children and matches any batch
+	(item-level reservation, the original behaviour).
+	"""
+	sre_batches = frappe.get_all(
+		"Serial and Batch Entry",
+		filters={"parent": sre_name, "parenttype": "Stock Reservation Entry"},
+		pluck="batch_no",
+	)
+	return (not sre_batches) or (batch_no in sre_batches)
+
+
 def to_prepare_data_for_make_mnf_stock_entry(self):
 	"""Use source_table (batch-wise) for stock entry creation.
 
@@ -254,13 +292,28 @@ def to_prepare_data_for_make_mnf_stock_entry(self):
 					pluck="name",
 				)
 
-				# Deduplicate and cancel SREs
+				row_batch = row.get("batch_no")
+				sre_matched = False
+				# SREs are created per (item, batch, warehouse); an item consumed from
+				# several batches has one SRE per batch. Process only the SRE that
+				# reserves THIS row's batch so each batch row adopts its own
+				# reservation warehouse + reserved qty (and cancels only its own SRE).
+				# Previously the first row swallowed/cancelled every SRE for the item,
+				# leaving later batch rows on a stale source warehouse with no stock
+				# -> BatchNegativeStockError. Matching by batch also makes resolution
+				# order-independent.
 				for sre_name in set(linked_sres):
+					if row_batch and not _sre_reserves_batch(sre_name, row_batch):
+						continue
+					sre_matched = True
 					frappe.clear_document_cache("Bin")
 					sre_doc = frappe.get_doc("Stock Reservation Entry", sre_name)
 
-					# Capture warehouse from SRE
-					if sre_doc.warehouse:
+					# Adopt the SRE warehouse only if the batch physically has stock
+					# there (it may have been moved since the reservation).
+					if sre_doc.warehouse and _warehouse_has_batch_stock(
+						row["item_code"], row_batch, sre_doc.warehouse
+					):
 						row["s_warehouse"] = sre_doc.warehouse
 
 					sre_reserved_qty_total += flt(sre_doc.reserved_qty)
@@ -269,7 +322,7 @@ def to_prepare_data_for_make_mnf_stock_entry(self):
 					frappe.clear_document_cache("Bin")
 
 				# Persist the corrected SRE warehouse back to source_table
-				if linked_sres:
+				if sre_matched:
 					for st_row in self.source_table:
 						if st_row.row_material == row[
 							"item_code"
@@ -280,7 +333,7 @@ def to_prepare_data_for_make_mnf_stock_entry(self):
 								row["s_warehouse"],
 							)
 
-				if not linked_sres:
+				if not sre_matched:
 					# ── PRIORITY 2: Product Certification Receive ──
 					pc_receive_data = frappe.db.sql(
 						"""
@@ -974,7 +1027,12 @@ def _get_source_raw_materials(mop_name, snc_doc):
 		batch_no = r.get("batch_no")
 		qty = flt(r.get("qty_after_transaction_batch_based") or 0)
 		pcs = flt(r.get("pcs_after_transaction_batch_based") or 0)
-		if qty <= 0 and pcs <= 0:
+		# Skip rows with no weight. A real consumable raw material always carries a
+		# weight (gold in grams, diamonds in carats). A qty-0 / pcs>0 balance row is
+		# a tracking artifact — e.g. a finished-gold finding piece that flowed
+		# through an operation as 1 pcs with no weight of its own — and must not
+		# become a source/FG line (it would produce a zero-qty Stock Entry item).
+		if qty <= 0:
 			continue
 
 		uom = frappe.db.get_value("Item", item_code, "stock_uom") if item_code else None

--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/test_serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/test_serial_number_creator.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 from decimal import ROUND_HALF_UP, Decimal
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -17,9 +18,13 @@ from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.test_m
 	create_pmo,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.serial_number_creator.serial_number_creator import (
+	_sre_reserves_batch,
+	_warehouse_has_batch_stock,
 	calulate_id_wise_sum_up,
 	validate_qty,
 )
+
+_SNC_MODULE = "jewellery_erpnext.jewellery_erpnext.doctype.serial_number_creator.serial_number_creator"
 
 
 class TestSerialNumberCreator(FrappeTestCase):
@@ -284,3 +289,80 @@ def create_snc(self):
 	mwo_serial_no.submit()
 
 	return frappe.get_last_doc("Serial Number Creator")
+
+
+class TestWarehouseHasBatchStockGuard(FrappeTestCase):
+	"""Regression for BatchNegativeStockError on Serial Number Creator submit.
+
+	When an item has several active Stock Reservation Entries in different
+	warehouses (e.g. 0.005 in Model Making WO and 5.203 in Waxing WO), the SRE
+	warehouse-capture loop must NOT adopt a warehouse where the batch has no
+	stock — otherwise the auto-created Manufacture Stock Entry consumes the batch
+	from the wrong warehouse and submit fails with BatchNegativeStockError.
+
+	These tests exercise the guard in isolation (no fixtures required).
+	"""
+
+	@patch(f"{_SNC_MODULE}.get_batch_qty")
+	def test_skips_warehouse_without_batch_stock(self, mock_get_batch_qty):
+		mock_get_batch_qty.return_value = 0.0
+		self.assertFalse(
+			_warehouse_has_batch_stock(
+				"M-G-18KT-75.4-Y", "KG2F054-MGL18754Y0-F874H", "Model Making WO - KGJPL"
+			)
+		)
+		# Must query *physical* stock (ignore_reserved_stock=True): the batch being
+		# consumed is itself reserved, and the negative-stock validator checks
+		# physical qty, so reserved stock must not be subtracted here.
+		mock_get_batch_qty.assert_called_once_with(
+			"KG2F054-MGL18754Y0-F874H",
+			"Model Making WO - KGJPL",
+			"M-G-18KT-75.4-Y",
+			ignore_reserved_stock=True,
+		)
+
+	@patch(f"{_SNC_MODULE}.get_batch_qty")
+	def test_keeps_warehouse_with_batch_stock(self, mock_get_batch_qty):
+		mock_get_batch_qty.return_value = 5.203
+		self.assertTrue(
+			_warehouse_has_batch_stock(
+				"M-G-18KT-75.4-Y", "KG2F054-MGL18754Y0-F874H", "Waxing WO - KGJPL"
+			)
+		)
+
+	@patch(f"{_SNC_MODULE}.get_batch_qty")
+	def test_no_batch_is_allowed_without_querying_stock(self, mock_get_batch_qty):
+		# A row without a batch has nothing to validate; do not query stock.
+		self.assertTrue(
+			_warehouse_has_batch_stock("M-G-18KT-75.4-Y", None, "Waxing WO - KGJPL")
+		)
+		mock_get_batch_qty.assert_not_called()
+
+
+class TestSREReservesBatch(FrappeTestCase):
+	"""Each SRE reserves a specific batch; PRIORITY 1 must only adopt/cancel the
+	SRE that reserves the current row's batch. Without this, the first batch row
+	swallows every SRE for the item and later batch rows fall back to a stale
+	warehouse -> BatchNegativeStockError (the -0.005 KG2F061 case).
+	"""
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_matches_when_batch_in_sre_children(self, mock_get_all):
+		mock_get_all.return_value = ["KG2F061-MGL18754Y0-24H0B"]
+		self.assertTrue(
+			_sre_reserves_batch("MAT-SRE-2026-79547", "KG2F061-MGL18754Y0-24H0B")
+		)
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_does_not_match_other_batch(self, mock_get_all):
+		# SRE 79554 reserves KG2F054, so it must NOT match the KG2F061 row.
+		mock_get_all.return_value = ["KG2F054-MGL18754Y0-F874H"]
+		self.assertFalse(
+			_sre_reserves_batch("MAT-SRE-2026-79554", "KG2F061-MGL18754Y0-24H0B")
+		)
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_qty_based_sre_matches_any_batch(self, mock_get_all):
+		# Qty-based SRE has no Serial and Batch Entry children -> item-level match.
+		mock_get_all.return_value = []
+		self.assertTrue(_sre_reserves_batch("MAT-SRE-QTY", "KG2F061-MGL18754Y0-24H0B"))

--- a/jewellery_erpnext/jewellery_erpnext/doctype/subcontracting/doc_events/sub_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/subcontracting/doc_events/sub_utils.py
@@ -24,7 +24,7 @@ def create_repack_entry(self):
 	purity_percentage = self.purity_percentage if self.purity_percentage > 0 else 100
 	inventory_type = None
 	for row in self.source_table:
-		temp_row = copy.deepcopy(row.__dict__)
+		temp_row = copy.deepcopy(row.as_dict())
 		temp_row["name"] = None
 		temp_row["idx"] = None
 		temp_row["use_serial_batch_fields"] = True
@@ -36,7 +36,9 @@ def create_repack_entry(self):
 			"attribute_value",
 		)
 		if attribute_value:
-			purity_percentage = frappe.db.get_value("Attribute Value", attribute_value, "purity_percentage")
+			purity_percentage = frappe.db.get_value(
+				"Attribute Value", attribute_value, "purity_percentage"
+			)
 
 		temp_row["pure_qty"] = flt((purity_percentage * temp_row["qty"]) / 100, 3)
 
@@ -61,7 +63,9 @@ def create_repack_entry(self):
 	finish_raw = []
 
 	if self.transaction_type == "Receive":
-		batch_number_series = frappe.db.get_value("Item", self.finish_item, "batch_number_series")
+		batch_number_series = frappe.db.get_value(
+			"Item", self.finish_item, "batch_number_series"
+		)
 
 		batch_doc = frappe.new_doc("Batch")
 		batch_doc.item = self.finish_item
@@ -82,7 +86,12 @@ def create_repack_entry(self):
 				"item_code": item_dict["item_code"],
 				"qty": ["!=", "consume_qty"],
 			},
-			["batch_no", "qty", "(consume_qty + employee_qty) as consume_qty", "inventory_type"],
+			[
+				"batch_no",
+				"qty",
+				"(consume_qty + employee_qty) as consume_qty",
+				"inventory_type",
+			],
 		)
 		total_qty = item_dict["qty"]
 		for row in msl_batch_data:

--- a/jewellery_erpnext/jewellery_erpnext/property_setter/stock_entry_detail.json
+++ b/jewellery_erpnext/jewellery_erpnext/property_setter/stock_entry_detail.json
@@ -1,0 +1,13 @@
+{
+    "Stock Entry Detail": [
+        {
+            "doctype_or_field": "DocField",
+            "doctype": "Stock Entry Detail",
+            "fieldname": "transfer_qty",
+            "row_name": null,
+            "property": "precision",
+            "value": "3",
+            "property_type": "Select"
+        }
+    ]
+}

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_loss_stock_entry_voucher_qty.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_loss_stock_entry_voucher_qty.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for ``_reservation_voucher_qty``.
+
+Recreating a (reduced) Stock Reservation Entry must clear ERPNext's
+``validate_with_allowed_qty`` guard even when the Sales Order line is already
+over-reserved by sibling MWO reservations. The helper lifts ``voucher_qty`` to
+cover ``total_so_reserved + reserved_qty`` so the guard passes — mirroring
+``stock_reservation_entry_for_mwo``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.doctype.employee_ir.doc_events import (
+	loss_stock_entry,
+)
+
+# The helper imports this name locally from erpnext, so patch it at its source.
+_TOTAL_RESERVED_PATH = (
+	"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry"
+	".get_sre_reserved_qty_for_voucher_detail_no"
+)
+
+
+def _sre(**fields):
+	defaults = {
+		"voucher_type": "Sales Order",
+		"voucher_no": "SAL-ORD-2026-00956",
+		"voucher_detail_no": "soi-1",
+		"item_code": "M-G-22KT-91.9-Y",
+		"name": "MAT-SRE-2026-73342",
+		"voucher_qty": 28.2675,
+	}
+	defaults.update(fields)
+	return SimpleNamespace(**defaults)
+
+
+class TestReservationVoucherQty(FrappeTestCase):
+	def test_over_reserved_so_lifts_voucher_qty(self):
+		# Other active SREs already hold 22.2 against a 28.2675 SO line; the
+		# reduced reservation of 7.76 would otherwise exceed the 6.068 allowance.
+		sre = _sre()
+		with patch(_TOTAL_RESERVED_PATH, return_value=22.2) as mock_total:
+			result = loss_stock_entry._reservation_voucher_qty(sre, 7.76)
+
+		self.assertAlmostEqual(result, 29.96)
+		mock_total.assert_called_once_with(
+			"M-G-22KT-91.9-Y",
+			"Sales Order",
+			"SAL-ORD-2026-00956",
+			"soi-1",
+			ignore_sre="MAT-SRE-2026-73342",
+		)
+
+	def test_keeps_base_when_not_over_reserved(self):
+		# total + qty (5.0 + 7.76 = 12.76) is below the SO qty → keep base.
+		sre = _sre()
+		with patch(_TOTAL_RESERVED_PATH, return_value=5.0):
+			result = loss_stock_entry._reservation_voucher_qty(sre, 7.76)
+
+		self.assertAlmostEqual(result, 28.2675)
+
+	def test_non_sales_order_returns_base(self):
+		sre = _sre(voucher_type="Work Order")
+		with patch(_TOTAL_RESERVED_PATH) as mock_total:
+			result = loss_stock_entry._reservation_voucher_qty(sre, 7.76)
+
+		self.assertAlmostEqual(result, 28.2675)
+		mock_total.assert_not_called()
+
+	def test_missing_voucher_detail_returns_base(self):
+		sre = _sre(voucher_detail_no=None)
+		with patch(_TOTAL_RESERVED_PATH) as mock_total:
+			result = loss_stock_entry._reservation_voucher_qty(sre, 7.76)
+
+		self.assertAlmostEqual(result, 28.2675)
+		mock_total.assert_not_called()
+
+
+def _loss_row(**fields):
+	defaults = {
+		"item_code": "D-NT-RO-MH12A-+7.5-8",
+		"batch_no": "GE2D075-DNTROMH12AG05H00-02",
+		"stock_uom": "Carat",
+		"manufacturing_operation": "MOP-W64S6",
+		"inventory_type": "Regular Stock",
+		"customer": None,
+		"pcs": "2",
+	}
+	defaults.update(fields)
+	return SimpleNamespace(**defaults)
+
+
+def _entry(row, **fields):
+	defaults = {
+		"row": row,
+		"qty": 0.01,
+		"mwo": "MWO-GEPL-EA04270-001-6-91.9-Y-01",
+		"s_warehouse": "Diamond Setting WO - GEPL",
+		"t_warehouse": "Diamond Setting Scrap - GEPL",
+		"loss_item": "DL-NT-RO-MH12A-+7.5-8",
+	}
+	defaults.update(fields)
+	return defaults
+
+
+class TestLossStockEntryPcs(FrappeTestCase):
+	"""``_build_combined_loss_se`` must carry the loss row's pcs onto both the
+	consume and produce Stock Entry rows, falling back to "1" when absent."""
+
+	def setUp(self):
+		self.eir = SimpleNamespace(
+			name="vdgd5en0kd",
+			company="Gurukrupa Export Private Limited",
+			department="Diamond Setting - GEPL",
+			subcontracting="No",
+			employee="HR-EMP-00336",
+			subcontractor=None,
+		)
+
+	def test_pcs_copied_to_both_rows(self):
+		row = _loss_row(pcs="2")
+		se = loss_stock_entry._build_combined_loss_se(self.eir, [_entry(row)])
+
+		# Two rows per loss entry: consume (idx 0) and produce (idx 1).
+		self.assertEqual(len(se.items), 2)
+		self.assertEqual(se.items[0].pcs, "2")
+		self.assertEqual(se.items[1].pcs, "2")
+
+	def test_missing_pcs_falls_back_to_one(self):
+		row = _loss_row(pcs=None)
+		se = loss_stock_entry._build_combined_loss_se(self.eir, [_entry(row)])
+
+		self.assertEqual(se.items[0].pcs, "1")
+		self.assertEqual(se.items[1].pcs, "1")

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_pcs.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_make_receive_entry_pcs.py
@@ -491,3 +491,298 @@ class TestCreateMrWoStockEntryPcsValidation(FrappeTestCase):
 				request_id="t13",
 			)
 		new_doc_mock.assert_not_called()
+
+
+def _batch_sre(name="SRE-D", item_code="D-NT-RO-7-+5.5-6"):
+	"""Batch-based SRE (one per Material Transfer item) — the popup expands it
+	into one row per Serial and Batch Entry line.
+	"""
+	return frappe._dict(
+		{
+			"name": name,
+			"item_code": item_code,
+			"warehouse": "WH-Src",
+			"reserved_qty": 0.0,
+			"delivered_qty": 0.0,
+			"stock_uom": "Carat",
+			"voucher_type": "Sales Order",
+			"voucher_no": "SO-1",
+			"voucher_detail_no": "SOI-1",
+			"has_serial_no": 0,
+			"has_batch_no": 1,
+			"reservation_based_on": "Serial and Batch",
+			"manufacturing_work_order": "MWO-1",
+			"manufacturing_operation": "MOP-1",
+		}
+	)
+
+
+def _sb_entry(name, parent, batch_no, qty, delivered_qty=0.0):
+	return frappe._dict(
+		{
+			"name": name,
+			"parent": parent,
+			"batch_no": batch_no,
+			"qty": qty,
+			"delivered_qty": delivered_qty,
+		}
+	)
+
+
+def _balance_row(item_code, batch_no, qty_batch, pcs_batch):
+	"""Latest running-balance row (what get_current_mop_balance_rows surfaces)."""
+	return frappe._dict(
+		{
+			"name": f"MOPLOG-BAL-{batch_no}",
+			"item_code": item_code,
+			"batch_no": batch_no,
+			"qty_after_transaction_batch_based": qty_batch,
+			"pcs_after_transaction_batch_based": pcs_batch,
+		}
+	)
+
+
+def _transfer_row(name, item_code, batch_no, qty_change, pcs_change):
+	"""Per-row incoming-transfer row (what get_mop_transfer_pcs_rows surfaces)."""
+	return frappe._dict(
+		{
+			"name": name,
+			"item_code": item_code,
+			"batch_no": batch_no,
+			"qty_after_transaction_batch_based": 0.0,
+			"pcs_after_transaction_batch_based": 0,
+			"qty_change": qty_change,
+			"pcs_change": pcs_change,
+		}
+	)
+
+
+class TestMakeReceiveEntryPerRowPcs(FrappeTestCase):
+	"""Two reserved batch lines sharing the same (item, batch) must each show
+	their OWN transferred PCS, not the batch-wide running total.
+
+	Regression: the popup summed pcs by item+batch and showed the total (31)
+	on every line; qty stayed per-line (0.072 / 0.046). The fix sources each
+	line's pcs from its originating MOP Log transfer row (19 / 12).
+	"""
+
+	ITEM = "D-NT-RO-7-+5.5-6"
+	BATCH = "GE2D075-DNTROX7E05F00-01"
+
+	def _patch_popup(self, sre_rows, mop_rows, sb_rows):
+		def _dispatcher(doctype, *args, **kwargs):
+			if doctype == "Stock Reservation Entry":
+				return list(sre_rows)
+			if doctype == "MOP Log":
+				return list(mop_rows)
+			if doctype == "Serial and Batch Entry":
+				return list(sb_rows)
+			return []
+
+		patches = [
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.get_doc",
+				return_value=_make_mo(),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_value",
+				return_value="WH-Raw",
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.get_single_value",
+				return_value=3,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.frappe.db.sql",
+				return_value=[],
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.resolve_and_validate",
+				return_value="WH-Resolved",
+			),
+			patch("frappe.db.get_all", side_effect=_dispatcher),
+		]
+		for p in patches:
+			p.start()
+			self.addCleanup(p.stop)
+
+	def test_per_row_pcs_split_across_same_item_batch(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		# One transfer SRE, two batch lines of the SAME (item, batch).
+		self._patch_popup(
+			sre_rows=[_batch_sre()],
+			mop_rows=[
+				# Running balance (batch total) — used for the qty/pcs cap.
+				_balance_row(self.ITEM, self.BATCH, qty_batch=0.118, pcs_batch=31),
+				# Per-row incoming transfers — the authoritative per-line pcs.
+				_transfer_row("T1", self.ITEM, self.BATCH, 0.072, 19),
+				_transfer_row("T2", self.ITEM, self.BATCH, 0.046, 12),
+			],
+			sb_rows=[
+				_sb_entry("SB1", "SRE-D", self.BATCH, 0.072),
+				_sb_entry("SB2", "SRE-D", self.BATCH, 0.046),
+			],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
+		by_qty = {round(r["available_to_receive_qty"], 3): r for r in rows}
+		self.assertEqual(len(rows), 2)
+		# Qty stays per-line; pcs is now ALSO per-line (was 31/31 before).
+		self.assertEqual(by_qty[0.072]["available_to_receive_pcs"], 19)
+		self.assertEqual(by_qty[0.046]["available_to_receive_pcs"], 12)
+		# Sum equals the batch balance — never over-states.
+		self.assertEqual(sum(r["available_to_receive_pcs"] for r in rows), 31)
+
+	def test_fallback_to_batch_aggregate_when_no_transfer_rows(self):
+		"""No per-row transfer rows (legacy data) → fall back to the batch
+		aggregate, preserving prior behaviour."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		self._patch_popup(
+			sre_rows=[_batch_sre()],
+			mop_rows=[_balance_row(self.ITEM, self.BATCH, qty_batch=0.05, pcs_batch=8)],
+			sb_rows=[_sb_entry("SB1", "SRE-D", self.BATCH, 0.05)],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["available_to_receive_pcs"], 8)
+
+	def _run_loss_scenario(self, sb_rows):
+		"""Two batch lines of the same (item, batch): one transferred 47 pcs
+		(0.494 ct) then lost 5 pcs (now 0.482 ct remaining), the other 15 pcs
+		(0.158 ct, untouched). Live batch balance after the loss is 57 pcs.
+		Returns ``{remaining_qty: available_to_receive_pcs}``.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		self._patch_popup(
+			sre_rows=[_batch_sre()],
+			mop_rows=[
+				# Latest running balance for the batch (post-loss cap).
+				_balance_row(self.ITEM, self.BATCH, qty_batch=0.640, pcs_batch=57),
+				# The two incoming Material Transfer rows (authoritative per-line).
+				_transfer_row("T-BIG", self.ITEM, self.BATCH, 0.494, 47),
+				_transfer_row("T-SML", self.ITEM, self.BATCH, 0.158, 15),
+			],
+			sb_rows=sb_rows,
+		)
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
+		self.assertEqual(len(rows), 2)
+		return {round(r["available_to_receive_qty"], 3): r for r in rows}
+
+	def test_loss_attributed_to_shrunken_line(self):
+		"""The line that absorbed the 5-pcs loss (0.494 → 0.482) shows 42; the
+		untouched 0.158 line keeps its full 15. Sum equals the 57 balance.
+		Mirrors GE-MR-MF-26-67704 / Employee IR tvhgsi1gk1.
+		"""
+		by_qty = self._run_loss_scenario(
+			sb_rows=[
+				_sb_entry("SB-BIG", "SRE-D", self.BATCH, 0.482),
+				_sb_entry("SB-SML", "SRE-D", self.BATCH, 0.158),
+			]
+		)
+		self.assertEqual(by_qty[0.482]["available_to_receive_pcs"], 42)
+		self.assertEqual(by_qty[0.158]["available_to_receive_pcs"], 15)
+		self.assertEqual(
+			sum(r["available_to_receive_pcs"] for r in by_qty.values()), 57
+		)
+
+	def test_loss_split_is_order_independent(self):
+		"""Same scenario with the sibling lines iterated in the opposite order
+		must yield the identical 42 / 15 split (regression for the prior
+		order-dependent cursor)."""
+		by_qty = self._run_loss_scenario(
+			sb_rows=[
+				_sb_entry("SB-SML", "SRE-D", self.BATCH, 0.158),
+				_sb_entry("SB-BIG", "SRE-D", self.BATCH, 0.482),
+			]
+		)
+		self.assertEqual(by_qty[0.482]["available_to_receive_pcs"], 42)
+		self.assertEqual(by_qty[0.158]["available_to_receive_pcs"], 15)
+
+	def test_no_loss_clean_lines_keep_own_transfer_pcs(self):
+		"""GE-MR-MF-26-67712: two reserved lines of +00-0 share a batch with no
+		loss (transfers 24 @ 0.720 and 8 @ 0.173, balance 32). Each keeps its OWN
+		transfer pcs — 24 and 8 — never the 32 aggregate. A sibling single-line
+		item (+7.5-8, 24 @ 0.825) is unaffected.
+		"""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			get_make_receive_entry_rows,
+		)
+
+		item_00 = "D-NT-RO-MH12A-+00-0"
+		item_78 = "D-NT-RO-MH12A-+7.5-8"
+		batch_00 = "GE2D075-DNTROMH12A0000-01"
+		batch_78 = "GE2D075-DNTROMH12A7508-01"
+
+		self._patch_popup(
+			sre_rows=[
+				_batch_sre(name="SRE-00", item_code=item_00),
+				_batch_sre(name="SRE-78", item_code=item_78),
+			],
+			mop_rows=[
+				# Balance rows FIRST per key (dedup keeps the first as latest).
+				_balance_row(item_00, batch_00, qty_batch=0.893, pcs_batch=32),
+				_transfer_row("T00-BIG", item_00, batch_00, 0.720, 24),
+				_transfer_row("T00-SML", item_00, batch_00, 0.173, 8),
+				_balance_row(item_78, batch_78, qty_batch=0.825, pcs_batch=24),
+				_transfer_row("T78", item_78, batch_78, 0.825, 24),
+			],
+			sb_rows=[
+				_sb_entry("SB00-BIG", "SRE-00", batch_00, 0.720),
+				_sb_entry("SB00-SML", "SRE-00", batch_00, 0.173),
+				_sb_entry("SB78", "SRE-78", batch_78, 0.825),
+			],
+		)
+		rows = get_make_receive_entry_rows("MOP-1")["rows"]
+		self.assertEqual(len(rows), 3)
+		by_qty = {round(r["available_to_receive_qty"], 3): r for r in rows}
+		self.assertEqual(by_qty[0.720]["available_to_receive_pcs"], 24)
+		self.assertEqual(by_qty[0.173]["available_to_receive_pcs"], 8)
+		self.assertEqual(by_qty[0.825]["available_to_receive_pcs"], 24)
+		# The two +00-0 lines sum to their 32 batch balance — no over-statement.
+		pcs_00 = [
+			r["available_to_receive_pcs"] for r in rows if r["item_code"] == item_00
+		]
+		self.assertEqual(sum(pcs_00), 32)
+
+
+class TestMopTransferPcsRowsScope(FrappeTestCase):
+	"""``get_mop_transfer_pcs_rows`` must scope by Manufacturing Work Order, not
+	a single MOP. The per-row transfer (pcs_change>0) is logged once at the
+	operation that first received the material; a downstream operation carries
+	only balance clones (pcs_change=0). MOP-scoping there finds nothing and the
+	popup falls back to the batch aggregate (the GE-MR-MF-26-67712 / MOP-O692V
+	bug). MWO is constant across operations, so the lookup must use it.
+	"""
+
+	def test_scopes_by_manufacturing_work_order(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+			get_mop_transfer_pcs_rows,
+		)
+
+		captured = {}
+
+		def _fake_get_all(doctype, filters=None, fields=None, order_by=None):
+			captured["doctype"] = doctype
+			captured["filters"] = filters
+			return []
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_all",
+			side_effect=_fake_get_all,
+		):
+			get_mop_transfer_pcs_rows("MWO-XYZ")
+
+		self.assertEqual(captured["doctype"], "MOP Log")
+		self.assertEqual(captured["filters"].get("manufacturing_work_order"), "MWO-XYZ")
+		# Must NOT scope by a single MOP, and must keep only incoming transfers.
+		self.assertNotIn("manufacturing_operation", captured["filters"])
+		self.assertEqual(captured["filters"].get("pcs_change"), [">", 0])
+		self.assertEqual(captured["filters"].get("is_cancelled"), 0)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_stock_entry_detail_precision.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_stock_entry_detail_precision.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Regression guard for Stock Entry Detail ``transfer_qty`` precision.
+
+A tiny but genuine metal loss (e.g. 0.005 g) is booked on the auto-created
+"Process Loss" Stock Entry. ERPNext's ``StockEntry.set_transfer_qty`` rounds
+``transfer_qty`` to the field precision and throws *"Qty in Stock UOM can not
+be zero."* when it lands on 0. Core ``Stock Entry Detail.qty`` already carries
+precision 3, but ``transfer_qty`` had no override and fell back to System
+Settings ``float_precision`` (2), where ``flt(0.005, 2)`` rounds to 0.00 under
+Banker's Rounding.
+
+A property setter (``property_setter/stock_entry_detail.json``, applied via
+``migrate.after_migrate`` → ``create_property_setter``) pins ``transfer_qty``
+to precision 3 so the loss survives as a real stock movement. This test fails
+if that customization is missing or regressed.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import flt
+
+
+class TestStockEntryDetailPrecision(FrappeTestCase):
+	def test_transfer_qty_precision_is_three(self):
+		# The property setter must be in effect so transfer_qty matches qty (3).
+		self.assertEqual(frappe.get_precision("Stock Entry Detail", "transfer_qty"), 3)
+		self.assertEqual(frappe.get_precision("Stock Entry Detail", "qty"), 3)
+
+	def test_sub_precision_loss_is_not_zeroed(self):
+		# At precision 3 a 0.005 g loss is representable; at precision 2 (the
+		# regressed state) it would round to 0.00 and trip the zero-qty throw.
+		precision = frappe.get_precision("Stock Entry Detail", "transfer_qty")
+		self.assertNotEqual(flt(0.005, precision), 0)

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_validate_pcs_batch_split.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_validate_pcs_batch_split.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for ``validate_pcs`` — the per-MR-item PCS distribution when a single
+Material Request Item's qty is split across multiple batch rows.
+
+Rule: the MR Item's PCS is the authoritative total; the first batch row keeps
+the bulk and every extra batch row defaults to 1 (never 0) so a row physically
+holding stock is never shown as 0 pcs. The total is preserved (e.g. 71 → 70 + 1)
+and the pass is idempotent (the MOP Stock Entry re-runs it on already-split rows).
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import validate_pcs
+
+
+class _Row:
+	def __init__(self, mri, pcs, batch_no=None):
+		self.material_request_item = mri
+		self.pcs = pcs
+		self.batch_no = batch_no
+
+
+class _SE:
+	def __init__(self, items):
+		self.items = items
+		self.flags = frappe._dict()
+
+
+class TestValidatePcsBatchSplit(FrappeTestCase):
+	def _run(self, items, mri_pcs):
+		def _gv(doctype, name, field):
+			return mri_pcs.get(name)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry.frappe.db.get_value",
+			side_effect=_gv,
+		):
+			validate_pcs(_SE(items))
+
+	def test_split_gives_extra_row_minimum_one(self):
+		"""MAT-STE-51278: MR item pcs 71 split across two batches → 70 + 1."""
+		items = [
+			_Row("n5c7c76keg", 71, "B05C00-02"),
+			_Row("n5c7c76keg", 71, "B05C00-04"),
+		]
+		self._run(items, {"n5c7c76keg": 71})
+		self.assertEqual([r.pcs for r in items], [70, 1])
+		self.assertEqual(sum(r.pcs for r in items), 71)
+
+	def test_idempotent_on_already_split_rows(self):
+		"""Re-running on rows already at 70/1 (the MOP SE copies the reserve SE
+		and runs before_validate again) keeps 70/1, not 69/1."""
+		items = [
+			_Row("n5c7c76keg", 70, "B05C00-02"),
+			_Row("n5c7c76keg", 1, "B05C00-04"),
+		]
+		self._run(items, {"n5c7c76keg": 71})
+		self.assertEqual([r.pcs for r in items], [70, 1])
+
+	def test_three_batch_split_preserves_total(self):
+		items = [_Row("n5", 71, "B1"), _Row("n5", 71, "B2"), _Row("n5", 71, "B3")]
+		self._run(items, {"n5": 71})
+		self.assertEqual([r.pcs for r in items], [69, 1, 1])
+		self.assertEqual(sum(r.pcs for r in items), 71)
+
+	def test_single_row_untouched(self):
+		items = [_Row("n5", 71, "B1")]
+		self._run(items, {"n5": 71})
+		self.assertEqual(items[0].pcs, 71)
+
+	def test_total_too_small_keeps_whole_count_on_first(self):
+		"""1 pc can't be spread one-each across two batches without driving the
+		first row below 1 — keep the whole count on the first (prior behaviour)."""
+		items = [_Row("n5", 1, "B1"), _Row("n5", 1, "B2")]
+		self._run(items, {"n5": 1})
+		self.assertEqual([r.pcs for r in items], [1, 0])
+
+	def test_rows_without_mr_item_are_ignored(self):
+		items = [_Row(None, 5, "B1"), _Row("", 9, "B2")]
+		self._run(items, {})
+		self.assertEqual([r.pcs for r in items], [5, 9])
+
+	def test_distinct_mr_items_independent(self):
+		items = [
+			_Row("a", 71, "B1"),
+			_Row("a", 71, "B2"),
+			_Row("b", 10, "B3"),
+		]
+		self._run(items, {"a": 71, "b": 10})
+		self.assertEqual([r.pcs for r in items], [70, 1, 10])

--- a/jewellery_erpnext/patches.txt
+++ b/jewellery_erpnext/patches.txt
@@ -13,3 +13,4 @@ jewellery_erpnext.patches.default_gemstone_item
 jewellery_erpnext.patches.add_mop_eod_sync_fields_and_indexes
 jewellery_erpnext.patches.add_eod_se_custom_fields
 jewellery_erpnext.patches.add_mop_eod_sync_log_indexes
+jewellery_erpnext.patches.backfill_employee_ir_mop_log_to_warehouse

--- a/jewellery_erpnext/patches/backfill_employee_ir_mop_log_to_warehouse.py
+++ b/jewellery_erpnext/patches/backfill_employee_ir_mop_log_to_warehouse.py
@@ -1,0 +1,154 @@
+import frappe
+
+from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+	_get_t_warehouse_from_logs,
+	_resolve_department_warehouse,
+)
+
+# Flush accumulated updates to the DB (and commit) every this many rows, so a
+# large backlog never trips Frappe's MAX_WRITES_PER_TRANSACTION limit and the
+# transaction / memory footprint stay bounded.
+FLUSH_EVERY = 5000
+
+
+def _flush(doc_updates):
+	"""bulk_update + commit the pending rows, then clear the buffer.
+
+	Returns the number of rows written. ``bulk_update`` collapses each chunk
+	into a single CASE-based UPDATE and preserves existing values for any field
+	a given row does not supply, so rows that only set ``to_warehouse`` keep
+	their ``from_warehouse`` untouched (and vice-versa).
+	"""
+	if not doc_updates:
+		return 0
+	frappe.db.bulk_update("MOP Log", doc_updates, chunk_size=100, update_modified=False)
+	frappe.db.commit()
+	n = len(doc_updates)
+	doc_updates.clear()
+	return n
+
+
+def execute():
+	"""Backfill blank ``to_warehouse`` on Employee IR MOP Log rows.
+
+	Employee IR *Receive* audit clones were historically written without a
+	destination warehouse (the receive path, unlike the issue path, did not
+	guarantee a resolved warehouse). Populate ``to_warehouse`` using the same
+	fallback chain the on-submit fix now uses:
+
+	  1. the row's Manufacturing Operation department's Manufacturing warehouse
+	  2. the latest non-null ``to_warehouse`` already on the MWO's logs
+
+	``from_warehouse`` is filled best-effort from the originating Employee IR's
+	employee / subcontractor Manufacturing warehouse. Fields are read-only, so
+	``frappe.db.set_value`` is used to bypass the form guard.
+	"""
+	rows = frappe.db.get_all(
+		"MOP Log",
+		filters={
+			"voucher_type": "Employee IR",
+			"to_warehouse": ["in", [None, ""]],
+		},
+		fields=[
+			"name",
+			"manufacturing_operation",
+			"manufacturing_work_order",
+			"voucher_no",
+			"from_warehouse",
+		],
+	)
+	if not rows:
+		print("backfill_employee_ir_mop_log_to_warehouse: nothing to backfill")
+		return
+
+	to_wh_by_mop = {}
+	to_wh_by_mwo = {}
+	from_wh_by_eir = {}
+	doc_updates = {}
+	updated = 0
+
+	for row in rows:
+		# --- destination (to_warehouse) ---
+		to_wh = None
+		mop = row.manufacturing_operation
+		if mop:
+			if mop not in to_wh_by_mop:
+				department = frappe.db.get_value(
+					"Manufacturing Operation", mop, "department"
+				)
+				to_wh_by_mop[mop] = (
+					_resolve_department_warehouse({"department": department})
+					if department
+					else None
+				)
+			to_wh = to_wh_by_mop[mop]
+
+		mwo = row.manufacturing_work_order
+		if not to_wh and mwo:
+			if mwo not in to_wh_by_mwo:
+				to_wh_by_mwo[mwo] = _get_t_warehouse_from_logs(
+					frappe.get_all(
+						"MOP Log",
+						filters={
+							"manufacturing_work_order": mwo,
+							"is_cancelled": 0,
+							"to_warehouse": ["not in", [None, ""]],
+						},
+						fields=["to_warehouse", "flow_index", "creation"],
+					)
+				)
+			to_wh = to_wh_by_mwo[mwo]
+
+		# --- source (from_warehouse), best-effort ---
+		from_wh = row.from_warehouse
+		eir = row.voucher_no
+		if not from_wh and eir:
+			if eir not in from_wh_by_eir:
+				from_wh_by_eir[eir] = _resolve_employee_ir_actor_warehouse(eir)
+			from_wh = from_wh_by_eir[eir]
+
+		updates = {}
+		if to_wh:
+			updates["to_warehouse"] = to_wh
+		if from_wh and not row.from_warehouse:
+			updates["from_warehouse"] = from_wh
+		if updates:
+			doc_updates[row.name] = updates
+			if len(doc_updates) >= FLUSH_EVERY:
+				updated += _flush(doc_updates)
+
+	updated += _flush(doc_updates)
+	print(
+		f"backfill_employee_ir_mop_log_to_warehouse: scanned {len(rows)}, "
+		f"updated {updated} MOP Log row(s)"
+	)
+
+
+def _resolve_employee_ir_actor_warehouse(eir_name):
+	"""Manufacturing warehouse of the Employee IR's employee / subcontractor."""
+	eir = frappe.db.get_value(
+		"Employee IR",
+		eir_name,
+		["subcontracting", "company", "subcontractor", "employee"],
+		as_dict=True,
+	)
+	if not eir:
+		return None
+	if eir.subcontracting == "Yes":
+		return frappe.db.get_value(
+			"Warehouse",
+			{
+				"disabled": 0,
+				"company": eir.company,
+				"subcontractor": eir.subcontractor,
+				"warehouse_type": "Manufacturing",
+			},
+		)
+	return frappe.db.get_value(
+		"Warehouse",
+		{
+			"disabled": 0,
+			"employee": eir.employee,
+			"warehouse_type": "Manufacturing",
+		},
+	)

--- a/jewellery_erpnext/patches/reset_silently_synced_missing_sre_mop_logs.py
+++ b/jewellery_erpnext/patches/reset_silently_synced_missing_sre_mop_logs.py
@@ -1,0 +1,112 @@
+"""One-off remediation for the silent-sync bug in MOP EOD Sync.
+
+A partially-completed EOD run (e.g. ``MOP-EOD-SYNC-2026-03606``) marked MOP Logs
+``is_synced=1`` for MWOs whose every item had a *Missing SRE* — even though no Stock
+Entry was created and no stock moved. Those logs are now buried (``is_synced=1``
+excludes them from future runs) so they can never be re-picked.
+
+This script resets ``is_synced=0`` on exactly those logs so a future EOD run re-picks
+them — but only AFTER the underlying Stock Reservation Entries are created/fixed,
+otherwise they will fail the same way (now visibly, not silently).
+
+It is NOT registered in patches.txt; run it manually. Dry-run first:
+
+    bench --site gk execute \
+        jewellery_erpnext.patches.reset_silently_synced_missing_sre_mop_logs.execute
+
+Apply:
+
+    bench --site gk execute \
+        jewellery_erpnext.patches.reset_silently_synced_missing_sre_mop_logs.execute \
+        --kwargs "{'dry_run': False}"
+
+Idempotent and scoped strictly to the sync log + its posting-date day window (matching
+``_mark_all_mwo_mop_logs_synced``'s window), so it is safe to re-run.
+"""
+
+import frappe
+from frappe.utils import add_days, getdate
+
+DEFAULT_SYNC_LOG = "MOP-EOD-SYNC-2026-03606"
+
+
+def execute(sync_log_name=DEFAULT_SYNC_LOG, dry_run=True):
+	if not frappe.db.exists("MOP EOD Sync Log", sync_log_name):
+		print(f"[reset-missing-sre] Sync log {sync_log_name} not found; nothing to do.")
+		return
+
+	posting_date = frappe.db.get_value(
+		"MOP EOD Sync Log", sync_log_name, "posting_date"
+	)
+	day_start = getdate(posting_date)
+	# Same window semantics as _mark_all_mwo_mop_logs_synced: [start 00:00, next 00:00)
+	today_start = f"{day_start} 00:00:00"
+	tomorrow_start = f"{add_days(day_start, 1)} 00:00:00"
+
+	# MWOs whose items failed with Missing SRE in this run (every such MWO was wrongly
+	# marked synced because all its rows were skipped → no transfer happened).
+	mwos = frappe.get_all(
+		"MOP EOD Sync Log Item",
+		filters={
+			"parent": sync_log_name,
+			"status": "Failed",
+			"error_type": "Missing SRE",
+		},
+		pluck="manufacturing_work_order",
+		distinct=True,
+	)
+	mwos = sorted({m for m in mwos if m})
+
+	if not mwos:
+		print("[reset-missing-sre] No Missing-SRE failures found; nothing to do.")
+		return
+
+	# Per-MWO counts of buried logs (is_synced=1) within the run's day window.
+	rows = frappe.db.sql(
+		"""
+		SELECT manufacturing_work_order AS mwo, COUNT(*) AS n
+		FROM `tabMOP Log`
+		WHERE manufacturing_work_order IN %(mwos)s
+		  AND is_synced = 1
+		  AND is_cancelled = 0
+		  AND creation >= %(today_start)s
+		  AND creation < %(tomorrow_start)s
+		GROUP BY manufacturing_work_order
+		""",
+		{"mwos": mwos, "today_start": today_start, "tomorrow_start": tomorrow_start},
+		as_dict=True,
+	)
+	per_mwo = {r.mwo: r.n for r in rows}
+	total = sum(per_mwo.values())
+
+	print(
+		f"[reset-missing-sre] Sync log {sync_log_name} (posting_date {day_start}): "
+		f"{len(mwos)} Missing-SRE MWO(s), {total} buried MOP Log(s) to reset."
+	)
+	for mwo in mwos:
+		print(f"  {mwo}: {per_mwo.get(mwo, 0)} log(s)")
+
+	if dry_run:
+		print(
+			"[reset-missing-sre] DRY RUN — no changes written. Re-run with dry_run=False to apply."
+		)
+		return
+
+	if not total:
+		print("[reset-missing-sre] Nothing to reset (already clean).")
+		return
+
+	frappe.db.sql(
+		"""
+		UPDATE `tabMOP Log`
+		SET is_synced = 0
+		WHERE manufacturing_work_order IN %(mwos)s
+		  AND is_synced = 1
+		  AND is_cancelled = 0
+		  AND creation >= %(today_start)s
+		  AND creation < %(tomorrow_start)s
+		""",
+		{"mwos": mwos, "today_start": today_start, "tomorrow_start": tomorrow_start},
+	)
+	frappe.db.commit()
+	print(f"[reset-missing-sre] Reset is_synced=0 on {total} MOP Log(s). Done.")

--- a/jewellery_erpnext/patches/retry_stuck_eod_submit_mwos.py
+++ b/jewellery_erpnext/patches/retry_stuck_eod_submit_mwos.py
@@ -1,0 +1,191 @@
+"""One-off retry for MOP EOD Sync MWOs left stuck after a Phase-2 submit failure.
+
+A partially-completed EOD run (e.g. ``MOP-EOD-SYNC-2026-03606``) left some MWOs with a
+draft Stock Entry because ``_recreate_sres_at`` failed (over-reserved SO line / batch not
+free). That re-reservation bug is now fixed, so these MWOs can be re-processed.
+
+Two groups (decided per MWO from the sync log's "Draft Created" child rows):
+  * Retryable — the draft SE is still un-submitted (docstatus 0/2). Phase 2 rolled back, so
+    the source SREs are intact and the MOP Logs are still ``is_synced=0``. We delete the
+    orphan draft SE and re-run the MWO through the real (fixed) per-MWO sync path in
+    selective mode (scheduled mode only handles *today's* logs; these are older).
+  * Skipped — the draft SE was submitted manually after the run. Stock moved but the SRE
+    relocation never ran and the logs are still unsynced: an inconsistent state that needs
+    separate manual reconciliation. We do NOT auto-retry (EOD would build a 2nd transfer).
+
+NOT registered in patches.txt; run it manually. Dry-run first:
+
+    bench --site gk execute \
+        jewellery_erpnext.patches.retry_stuck_eod_submit_mwos.execute
+
+Apply:
+
+    bench --site gk execute \
+        jewellery_erpnext.patches.retry_stuck_eod_submit_mwos.execute \
+        --kwargs "{'dry_run': False}"
+"""
+
+import frappe
+
+DEFAULT_SYNC_LOG = "MOP-EOD-SYNC-2026-03606"
+
+
+def _classify(sync_log_name):
+	"""Return (retryable, skipped): {mwo: [draft_se,...]} from the sync log."""
+	rows = frappe.get_all(
+		"MOP EOD Sync Log Item",
+		filters={"parent": sync_log_name, "status": "Draft Created"},
+		fields=["manufacturing_work_order", "draft_stock_entry"],
+		limit_page_length=0,
+	)
+	mwo_drafts = {}
+	for r in rows:
+		if r.manufacturing_work_order:
+			mwo_drafts.setdefault(r.manufacturing_work_order, set()).add(
+				r.draft_stock_entry or ""
+			)
+
+	retryable, skipped = {}, {}
+	for mwo, drafts in mwo_drafts.items():
+		states = []
+		for se in drafts:
+			if not se:
+				continue
+			ds = frappe.db.get_value("Stock Entry", se, "docstatus")
+			states.append((se, ds))
+		# Submitted (docstatus 1) draft anywhere → inconsistent, manual reconciliation.
+		if any(ds == 1 for _, ds in states):
+			skipped[mwo] = [se for se, ds in states if ds == 1]
+		else:
+			retryable[mwo] = [se for se, ds in states if ds == 0]
+	return retryable, skipped
+
+
+def execute(sync_log_name=DEFAULT_SYNC_LOG, dry_run=True):
+	if not frappe.db.exists("MOP EOD Sync Log", sync_log_name):
+		print(f"[retry-stuck-eod] Sync log {sync_log_name} not found; nothing to do.")
+		return
+
+	retryable, skipped = _classify(sync_log_name)
+
+	print(f"[retry-stuck-eod] Sync log {sync_log_name}")
+	print(f"  Retryable MWOs (will delete orphan draft + re-run): {len(retryable)}")
+	for mwo, drafts in retryable.items():
+		print(f"    {mwo}: drafts={drafts or '(none)'}")
+	print(
+		f"  Skipped MWOs (manually submitted — manual reconciliation needed): {len(skipped)}"
+	)
+	for mwo, drafts in skipped.items():
+		print(f"    {mwo}: submitted={drafts}")
+
+	if dry_run:
+		print(
+			"[retry-stuck-eod] DRY RUN — no changes written. Re-run with dry_run=False to apply."
+		)
+		return
+
+	if not retryable:
+		print("[retry-stuck-eod] No retryable MWOs; nothing to do.")
+		return
+
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+		_get_unsynced_mop_groups,
+		_process_mwo_group,
+	)
+
+	# EOD-internal writes (SE submit, SRE relocation) must bypass the transaction lock.
+	frappe.flags.in_eod_mop_sync = True
+
+	# 1. Delete the orphan draft SEs so the re-run recreates cleanly.
+	for mwo, drafts in retryable.items():
+		for se in drafts:
+			frappe.delete_doc("Stock Entry", se, force=1, ignore_permissions=True)
+	frappe.db.commit()
+	print(
+		f"[retry-stuck-eod] Deleted {sum(len(d) for d in retryable.values())} orphan draft SE(s)."
+	)
+
+	# 2. Re-process the retryable MWOs through the real per-MWO path in selective mode
+	#    (full unsynced history, ignores the today-only window).
+	mwos = list(retryable.keys())
+	settings = frappe._dict(
+		eod_sync_work_order_filter=[
+			frappe._dict(enabled=1, manufacturing_work_order=m) for m in mwos
+		]
+	)
+	groups = _get_unsynced_mop_groups(settings=settings)
+	failures = []
+	stats = {
+		"total_mwos": len(groups),
+		"processed_mwos": 0,
+		"failed_mwos": 0,
+		"submitted_ses": [],
+		"draft_ses": [],
+		"artifact_skipped": [],
+		"started_on": frappe.utils.now_datetime(),
+	}
+	for group_key, mop_data_list in groups.items():
+		_process_mwo_group(
+			group_key,
+			mop_data_list,
+			failures,
+			stats,
+			sync_log_name=None,
+			selective=True,
+		)
+	frappe.db.commit()
+
+	print(
+		f"[retry-stuck-eod] Re-run: processed(ok)={stats['processed_mwos']} "
+		f"failed={stats['failed_mwos']} submitted_SEs={stats['submitted_ses']} "
+		f"new_drafts={stats['draft_ses']}"
+	)
+	if failures:
+		for f in failures:
+			print(
+				f"  FAILURE mwo={f.get('mwo')} step={f.get('step')} :: {f.get('error_message')}"
+			)
+
+	# 3. Verify each retried MWO is now fully synced.
+	print("[retry-stuck-eod] Verification:")
+	for mwo in mwos:
+		logs = frappe.get_all(
+			"MOP Log",
+			filters={"manufacturing_work_order": mwo, "is_cancelled": 0},
+			fields=["is_synced"],
+			limit_page_length=0,
+		)
+		total = len(logs)
+		unsynced = sum(1 for l in logs if not l.is_synced)
+		print(f"    {mwo}: logs={total} still_unsynced={unsynced}")
+
+
+def verify(sync_log_name=DEFAULT_SYNC_LOG):
+	"""Read-only post-retry report: for each formerly-retryable MWO show its new
+	submitted transfer SE (if any) and active SRE count at the target."""
+	retryable, _ = _classify(sync_log_name)
+	for mwo in retryable:
+		ses = frappe.get_all(
+			"Stock Entry",
+			filters={
+				"custom_manufacturing_work_order": mwo,
+				"stock_entry_type": "Material Transfer to Department",
+				"docstatus": 1,
+			},
+			fields=["name"],
+			limit_page_length=0,
+		)
+		sres = frappe.get_all(
+			"Stock Reservation Entry",
+			filters={"manufacturing_work_order": mwo, "docstatus": 1},
+			fields=["name"],
+			limit_page_length=0,
+		)
+		unsynced = frappe.db.count(
+			"MOP Log",
+			{"manufacturing_work_order": mwo, "is_cancelled": 0, "is_synced": 0},
+		)
+		print(
+			f"  {mwo}: submitted_transfer_SEs={[s.name for s in ses]} "
+			f"active_SREs={len(sres)} unsynced_logs={unsynced}"
+		)

--- a/jewellery_erpnext/public/js/doctype_js/stock_entry.js
+++ b/jewellery_erpnext/public/js/doctype_js/stock_entry.js
@@ -675,6 +675,18 @@ frappe.ui.form.on("Stock Entry", {
 					if (r.message.status == "Not Started") {
 						frm.set_df_property("to_employee", "hidden", 1);
 						frm.set_df_property("employee", "hidden", 1);
+						frappe.db
+							.get_value(
+								"Warehouse",
+								{
+									department: r.message.department,
+									warehouse_type: "Manufacturing",
+								},
+								"name"
+							)
+							.then((k) => {
+								if (k.message) frm.set_value("to_warehouse", k.message.name);
+							});
 					} else {
 						frm.set_df_property("to_employee", "hidden", 0);
 						frm.set_df_property("employee", "hidden", 0);

--- a/jewellery_erpnext/utils.py
+++ b/jewellery_erpnext/utils.py
@@ -30,7 +30,17 @@ def set_items_from_attribute(item_template, item_template_attribute):
 		# value (template attribute not present on the source item) to avoid
 		# ERPNext's "Attribute Value None is not valid" validation error.
 		variant.attributes = [a for a in variant.attributes if a.attribute_value]
-		variant.save()
+		# The loss/target template often defines fewer attributes than the source
+		# item, so get_variant()'s exact attribute-count match can miss an item that
+		# was already created (possibly within this same transaction). create_variant
+		# assigns a deterministic item_code, so look it up by name to stay idempotent
+		# and avoid a DuplicateEntryError.
+		if frappe.db.exists("Item", variant.item_code):
+			return frappe.get_doc("Item", variant.item_code)
+		try:
+			variant.save()
+		except frappe.DuplicateEntryError:
+			return frappe.get_doc("Item", variant.item_code)
 		return variant
 
 


### PR DESCRIPTION
…ch split

- Introduced regression tests for Stock Entry Detail to ensure `transfer_qty` maintains precision of 3, preventing loss of small quantities during stock movements.
- Implemented tests for `validate_pcs` to verify correct distribution of PCS across multiple batch rows in Material Requests, ensuring no row shows zero PCS and total is preserved.
- Added a patch to backfill missing `to_warehouse` in MOP Log entries for Employee IRs, ensuring accurate warehouse tracking.
- Created a patch to reset `is_synced` on MOP Logs that were incorrectly marked as synced due to missing Stock Reservation Entries, allowing them to be reprocessed.
- Developed a retry mechanism for stuck EOD submissions, allowing MWOs with draft Stock Entries to be reprocessed after fixing underlying issues.
- Enhanced the Stock Entry form to automatically set the `to_warehouse` based on the selected department, improving user experience.
- Updated utility functions to handle item variant creation more robustly, ensuring idempotency and avoiding duplicate entries.