### PR TITLE
feat: Enhance stock reconciliation and material request handling

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doc_events/material_request.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/material_request.py
@@ -78,21 +78,31 @@ def validate_gemstone_alternative_items(self, method=None):
 
 
 def before_validate(self, method):
-	if self.set_warehouse and self.set_from_warehouse:
-		source_branch = frappe.db.get_value(
-			"Warehouse", self.set_from_warehouse, "custom_branch"
-		)
-		target_branch = frappe.db.get_value(
-			"Warehouse", self.set_warehouse, "custom_branch"
-		)
+	# Auto-derive the transfer type ONLY when it has not been set yet. Once a
+	# value exists (chosen manually, or defaulted on a prior save) it is
+	# respected and never overwritten on subsequent saves. ``or None`` normalises
+	# a blank ("") vs NULL custom_branch so two no-branch warehouses are treated
+	# as the same branch (Transfer To Department) instead of "" != None.
+	if not self.custom_transfer_type:
+		if self.set_warehouse and self.set_from_warehouse:
+			source_branch = (
+				frappe.db.get_value(
+					"Warehouse", self.set_from_warehouse, "custom_branch"
+				)
+				or None
+			)
+			target_branch = (
+				frappe.db.get_value("Warehouse", self.set_warehouse, "custom_branch")
+				or None
+			)
 
-		if source_branch == target_branch:
-			self.custom_transfer_type = "Transfer To Department"
-		else:
-			self.custom_transfer_type = "Transfer To Branch"
+			if source_branch == target_branch:
+				self.custom_transfer_type = "Transfer To Department"
+			else:
+				self.custom_transfer_type = "Transfer To Branch"
 
-	elif self.material_request_type == "Manufacture":
-		self.custom_transfer_type = "Transfer to Reserve"
+		elif self.material_request_type == "Manufacture":
+			self.custom_transfer_type = "Transfer to Reserve"
 
 	update_pure_qty(self)
 	validate_target_item(self)

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/doc_events/pc_tagging_stock_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/doc_events/pc_tagging_stock_sync.py
@@ -1,4 +1,5 @@
 import frappe
+from erpnext.stock.doctype.batch.batch import get_batch_qty
 from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
 	get_available_qty_to_reserve,
 	get_sre_reserved_qty_for_voucher_detail_no,
@@ -229,6 +230,72 @@ def _find_stock_entry_source_warehouse(
 		limit=1,
 	)
 	return rows[0]["s_warehouse"] if rows else None
+
+
+def _physical_batch_qty(item_code, batch_no, warehouse):
+	"""Physical SBB qty of (item, batch) in warehouse, ignoring reservations.
+
+	Returns None for non-batch lines (batch_no falsy) — the SBB negative-batch
+	validator only fires on batched items. ``ignore_reserved_stock=True`` is
+	required: the batch we are about to consume is itself reserved by the SRE
+	being processed, so the default (reservation-subtracted) qty would understate
+	the correct warehouse. Mirrors ``_warehouse_has_batch_stock`` in
+	serial_number_creator.py.
+	"""
+	if not batch_no or not warehouse:
+		return None
+	try:
+		return flt(
+			get_batch_qty(batch_no, warehouse, item_code, ignore_reserved_stock=True),
+			3,
+		)
+	except Exception:
+		return 0.0
+
+
+def _warehouses_with_physical_batch(item_code, batch_no):
+	"""Return [(warehouse, qty)] for warehouses physically holding the batch.
+
+	Sorted by qty descending. Used only for the fail-fast diagnostic message.
+	``get_batch_qty`` with no warehouse returns a list of {batch_no, warehouse,
+	qty} dicts (negative/zero batches already filtered out by core).
+	"""
+	if not batch_no:
+		return []
+	try:
+		rows = get_batch_qty(
+			batch_no=batch_no, item_code=item_code, ignore_reserved_stock=True
+		)
+	except Exception:
+		rows = None
+	out = []
+	for r in rows or []:
+		if r.get("batch_no") == batch_no:
+			q = flt(r.get("qty"), 3)
+			if q > TOLERANCE:
+				out.append((r.get("warehouse"), q))
+	out.sort(key=lambda t: t[1], reverse=True)
+	return out
+
+
+def _pick_source_warehouse(item_code, batch_no, requested_qty, candidates):
+	"""Return the first candidate warehouse that can physically source the line.
+
+	``candidates`` is an ordered list of warehouse names (highest priority first:
+	MOP Log from_warehouse → submitted SE Detail → active SRE warehouse). For
+	non-batch items there is nothing for the batch validator to check, so the
+	first candidate is returned (legacy behaviour). For batch-tracked items the
+	first candidate whose physical batch qty covers ``requested_qty`` is returned;
+	None if no candidate qualifies (the caller decides how to handle that).
+	"""
+	if not candidates:
+		return None
+	if not batch_no:
+		return candidates[0]
+	for wh in candidates:
+		if flt(_physical_batch_qty(item_code, batch_no, wh) or 0) + TOLERANCE >= requested_qty:
+			return wh
+	return None
 
 
 def _resolve_voucher_fields_from_mwo(mwo):
@@ -478,31 +545,73 @@ def _process_row(dept_ir_doc, row, scenario):
 		if qty <= TOLERANCE:
 			continue
 
-		# Primary: MOP Log from_warehouse (always set by create_mop_log_for_department_ir)
-		s_warehouse = log.get("from_warehouse")
-
-		# Secondary: submitted SE Detail linked to this Department IR
-		if not s_warehouse:
-			s_warehouse = _find_stock_entry_source_warehouse(
-				dept_ir_doc.name, row.name, item_code, batch_no, mwo
-			)
-
-		# Tertiary: active SRE warehouse
+		# Resolve the source warehouse, preferring a candidate that PHYSICALLY
+		# holds the batch. The MOP Log from_warehouse is the *logical* position;
+		# for findings/diamonds it can diverge from where the stock is physically
+		# reserved (the department flow is logical-only, so physical WIP stays
+		# parked in the reserved warehouse). Candidate priority:
+		#   MOP Log from_warehouse → submitted SE Detail → active SRE warehouse.
 		sre_hit = sre_info_by_key.get((item_code, batch_no))
-		if not s_warehouse and sre_hit:
-			s_warehouse = sre_hit[1]
+
+		candidates = []
+		if log.get("from_warehouse"):
+			candidates.append(log["from_warehouse"])
+		se_source_wh = _find_stock_entry_source_warehouse(
+			dept_ir_doc.name, row.name, item_code, batch_no, mwo
+		)
+		if se_source_wh:
+			candidates.append(se_source_wh)
+		if sre_hit:
+			candidates.append(sre_hit[1])
+
+		s_warehouse = _pick_source_warehouse(
+			item_code, batch_no, flt(qty, 3), candidates
+		)
 
 		if not s_warehouse:
-			frappe.log_error(
-				"Unable to resolve source warehouse for item {0}, batch {1}, "
-				"Department IR {2}, row {3}. "
-				"Checked MOP Log from_warehouse, submitted Stock Entry Detail, "
-				"and active Stock Reservation Entry. Skipping line.".format(
-					item_code, batch_no, dept_ir_doc.name, row.name
-				),
-				"PC Tagging Sync Source Warehouse Missing",
+			if not candidates:
+				frappe.log_error(
+					"Unable to resolve source warehouse for item {0}, batch {1}, "
+					"Department IR {2}, row {3}. "
+					"Checked MOP Log from_warehouse, submitted Stock Entry Detail, "
+					"and active Stock Reservation Entry. Skipping line.".format(
+						item_code, batch_no, dept_ir_doc.name, row.name
+					),
+					"PC Tagging Sync Source Warehouse Missing",
+				)
+				continue
+
+			# Batch-tracked line with candidate warehouses but no physical stock:
+			# the MOP Log logical balance has diverged from physical SBB stock.
+			# Fail fast with an actionable diagnostic instead of letting the SE
+			# submit blow up with an opaque BatchNegativeStockError.
+			cand_desc = "; ".join(
+				"{0} (physical {1})".format(
+					wh, flt(_physical_batch_qty(item_code, batch_no, wh) or 0, 3)
+				)
+				for wh in candidates
 			)
-			continue
+			where_stock = _warehouses_with_physical_batch(item_code, batch_no)
+			where_desc = (
+				"; ".join("{0} ({1})".format(wh, q) for wh, q in where_stock)
+				or "no warehouse"
+			)
+			frappe.throw(
+				_(
+					"PC→Tagging transfer (Department IR {0}): cannot source {1} of "
+					"item {2}, batch {3}. None of the candidate warehouses holds "
+					"enough physical stock [{4}]. The batch physically has stock in: "
+					"{5}. Reconcile the MOP Log / Stock Reservation before submitting."
+				).format(
+					dept_ir_doc.name,
+					flt(qty, 3),
+					item_code,
+					batch_no,
+					cand_desc,
+					where_desc,
+				),
+				title=_("Insufficient physical batch stock for PC→Tagging transfer"),
+			)
 
 		t_warehouse = log["to_warehouse"]
 		pcs = (

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/tests/test_pc_tagging_stock_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/tests/test_pc_tagging_stock_sync.py
@@ -12,9 +12,14 @@ from jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.pc_tag
 	SCENARIO_TAGGING_TO_PC_RECEIVE,
 	_build_sre_info_by_key,
 	_norm,
+	_physical_batch_qty,
+	_pick_source_warehouse,
 	_requires_pcs,
 	_resolve_scenario,
+	_warehouses_with_physical_batch,
 )
+
+MOD = "jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.pc_tagging_stock_sync"
 
 
 def _make_doc(type_, current, nxt=None, prev=None):
@@ -349,6 +354,253 @@ class TestProcessPcTaggingStockSync(unittest.TestCase):
 		process_pc_tagging_stock_sync(doc, cancel=True)
 
 		mock_cancel.assert_called_once_with(doc, row1, SCENARIO_PC_TO_TAGGING_ISSUE)
+
+
+class TestPickSourceWarehouse(unittest.TestCase):
+	"""The physical-stock-aware source warehouse picker (the fix's core decision)."""
+
+	def test_empty_candidates_returns_none(self):
+		self.assertIsNone(_pick_source_warehouse("D-1", "B1", 0.5, []))
+
+	def test_non_batch_returns_first_candidate_without_physical_check(self):
+		with patch(f"{MOD}._physical_batch_qty") as mock_phys:
+			wh = _pick_source_warehouse("M-18KT-750", None, 5.0, ["WH-A", "WH-B"])
+		self.assertEqual(wh, "WH-A")
+		mock_phys.assert_not_called()
+
+	def test_first_candidate_with_stock_chosen_no_regression(self):
+		# MOP-Log warehouse (candidate 0) physically covers -> chosen, SRE untouched.
+		with patch(f"{MOD}._physical_batch_qty", return_value=1.0):
+			wh = _pick_source_warehouse(
+				"D-1", "B1", 0.036, ["PC WO - GEPL", "Diamond Setting WO - GEPL"]
+			)
+		self.assertEqual(wh, "PC WO - GEPL")
+
+	def test_falls_through_to_warehouse_with_stock(self):
+		# Core fix: candidate 0 is physically empty, candidate 1 (SRE WH) covers.
+		def physical(item, batch, w):
+			return {"PC WO - GEPL": 0.0, "Diamond Setting WO - GEPL": 0.036}[w]
+
+		with patch(f"{MOD}._physical_batch_qty", side_effect=physical):
+			wh = _pick_source_warehouse(
+				"D-1", "B1", 0.036, ["PC WO - GEPL", "Diamond Setting WO - GEPL"]
+			)
+		self.assertEqual(wh, "Diamond Setting WO - GEPL")
+
+	def test_partial_candidate_rejected_in_favor_of_covering_one(self):
+		def physical(item, batch, w):
+			return {"PC WO - GEPL": 0.02, "Diamond Setting WO - GEPL": 0.036}[w]
+
+		with patch(f"{MOD}._physical_batch_qty", side_effect=physical):
+			wh = _pick_source_warehouse(
+				"D-1", "B1", 0.036, ["PC WO - GEPL", "Diamond Setting WO - GEPL"]
+			)
+		self.assertEqual(wh, "Diamond Setting WO - GEPL")
+
+	def test_none_when_no_candidate_covers(self):
+		with patch(f"{MOD}._physical_batch_qty", return_value=0.0):
+			self.assertIsNone(
+				_pick_source_warehouse(
+					"D-1", "B1", 0.036, ["PC WO - GEPL", "Diamond Setting WO - GEPL"]
+				)
+			)
+
+	def test_within_tolerance_is_accepted(self):
+		# physical 0.0359 + TOLERANCE (0.0001) >= requested 0.036
+		with patch(f"{MOD}._physical_batch_qty", return_value=0.0359):
+			wh = _pick_source_warehouse("D-1", "B1", 0.036, ["PC WO - GEPL"])
+		self.assertEqual(wh, "PC WO - GEPL")
+
+
+class TestPhysicalBatchHelpers(unittest.TestCase):
+	def test_physical_batch_qty_none_for_missing_batch_or_warehouse(self):
+		self.assertIsNone(_physical_batch_qty("D-1", None, "WH-A"))
+		self.assertIsNone(_physical_batch_qty("D-1", "B1", None))
+
+	@patch(f"{MOD}.get_batch_qty")
+	def test_physical_batch_qty_ignores_reserved_stock(self, mock_gbq):
+		mock_gbq.return_value = 0.036
+		result = _physical_batch_qty("D-NT-RO-5-+0-1", "B1", "WH-A")
+		self.assertAlmostEqual(result, 0.036)
+		mock_gbq.assert_called_once_with(
+			"B1", "WH-A", "D-NT-RO-5-+0-1", ignore_reserved_stock=True
+		)
+
+	@patch(f"{MOD}.get_batch_qty")
+	def test_physical_batch_qty_swallows_errors(self, mock_gbq):
+		mock_gbq.side_effect = Exception("boom")
+		self.assertEqual(_physical_batch_qty("D-1", "B1", "WH-A"), 0.0)
+
+	def test_warehouses_with_physical_batch_empty_for_no_batch(self):
+		self.assertEqual(_warehouses_with_physical_batch("D-1", None), [])
+
+	@patch(f"{MOD}.get_batch_qty")
+	def test_warehouses_with_physical_batch_filters_and_sorts(self, mock_gbq):
+		mock_gbq.return_value = [
+			{"batch_no": "B1", "warehouse": "WH-A", "qty": 0.02},
+			{"batch_no": "B1", "warehouse": "WH-B", "qty": 0.0},  # filtered: <= TOLERANCE
+			{"batch_no": "B1", "warehouse": "WH-C", "qty": 0.05},
+			{"batch_no": "OTHER", "warehouse": "WH-D", "qty": 0.5},  # different batch
+		]
+		out = _warehouses_with_physical_batch("D-1", "B1")
+		self.assertEqual(out, [("WH-C", 0.05), ("WH-A", 0.02)])
+
+
+class TestProcessRowPhysicalReconcile(unittest.TestCase):
+	"""Integration of the physical-stock-aware resolution inside _process_row."""
+
+	def _log(self, item_code, batch_no, qty, pcs=0):
+		return {
+			"name": f"MOP-LOG-{item_code}",
+			"item_code": item_code,
+			"batch_no": batch_no,
+			"qty_after_transaction_batch_based": qty,
+			"pcs_after_transaction_batch_based": pcs,
+			"from_warehouse": "Product Certification WO - GEPL",
+			"to_warehouse": "Tagging Transit - GEPL",
+			"manufacturing_operation": "MOP-TAG",
+			"manufacturing_work_order": "MWO-001",
+			"flow_index": 1,
+		}
+
+	def _row(self):
+		row = MagicMock()
+		row.manufacturing_work_order = "MWO-001"
+		row.manufacturing_operation = "MOP-001"
+		row.name = "DIR-ROW-001"
+		return row
+
+	@patch(f"{MOD}._build_sre_from_context")
+	@patch(f"{MOD}.get_batch_qty")
+	@patch(f"{MOD}._find_stock_entry_source_warehouse")
+	@patch(f"{MOD}._build_sre_info_by_key")
+	@patch(f"{MOD}._get_active_sres_for_mwo")
+	@patch(f"{MOD}._get_dept_ir_mop_logs")
+	@patch(f"{MOD}.frappe")
+	def test_core_fix_sources_from_reserved_warehouse(
+		self,
+		mock_frappe,
+		mock_logs,
+		mock_sres,
+		mock_sre_info,
+		mock_find_se,
+		mock_gbq,
+		mock_build_sre,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.pc_tagging_stock_sync import (
+			_process_row,
+		)
+
+		mock_frappe.db.get_all.return_value = []  # duplicate-SE guard: none exists
+		mock_frappe._ = lambda s: s
+		mock_frappe.get_cached_value.return_value = "Carat"
+		se = MagicMock()
+		mock_frappe.new_doc.return_value = se
+		sre_doc = MagicMock()
+		sre_doc.docstatus = 1
+		mock_frappe.get_doc.return_value = sre_doc
+
+		mock_logs.return_value = [self._log("D-NT-RO-5-+0-1", "BATCH-001", 0.036, pcs=6)]
+		mock_sres.return_value = [{"name": "SRE-001"}]
+		mock_sre_info.return_value = {
+			("D-NT-RO-5-+0-1", "BATCH-001"): (
+				"SRE-001",
+				"Diamond Setting WO - GEPL",
+				0.036,
+			)
+		}
+		mock_find_se.return_value = None
+
+		def gbq(*args, **kwargs):
+			# _physical_batch_qty(batch_no, warehouse, item_code, ignore_reserved_stock=True)
+			if args:
+				return 0.0 if args[1] == "Product Certification WO - GEPL" else 0.036
+			return []  # _warehouses_with_physical_batch (not reached on the happy path)
+
+		mock_gbq.side_effect = gbq
+		mock_build_sre.return_value = MagicMock()
+
+		dept_ir = _make_doc(
+			"Issue", "Product Certification - GEPL", nxt="Tagging - GEPL"
+		)
+		dept_ir.name = "DIR-TEST-CORE"
+
+		_process_row(dept_ir, self._row(), SCENARIO_PC_TO_TAGGING_ISSUE)
+
+		# SE built sourcing from the reserved (physically-stocked) warehouse.
+		item_appends = [c for c in se.append.call_args_list if c.args[0] == "items"]
+		self.assertEqual(len(item_appends), 1)
+		item_row = item_appends[0].args[1]
+		self.assertEqual(item_row["s_warehouse"], "Diamond Setting WO - GEPL")
+		self.assertAlmostEqual(item_row["qty"], 0.036)
+		self.assertEqual(item_row["batch_no"], "BATCH-001")
+		se.submit.assert_called_once()
+		# Old SRE cancelled, replacement created.
+		sre_doc.cancel.assert_called_once()
+		mock_build_sre.return_value.submit.assert_called_once()
+
+	@patch(f"{MOD}._build_sre_from_context")
+	@patch(f"{MOD}.get_batch_qty")
+	@patch(f"{MOD}._find_stock_entry_source_warehouse")
+	@patch(f"{MOD}._build_sre_info_by_key")
+	@patch(f"{MOD}._get_active_sres_for_mwo")
+	@patch(f"{MOD}._get_dept_ir_mop_logs")
+	@patch(f"{MOD}.frappe")
+	def test_fail_fast_when_no_warehouse_has_physical_stock(
+		self,
+		mock_frappe,
+		mock_logs,
+		mock_sres,
+		mock_sre_info,
+		mock_find_se,
+		mock_gbq,
+		mock_build_sre,
+	):
+		from jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.pc_tagging_stock_sync import (
+			_process_row,
+		)
+
+		mock_frappe.db.get_all.return_value = []
+		mock_frappe._ = lambda s: s
+		mock_frappe.throw.side_effect = frappe.exceptions.ValidationError
+
+		mock_logs.return_value = [self._log("D-NT-RO-5-+0-1", "BATCH-001", 0.036, pcs=6)]
+		mock_sres.return_value = []  # no SRE -> only the MOP-Log warehouse is a candidate
+		mock_sre_info.return_value = {}
+		mock_find_se.return_value = None
+
+		def gbq(*args, **kwargs):
+			if args:  # _physical_batch_qty -> MOP-Log warehouse is empty
+				return 0.0
+			# _warehouses_with_physical_batch (diagnostic): stock is elsewhere
+			return [
+				{
+					"batch_no": "BATCH-001",
+					"warehouse": "Diamond Setting WO - GEPL",
+					"qty": 0.036,
+				}
+			]
+
+		mock_gbq.side_effect = gbq
+
+		dept_ir = _make_doc(
+			"Issue", "Product Certification - GEPL", nxt="Tagging - GEPL"
+		)
+		dept_ir.name = "DIR-TEST-FAIL"
+
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			_process_row(dept_ir, self._row(), SCENARIO_PC_TO_TAGGING_ISSUE)
+
+		# No SE created, no SRE cancelled — reservations left intact for resubmit.
+		mock_frappe.new_doc.assert_not_called()
+		mock_frappe.get_doc.assert_not_called()
+		# Diagnostic names the item, batch, qty, empty source WH and where stock is.
+		msg = mock_frappe.throw.call_args.args[0]
+		self.assertIn("D-NT-RO-5-+0-1", msg)
+		self.assertIn("BATCH-001", msg)
+		self.assertIn("0.036", msg)
+		self.assertIn("Product Certification WO - GEPL", msg)
+		self.assertIn("Diamond Setting WO - GEPL", msg)
 
 
 if __name__ == "__main__":

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
@@ -1,16 +1,22 @@
 """
-EOD MOP Log Sync — converts unsynced MOP Log entries into a single consolidating Stock Entry
-per Manufacturing Work Order.
+EOD MOP Log Sync — converts unsynced MOP Log entries into consolidated Stock Entries.
 
 MOP Logs with ``is_synced = 0`` represent virtual warehouse movements recorded by
-Department IR and Employee IR. This module groups those logs by Manufacturing Work Order
-and creates exactly ONE **Material Transfer to Department** Stock Entry per MWO that moves
-items from the Stock Reservation Entry warehouse (where stock is physically reserved) to
-the last Manufacturing Operation's final ``to_warehouse``.
+Department IR and Employee IR. Each run **plans** every Manufacturing Work Order, then
+**commits** ONE consolidated **Material Transfer to Department** Stock Entry per
+(company, manufacturer) covering all fully-resolvable MWOs — moving each item from its
+Stock Reservation Entry warehouse (where stock is physically reserved) to the last
+Manufacturing Operation's final ``to_warehouse``. Classification is all-or-nothing per
+MWO: an MWO with any unresolvable / batch-short / invalid row is held out of the
+transfer (its MOP Logs stay unsynced and retryable) and its buildable rows are placed in
+a per-bucket DRAFT "issues" Stock Entry for visibility; rows with no SRE source warehouse
+are reported in the consolidated Error Log only.
 
-**Today-only filter (scheduled mode)**: With no enabled MWO filter rows, only MOP
-Logs created today (creation >= today 00:00:00 and < tomorrow 00:00:00) are processed.
-Old unsynced logs are counted and reported but never marked synced or used for SEs.
+**Windowed filter (scheduled mode)**: With no enabled MWO filter rows, only MOP
+Logs created inside the run's window are processed. The window defaults to today
+(creation between today 00:00:00 and today 23:59:59); the manual EOD Sync button may
+pass a custom From/To. The nightly scheduler always uses today. Unsynced logs outside
+the window are counted and reported but never marked synced or used for SEs.
 
 **Selective mode (MWO filter)**: If MOP Settings has enabled rows in
 ``eod_sync_work_order_filter``, the run switches to selective mode: only the listed
@@ -30,18 +36,20 @@ operation is last — ``flow_index`` is per-MOP-scoped and unreliable for cross-
 **Loss entries**: Process Loss Stock Entries are NOT created here. Loss handling is owned
 by the Employee IR Process Loss feature (``doc_events/loss_stock_entry.py``).
 
-**Syncing**: after SE submit, ALL unsynced non-cancelled MOP Logs for the MWO (created today)
-are marked synced atomically within the same savepoint.
+**Syncing**: after SE submit, ALL unsynced non-cancelled MOP Logs for the MWO (created
+inside the run's window) are marked synced atomically within the same savepoint.
 
-**Transaction phases per MWO**:
-  Phase 1 (savepoint "eod_draft_phase"): validate + save SE as draft.
-  Phase 2 (savepoint "eod_submit_phase"): cancel the MWO's source-warehouse SREs
-    (releasing the reservation so the transfer can consume the stock), submit the SE,
-    re-reserve at the target warehouse where the stock lands, then mark MOP Logs synced.
-    All of this is ONE atomic savepoint — the SRE relocation is all-or-nothing.
+**Transaction phases (per (company, manufacturer) bucket)**:
+  Phase 1 (savepoint "eod_draft_phase"): save the consolidated SE as draft.
+  Phase 2 (savepoint "eod_submit_phase"): cancel every included MWO's source-warehouse
+    SREs (releasing the reservations so the transfer can consume the stock), submit the
+    single SE, re-reserve at each MWO's target warehouse where its stock lands, then mark
+    each MWO's MOP Logs synced. All of this is ONE atomic savepoint — the SRE relocation
+    is all-or-nothing for the whole bucket.
   On Phase 2 failure: rollback the whole submit savepoint; the cancelled SREs are
     restored (never left cancelled without a transfer/re-reservation) and the draft SE
-    survives for manual recovery.
+    survives for manual recovery — so a single submit failure holds the whole bucket as a
+    draft (the "one SE for the run" trade-off).
 
 **MOP EOD Sync Log**: every run creates/updates a MOP EOD Sync Log document with full
 progress tracking. Every item/batch/MWO decision is recorded in the child table.
@@ -53,7 +61,6 @@ created at the end of the full sync — no per-row or per-MWO log_error calls in
 import frappe
 from frappe import _
 from frappe.utils import (
-	add_days,
 	cint,
 	flt,
 	now_datetime,
@@ -67,8 +74,15 @@ from .eod_lock import release_eod_sync_lock, set_eod_sync_running
 # ---------------------------------------------------------------------------
 
 
-def sync_mop_logs(sync_log_name=None):
-	"""Main entry point called by scheduler or manual trigger. Returns a summary dict."""
+def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
+	"""Main entry point called by scheduler or manual trigger. Returns a summary dict.
+
+	``from_datetime`` / ``to_datetime`` bound the MOP Log ``creation`` window scanned in
+	scheduled (non-selective) mode. Only the manual EOD Sync button passes them; the
+	nightly scheduler leaves them empty so it always uses today. When both are absent the
+	window defaults to today's start/end (see :func:`_resolve_run_range`). Selective
+	MWO-filter mode ignores the window and always covers full unsynced history.
+	"""
 	# If no sync log provided (legacy path), create one now
 	if not sync_log_name:
 		try:
@@ -89,6 +103,10 @@ def sync_mop_logs(sync_log_name=None):
 			sync_log_name = None
 
 	frappe.flags.in_eod_mop_sync = True
+	# Resolve the creation window once for the whole run. Scheduled runs pass nothing
+	# → today's range; the manual button passes the user-chosen From/To. Stash it on a
+	# flag so the gather + mark-synced steps share one source of truth.
+	frappe.flags.eod_sync_range = _resolve_run_range(from_datetime, to_datetime)
 	set_eod_sync_running(sync_log_name=sync_log_name)
 
 	failures = []
@@ -126,26 +144,77 @@ def sync_mop_logs(sync_log_name=None):
 			)
 			frappe.db.commit()
 
-		for group_key, mop_data_list in unsynced_groups.items():
-			_process_mwo_group(
-				group_key,
-				mop_data_list,
-				failures,
-				stats,
-				sync_log_name,
-				selective=selective,
-			)
-			# Update progress after each MWO
-			if sync_log_name:
-				recalculate_sync_log_totals(sync_log_name)
-				frappe.db.set_value(
-					"MOP EOD Sync Log",
+			# PLAN: classify every MWO without writing any Stock Entry. Resolvable MWOs are
+			# bucketed by (company, manufacturer) for ONE consolidated transfer SE; failed
+			# MWOs contribute their buildable rows to a per-bucket draft "issues" SE.
+			main_buckets = {}
+			issues_buckets = {}
+			for group_key, mop_data_list in unsynced_groups.items():
+				# Isolate each MWO: an unexpected error while planning ONE MWO must not
+				# abort the whole run — record it as a failure and move on.
+				try:
+					result = _plan_mwo_group(
+						group_key,
+						mop_data_list,
+						failures,
+						stats,
+						sync_log_name,
+						selective=selective,
+					)
+				except Exception:
+					stats["failed_mwos"] += 1
+					failures.append(
+						{
+							"step": "plan",
+							"company": group_key[0],
+							"mwo": group_key[1],
+							"error_message": "Unexpected error while planning this MWO.",
+							"traceback": frappe.get_traceback(),
+							"suggested_fix": (
+								"Investigate the traceback; this MWO was skipped. Other MWOs "
+								"were unaffected."
+							),
+						}
+					)
+					continue
+				if not result:
+					continue
+				bucket_key = (result["company"], result.get("manufacturer"))
+				if result["kind"] == "resolvable":
+					main_buckets.setdefault(bucket_key, []).append(result)
+				elif result["kind"] == "failed" and result.get("issues_rows"):
+					issues_buckets.setdefault(bucket_key, []).extend(result["issues_rows"])
+
+			# COMMIT: one submitted Material Transfer to Department per (company,
+			# manufacturer) for all resolvable MWOs.
+			for (company, manufacturer), main_mwos in main_buckets.items():
+				_commit_company_main_se(
+					company,
+					manufacturer,
+					main_mwos,
+					failures,
+					stats,
 					sync_log_name,
-					"progress_message",
-					f"Processed {stats['processed_mwos']} / {stats['total_mwos']} MWOs...",
-					update_modified=False,
+					selective=selective,
 				)
-				frappe.db.commit()
+				if sync_log_name:
+					recalculate_sync_log_totals(sync_log_name)
+					frappe.db.set_value(
+						"MOP EOD Sync Log",
+						sync_log_name,
+						"progress_message",
+						f"Processed {stats['processed_mwos']} / {stats['total_mwos']} MWOs...",
+						update_modified=False,
+					)
+					frappe.db.commit()
+
+			# Best-effort draft "issues" SE per bucket for unresolved-but-buildable rows.
+			for (company, manufacturer), issues_rows in issues_buckets.items():
+				_commit_company_issues_se(
+					company, manufacturer, issues_rows, stats, sync_log_name
+				)
+				if sync_log_name:
+					frappe.db.commit()
 
 		# SRE reconciliation audit
 		for mwo in {k[1] for k in unsynced_groups}:
@@ -248,6 +317,7 @@ def sync_mop_logs(sync_log_name=None):
 
 	finally:
 		frappe.flags.in_eod_mop_sync = False
+		frappe.flags.eod_sync_range = None
 
 	return {
 		"processed": stats["processed_mwos"],
@@ -256,25 +326,41 @@ def sync_mop_logs(sync_log_name=None):
 
 
 # ---------------------------------------------------------------------------
-# Per-MWO processing
+# Plan + commit (consolidated single Stock Entry per company/manufacturer)
 # ---------------------------------------------------------------------------
 
 
-def _process_mwo_group(
+def _bulk_set_child_rows(child_row_names, values):
+	"""Apply the same field updates to a list of MOP EOD Sync Log Item rows."""
+	for rn in child_row_names or []:
+		frappe.db.set_value(
+			"MOP EOD Sync Log Item", rn, values, update_modified=False
+		)
+
+
+def _plan_mwo_group(
 	group_key, mop_data_list, failures, stats, sync_log_name=None, selective=False
 ):
-	"""Process one (company, mwo) group through two savepoint phases.
+	"""Classify one (company, mwo) group for the consolidated run — no Stock Entry is
+	created here.
 
-	When ``selective`` is True (an enabled MWO filter row exists for this MWO),
-	the full unsynced history is synced and marked — not just today's logs.
+	Returns one of:
+	  * ``None`` — fully handled in place (artifact / no last operation / genuine
+	    no-op / no target warehouse). Sync marking, stats and sync-log rows are done.
+	  * ``{"kind": "resolvable", ...}`` — every row resolves and validates; the payload
+	    carries the rows + relocation metadata for the bucket's single transfer SE.
+	  * ``{"kind": "failed", "issues_rows": [...], ...}`` — the MWO cannot be fully
+	    transferred (missing SRE / batch short / invalid row). It is NOT marked synced;
+	    its buildable rows are returned for the per-bucket draft "issues" SE.
+
+	Classification is all-or-nothing per MWO: a partially transferable MWO is held
+	entirely so its MOP Logs are never buried as synced and its good rows are not
+	double-transferred on a later run.
 	"""
 	company, mwo = group_key
 	all_mop_names = [md["mop_name"] for md in mop_data_list]
 
-	# If the Serial Number Creator already produced this MWO's finished product
-	# (submitted Manufacture Stock Entry), the reserved stock is already physically
-	# consumed. A Material Transfer here would fail against missing stock, so skip
-	# the transfer and just mark the leftover MOP Logs synced, attributed to the artifact.
+	# Artifact (Serial Number Creator already realized the MWO) → mark synced, no transfer.
 	artifact_se = _mwo_realized_by_artifact(mwo)
 	if artifact_se:
 		_mark_all_mwo_mop_logs_synced([mwo], selective=selective)
@@ -305,20 +391,20 @@ def _process_mwo_group(
 							"completed_on": now_datetime(),
 						},
 					)
-		return
+		return None
 
 	last_mop_data = _find_last_operation(mop_data_list)
 	if not last_mop_data:
 		_mark_all_mwo_mop_logs_synced([mwo], selective=selective)
 		stats["processed_mwos"] += 1
-		return
+		return None
 
 	last_mop_name = last_mop_data["mop_name"]
 	last_logs = _get_last_logs_per_item_batch(last_mop_data["logs"])
-	# Resolve the target (department) warehouse. The last operation may be an
-	# Employee IR receive whose audit MOP Logs carry no warehouse, so fall back to
-	# the latest to_warehouse across ALL the MWO's logs, then to the department's
-	# Manufacturing warehouse.
+	manufacturer = _mop_manufacturer_label(last_mop_data["mop_doc"])
+	# Resolve the target (department) warehouse. The last operation may be an Employee IR
+	# receive whose audit MOP Logs carry no warehouse, so fall back to the latest
+	# to_warehouse across ALL the MWO's logs, then to the department's Manufacturing WH.
 	t_warehouse = (
 		_get_t_warehouse_from_logs(last_logs)
 		or _get_t_warehouse_from_logs(
@@ -346,7 +432,6 @@ def _process_mwo_group(
 			}
 		)
 		stats["failed_mwos"] += 1
-		# Log all items as failed
 		if sync_log_name:
 			for log in last_logs:
 				_insert_sync_log_item(
@@ -365,15 +450,16 @@ def _process_mwo_group(
 						"suggested_fix": "Check Department IR or Employee IR receive vouchers.",
 					},
 				)
-		return
+		return None
 
 	# One query for all (item_code, batch_no) → warehouse for this MWO
 	sre_map = _preload_sre_warehouse_map(mwo)
-
 	items, skipped_rows = _build_eod_se_rows(
 		mwo, last_mop_name, last_logs, t_warehouse, sre_map
 	)
 
+	# Missing-SRE rows have no source warehouse and cannot be transferred or even placed
+	# in a draft SE — record them as failures only.
 	for skip in skipped_rows:
 		failures.append(
 			{
@@ -413,27 +499,100 @@ def _process_mwo_group(
 				},
 			)
 
-	# Any unresolved (Missing SRE) row means the MWO's stock can't be fully
-	# transferred. Do NOT mark its MOP Logs synced — that buries them as done
-	# (is_synced=1 excludes them from future runs) while nothing moved. Count the
-	# MWO as failed so it stays retryable after the SRE is fixed. Per-row failures
-	# and child "Failed" rows were already recorded in the skipped loop above.
-	if skipped_rows:
+	# Non-throwing validation of the buildable rows (batch/serial presence + batch stock).
+	invalid = False
+	try:
+		_validate_eod_items_for_mwo_reservation(items)
+	except Exception as exc:
+		invalid = True
+		failures.append(
+			{
+				"step": "reservation_validate",
+				"mwo": mwo,
+				"company": company,
+				"last_mop": last_mop_name,
+				"affected_mops": all_mop_names,
+				"t_warehouse": t_warehouse,
+				"error_message": str(exc),
+				"suggested_fix": (
+					"Fix the MOP Log batch/serial data for this MWO, then retry EOD sync."
+				),
+			}
+		)
+	short_keys = _check_eod_source_batch_stock(items) if items else {}
+	if short_keys:
+		invalid = True
+		for (wh, item_code, batch_no), (req_qty, physical) in short_keys.items():
+			failures.append(
+				{
+					"step": "batch_short",
+					"mwo": mwo,
+					"company": company,
+					"last_mop": last_mop_name,
+					"affected_mops": all_mop_names,
+					"item_code": item_code,
+					"batch_no": batch_no,
+					"s_warehouse": wh,
+					"t_warehouse": t_warehouse,
+					"error_message": (
+						f"Insufficient physical batch stock for item {item_code} batch {batch_no} "
+						f"in {wh}: require {req_qty}, have {physical}."
+					),
+					"suggested_fix": (
+						"Reconcile vouchers / MOP Log / stale reservations so physical batch "
+						"stock covers the transfer, then retry EOD sync."
+					),
+				}
+			)
+
+	# FAILED: any unresolvable / short / invalid row holds the whole MWO. Its buildable
+	# rows go to the per-bucket draft "issues" SE; its MOP Logs are NOT marked synced.
+	if skipped_rows or invalid:
 		stats["failed_mwos"] += 1
-		return
+		if sync_log_name:
+			for item in items:
+				_insert_sync_log_item(
+					sync_log_name,
+					{
+						"manufacturing_work_order": mwo,
+						"manufacturing_operation": item.get("manufacturing_operation")
+						or last_mop_name,
+						"company": company,
+						"item_code": item.get("item_code"),
+						"batch_no": item.get("batch_no"),
+						"serial_no": item.get("serial_no"),
+						"source_warehouse": item.get("s_warehouse"),
+						"target_warehouse": item.get("t_warehouse") or t_warehouse,
+						"qty": flt(item.get("qty"), 3),
+						"status": "Failed",
+						"sync_stage": "Build Stock Entry Row",
+						"error_type": "Validation Failed",
+						"error_message": (
+							"MWO has unresolved or short rows; held out of the consolidated "
+							"transfer. Buildable rows placed in the draft issues Stock Entry."
+						),
+						"suggested_fix": "Resolve the failures above, then retry EOD sync.",
+					},
+				)
+		return {
+			"kind": "failed",
+			"company": company,
+			"manufacturer": manufacturer,
+			"issues_rows": items,
+		}
 
 	if not items:
-		# Genuine no-op: every row was same-warehouse or non-positive qty — nothing
-		# to move. Safe to mark the MWO's logs synced.
+		# Genuine no-op: every row was same-warehouse or non-positive qty — nothing to
+		# move. Safe to mark the MWO's logs synced.
 		frappe.logger().info(
 			"MOP EOD Sync MWO %s: no SE rows to create (same WH); marking logs synced.",
 			mwo,
 		)
 		_mark_all_mwo_mop_logs_synced([mwo], selective=selective)
 		stats["processed_mwos"] += 1
-		return
+		return None
 
-	# Insert child log rows as Pending before we start
+	# RESOLVABLE — insert Pending child rows; commit happens later in the bucket SE.
 	child_row_names = []
 	if sync_log_name:
 		for item in items:
@@ -456,25 +615,47 @@ def _process_mwo_group(
 			)
 			child_row_names.append(row_name)
 
-	# Phase 1 — Validate and save draft SE
-	draft_se_name = None
+	return {
+		"kind": "resolvable",
+		"company": company,
+		"manufacturer": manufacturer,
+		"mwo": mwo,
+		"items": items,
+		"t_warehouse": t_warehouse,
+		"mop_data_list": mop_data_list,
+		"last_mop_name": last_mop_name,
+		"child_row_names": child_row_names,
+	}
+
+
+def _commit_company_main_se(
+	company, manufacturer, main_mwos, failures, stats, sync_log_name=None, selective=False
+):
+	"""Build ONE submitted *Material Transfer to Department* for all resolvable MWOs of a
+	(company, manufacturer).
+
+	Phase 1 (savepoint ``eod_draft_phase``) saves the consolidated draft. Phase 2
+	(savepoint ``eod_submit_phase``) is atomic for the whole bucket: cancel every MWO's
+	source SREs, submit the single SE, reserve at each MWO's target FROM the submitted SE's
+	rows (Sales-Order-anchored), hard-delete the now-cancelled source SREs, then mark each
+	MWO's MOP Logs synced. On Phase-2 failure the whole bucket rolls back (SREs restored,
+	never deleted) and the draft survives for manual recovery — the user-chosen "one SE for
+	the run" trade-off: a single submit failure holds the whole bucket as a draft.
+	"""
+	items = [it for m in main_mwos for it in m["items"]]
+	child_rows = [rn for m in main_mwos for rn in m["child_row_names"]]
+	mwo_list = [m["mwo"] for m in main_mwos]
+	mop_names = sorted({md["mop_name"] for m in main_mwos for md in m["mop_data_list"]})
+
+	# Phase 1 — save consolidated draft (no header MWO; rows carry their own MWO/op).
 	try:
 		frappe.db.savepoint("eod_draft_phase")
-		_validate_eod_items_for_mwo_reservation(items)
-		_validate_eod_source_batch_stock(
-			items,
-			manufacturing_work_order=mwo,
-			mop_data_list=mop_data_list,
-			company=company,
-		)
-		manufacturing_order = last_mop_data["mop_doc"].get("manufacturing_order")
 		draft_se_name = _save_draft_eod_se(
 			company,
-			mwo,
-			manufacturing_order,
+			None,
+			None,
 			items,
-			header_mop_name=last_mop_name,
-			header_manufacturer=_mop_manufacturer_label(last_mop_data["mop_doc"]),
+			header_manufacturer=manufacturer,
 			sync_log_name=sync_log_name,
 		)
 		frappe.db.release_savepoint("eod_draft_phase")
@@ -483,118 +664,164 @@ def _process_mwo_group(
 		failures.append(
 			{
 				"step": "draft_save",
-				"mwo": mwo,
+				"mwo": ", ".join(mwo_list),
 				"company": company,
-				"last_mop": last_mop_name,
-				"affected_mops": all_mop_names,
-				"t_warehouse": t_warehouse,
+				"affected_mops": mop_names,
 				"error_message": str(exc),
 				"traceback": frappe.get_traceback(),
 				"suggested_fix": (
-					"Check MOP Log data: item codes, batch numbers, warehouses, and "
-					"Stock Reservation Entries. Verify physical batch stock at source warehouse."
+					"Check MOP Log data for the listed MWOs: item codes, batch numbers, "
+					"warehouses, Stock Reservation Entries, and physical batch stock."
 				),
 			}
 		)
-		stats["failed_mwos"] += 1
-		# Update child rows to Failed
-		if sync_log_name and child_row_names:
-			for rn in child_row_names:
-				frappe.db.set_value(
-					"MOP EOD Sync Log Item",
-					rn,
-					{
-						"status": "Failed",
-						"sync_stage": "Save Draft Stock Entry",
-						"error_type": "Stock Entry Save Failed",
-						"error_message": str(exc)[:500],
-						"technical_traceback": frappe.get_traceback()[:3000],
-						"suggested_fix": "Check MOP Log data: item codes, batch numbers, warehouses, SREs, and physical batch stock.",
-						"completed_on": now_datetime(),
-					},
-					update_modified=False,
-				)
+		stats["failed_mwos"] += len(main_mwos)
+		_bulk_set_child_rows(
+			child_rows,
+			{
+				"status": "Failed",
+				"sync_stage": "Save Draft Stock Entry",
+				"error_type": "Stock Entry Save Failed",
+				"error_message": str(exc)[:500],
+				"technical_traceback": frappe.get_traceback()[:3000],
+				"suggested_fix": "Check MOP Log data, warehouses, SREs, and physical batch stock.",
+				"completed_on": now_datetime(),
+			},
+		)
 		return
 
-	# Phase 2 — Submit SE, relocate reservations, and mark logs synced — all in ONE
-	# savepoint so the SRE relocation is atomic. The MWO's stock is reserved at the
-	# source warehouse, which blocks the transfer; we cancel those SREs to release it,
-	# transfer, then re-reserve at the target. If ANY step fails, the whole savepoint
-	# rolls back — the cancelled SREs are restored and nothing is left half-done
-	# (never a state with reservations cancelled and no transfer/re-reservation).
+	# Phase 2 — cancel SREs, submit once, reserve from the SE rows, delete the cancelled
+	# sources, mark synced. Atomic for the bucket.
 	try:
 		frappe.db.savepoint("eod_submit_phase")
-		sre_snapshots = _snapshot_mwo_sres_for_relocation(mwo, items, t_warehouse)
-		_cancel_sre_snapshots(sre_snapshots)
+		snaps_by_mwo = {}
+		for m in main_mwos:
+			snaps = _snapshot_mwo_sres_for_relocation(
+				m["mwo"], m["items"], m["t_warehouse"]
+			)
+			snaps_by_mwo[m["mwo"]] = snaps
+			_cancel_sre_snapshots(snaps)
 		frappe.get_doc("Stock Entry", draft_se_name).submit()
-		_recreate_sres_at(sre_snapshots, t_warehouse, target_operation=last_mop_name)
-		_mark_all_mwo_mop_logs_synced([mwo], selective=selective)
-		_stamp_last_eod_sync(mop_data_list)
+		# Reserve at each MWO's target FROM the submitted SE's rows (Sales-Order-anchored,
+		# per-row MWO/operation), then hard-delete the now-cancelled source SREs.
+		_reserve_sres_from_eod_se_rows(company, items, sync_log_name=sync_log_name)
+		for m in main_mwos:
+			_hard_delete_cancelled_snapshots(snaps_by_mwo[m["mwo"]])
+		for m in main_mwos:
+			_mark_all_mwo_mop_logs_synced([m["mwo"]], selective=selective)
+			_stamp_last_eod_sync(m["mop_data_list"])
 		frappe.db.release_savepoint("eod_submit_phase")
 		stats["submitted_ses"].append(draft_se_name)
-		stats["processed_mwos"] += 1
-
-		# Update child rows to Synced
-		if sync_log_name and child_row_names:
-			for rn in child_row_names:
-				frappe.db.set_value(
-					"MOP EOD Sync Log Item",
-					rn,
-					{
-						"status": "Synced",
-						"is_synced": 1,
-						"stock_entry": draft_se_name,
-						"sync_stage": "Completed",
-						"completed_on": now_datetime(),
-					},
-					update_modified=False,
-				)
-
+		stats["processed_mwos"] += len(main_mwos)
+		_bulk_set_child_rows(
+			child_rows,
+			{
+				"status": "Synced",
+				"is_synced": 1,
+				"stock_entry": draft_se_name,
+				"sync_stage": "Completed",
+				"completed_on": now_datetime(),
+			},
+		)
 	except Exception as exc:
-		# The whole Phase-2 savepoint is rolled back: SE submit, SRE cancellation and
-		# re-reservation are all undone, so the reservations are restored to their
-		# original state. The draft SE (created in Phase 1, before this savepoint)
-		# is preserved for manual recovery.
+		# Whole Phase-2 savepoint rolled back: submit + SRE cancel/re-reserve undone, so
+		# reservations are restored. The Phase-1 draft (saved before this savepoint)
+		# survives for manual recovery.
 		frappe.db.rollback(save_point="eod_submit_phase")
 		failures.append(
 			{
 				"step": "submit",
-				"mwo": mwo,
+				"mwo": ", ".join(mwo_list),
 				"company": company,
-				"last_mop": last_mop_name,
-				"affected_mops": all_mop_names,
-				"t_warehouse": t_warehouse,
+				"affected_mops": mop_names,
 				"draft_se": draft_se_name,
 				"error_message": str(exc),
 				"traceback": frappe.get_traceback(),
 				"suggested_fix": (
-					f"Stock Entry {draft_se_name} is saved as Draft but failed to submit. "
-					"Stock Reservation Entries were restored (rolled back), so nothing is "
-					"left half-done. Review the validation error, fix the underlying issue, "
-					"and submit the draft manually. MOP Logs remain unsynced until then."
+					f"Consolidated Stock Entry {draft_se_name} is saved as Draft but failed "
+					"to submit. Stock Reservation Entries were restored (rolled back). Review "
+					"the validation error, fix the underlying issue, and submit the draft "
+					"manually. MOP Logs for these MWOs remain unsynced until then."
 				),
 			}
 		)
 		stats["draft_ses"].append(draft_se_name)
-		stats["failed_mwos"] += 1
-		# Update child rows to Draft Created
-		if sync_log_name and child_row_names:
-			for rn in child_row_names:
-				frappe.db.set_value(
-					"MOP EOD Sync Log Item",
-					rn,
-					{
-						"status": "Draft Created",
-						"draft_stock_entry": draft_se_name,
-						"sync_stage": "Submit Stock Entry",
-						"error_type": "Stock Entry Submit Failed",
-						"error_message": str(exc)[:500],
-						"technical_traceback": frappe.get_traceback()[:3000],
-						"suggested_fix": f"Open draft Stock Entry {draft_se_name}, fix the error, and submit manually. MOP Logs remain unsynced.",
-						"completed_on": now_datetime(),
-					},
-					update_modified=False,
-				)
+		stats["failed_mwos"] += len(main_mwos)
+		_bulk_set_child_rows(
+			child_rows,
+			{
+				"status": "Draft Created",
+				"draft_stock_entry": draft_se_name,
+				"sync_stage": "Submit Stock Entry",
+				"error_type": "Stock Entry Submit Failed",
+				"error_message": str(exc)[:500],
+				"technical_traceback": frappe.get_traceback()[:3000],
+				"suggested_fix": f"Open draft Stock Entry {draft_se_name}, fix the error, and submit manually.",
+				"completed_on": now_datetime(),
+			},
+		)
+
+
+def _commit_company_issues_se(company, manufacturer, issues_rows, stats, sync_log_name=None):
+	"""Best-effort single DRAFT *Material Transfer to Department* holding the buildable
+	rows of failed MWOs, for visibility. Wrapped so it can never block the run."""
+	if not issues_rows:
+		return
+	try:
+		frappe.db.savepoint("eod_issues_phase")
+		draft_se_name = _save_draft_eod_se(
+			company,
+			None,
+			None,
+			issues_rows,
+			header_manufacturer=manufacturer,
+			sync_log_name=sync_log_name,
+			eod_sync_source="MOP EOD Sync (Unresolved)",
+		)
+		frappe.db.release_savepoint("eod_issues_phase")
+		stats["draft_ses"].append(draft_se_name)
+	except Exception:
+		frappe.db.rollback(save_point="eod_issues_phase")
+		frappe.logger().exception(
+			"MOP EOD Sync: could not build draft issues SE for %s / %s",
+			company,
+			manufacturer,
+		)
+
+
+def _process_mwo_group(
+	group_key, mop_data_list, failures, stats, sync_log_name=None, selective=False
+):
+	"""Plan and commit a single MWO group end-to-end.
+
+	Convenience wrapper: ``sync_mop_logs`` drives the production flow with
+	:func:`_plan_mwo_group` + per-bucket :func:`_commit_company_main_se`, but processing
+	exactly one group (one resolvable MWO ⇒ one consolidated SE for that MWO) is a useful
+	unit for the manual retry patch and tests.
+	"""
+	result = _plan_mwo_group(
+		group_key, mop_data_list, failures, stats, sync_log_name, selective=selective
+	)
+	if not result:
+		return
+	if result["kind"] == "resolvable":
+		_commit_company_main_se(
+			result["company"],
+			result.get("manufacturer"),
+			[result],
+			failures,
+			stats,
+			sync_log_name,
+			selective=selective,
+		)
+	elif result["kind"] == "failed" and result.get("issues_rows"):
+		_commit_company_issues_se(
+			result["company"],
+			result.get("manufacturer"),
+			result["issues_rows"],
+			stats,
+			sync_log_name,
+		)
 
 
 # ---------------------------------------------------------------------------
@@ -740,16 +967,185 @@ def _reconcile_reservations_for_mwo(mwo, dry_run=True):
 					)
 
 
+def _active_sre_exists(mwo, item_code, batch_no):
+	"""True when an active (docstatus=1) SRE already reserves this item/batch on the MWO."""
+	if batch_no:
+		return bool(
+			frappe.db.sql(
+				"""
+				SELECT 1 FROM `tabStock Reservation Entry` sre
+				INNER JOIN `tabSerial and Batch Entry` sbe ON sbe.parent = sre.name
+				WHERE sre.docstatus = 1
+				  AND sre.manufacturing_work_order = %s
+				  AND sre.item_code = %s
+				  AND sbe.batch_no = %s
+				LIMIT 1
+				""",
+				(mwo, item_code, batch_no),
+			)
+		)
+	return bool(
+		frappe.db.exists(
+			"Stock Reservation Entry",
+			{
+				"manufacturing_work_order": mwo,
+				"item_code": item_code,
+				"docstatus": 1,
+			},
+		)
+	)
+
+
+@frappe.whitelist()
+def backfill_missing_wip_reservations(mwo=None, dry_run=True):
+	"""Re-create the destination SREs that EOD sync skipped for batched WIP.
+
+	Older EOD runs dropped batched WIP rows while reserving at the new operation:
+	ERPNext's batch availability reads 0 under v16 Serial-and-Batch-Bundle stock
+	(see ``_free_batch_qty_to_reserve``), so the source SRE was cancelled and no
+	destination SRE was ever created. The current operation then holds physical WIP
+	with no active Stock Reservation Entry, and Employee IR Process Loss throws
+	"No active Stock Reservation Entry found".
+
+	For each affected MWO's current operation, rebuild the missing (item, batch)
+	reservations from the live MOP balance, reusing ``_reserve_sres_from_eod_se_rows``
+	so the new SREs stay Sales-Order-anchored exactly like a fresh EOD run.
+	Idempotent: an (item, batch) that already has an active SRE is skipped.
+
+	Pass ``mwo`` to fix one work order; omit to scan every submitted/draft Employee
+	IR loss row for MWOs missing their reservation. ``dry_run`` (default) only reports.
+
+	Run:  bench --site <site> execute \
+	  jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.backfill_missing_wip_reservations \
+	  --kwargs "{'mwo': 'MWO-...', 'dry_run': False}"
+	"""
+	from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+		get_current_mop_balance_rows,
+	)
+
+	dry_run = cint(dry_run)
+	if mwo:
+		mwos = [mwo]
+	else:
+		mwos = [
+			r[0]
+			for r in frappe.db.sql(
+				"""
+				SELECT DISTINCT eld.manufacturing_work_order
+				FROM `tabEmployee Loss Details` eld
+				INNER JOIN `tabEmployee IR` eir ON eir.name = eld.parent
+				WHERE eir.docstatus < 2
+				  AND eld.proportionally_loss > 0
+				  AND eld.manufacturing_work_order IS NOT NULL
+				"""
+			)
+		]
+
+	report = []
+	for mwo_name in mwos:
+		op, company = frappe.db.get_value(
+			"Manufacturing Work Order",
+			mwo_name,
+			["manufacturing_operation", "company"],
+		) or (None, None)
+		if not op:
+			continue
+		# Reserve where the WIP physically landed — the EOD transfer's department WO
+		# warehouse (where the SBB batch stock and the operation's sibling SREs live),
+		# NOT the MOP Log's logical operation warehouse (often the employee hand WIP WH,
+		# which holds no batch stock). _reserve_sres_from_eod_se_rows clamps each row to
+		# the free batch qty there, so a row whose batch is absent is harmlessly skipped.
+		dept_wh = _resolve_department_warehouse(
+			frappe.get_cached_doc("Manufacturing Operation", op)
+		)
+		balance_rows = get_current_mop_balance_rows(
+			op,
+			include_fields=[
+				"item_code",
+				"batch_no",
+				"qty_after_transaction_batch_based as qty",
+				"to_warehouse",
+			],
+		)
+		synthetic = []
+		for b in balance_rows:
+			item_code = b.get("item_code")
+			batch_no = b.get("batch_no")
+			t_warehouse = dept_wh or b.get("to_warehouse")
+			qty = flt(b.get("qty"))
+			if not (item_code and t_warehouse) or qty <= 0:
+				continue
+			if _active_sre_exists(mwo_name, item_code, batch_no):
+				continue
+			synthetic.append(
+				{
+					"custom_manufacturing_work_order": mwo_name,
+					"manufacturing_operation": op,
+					"item_code": item_code,
+					"batch_no": batch_no,
+					"t_warehouse": t_warehouse,
+					"qty": qty,
+				}
+			)
+		if not synthetic:
+			continue
+		if dry_run:
+			report.append(
+				{
+					"mwo": mwo_name,
+					"operation": op,
+					"would_create": [
+						{
+							"item_code": s["item_code"],
+							"batch_no": s["batch_no"],
+							"warehouse": s["t_warehouse"],
+							"qty": s["qty"],
+						}
+						for s in synthetic
+					],
+				}
+			)
+		else:
+			created = _reserve_sres_from_eod_se_rows(company, synthetic)
+			report.append({"mwo": mwo_name, "operation": op, "created": created})
+
+	return report
+
+
 # ---------------------------------------------------------------------------
-# Data gathering: unsynced MOP groups (today-only, with MWO filter)
+# Data gathering: unsynced MOP groups (configurable window, with MWO filter)
 # ---------------------------------------------------------------------------
 
 
-def _get_today_range():
-	"""Return (today_start_str, tomorrow_start_str) as datetime strings."""
+def _today_range():
+	"""Return today's (start_str, end_str) as inclusive datetime strings."""
 	today = nowdate()
-	tomorrow = add_days(today, 1)
-	return f"{today} 00:00:00", f"{tomorrow} 00:00:00"
+	return f"{today} 00:00:00", f"{today} 23:59:59"
+
+
+def _resolve_run_range(from_datetime=None, to_datetime=None):
+	"""Resolve the (start, end) creation window for a sync run as datetime strings.
+
+	If both bounds are supplied (manual EOD Sync), they are used verbatim; otherwise
+	(scheduler, or a manual run that left them blank) the window defaults to today's
+	start/end. Bounds are inclusive on both ends.
+	"""
+	if from_datetime and to_datetime:
+		return str(from_datetime), str(to_datetime)
+	return _today_range()
+
+
+def _get_sync_range():
+	"""Return the (start, end) creation window for the current run.
+
+	Reads the window stashed on ``frappe.flags.eod_sync_range`` by
+	:func:`sync_mop_logs`; falls back to today's range when unset (e.g. when a helper
+	is called outside a full run). Bounds are inclusive on both ends.
+	"""
+	rng = getattr(frappe.flags, "eod_sync_range", None)
+	if rng:
+		return rng
+	return _today_range()
 
 
 def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
@@ -802,9 +1198,9 @@ def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
 			order_by=log_order_by,
 		)
 	else:
-		today_start, tomorrow_start = _get_today_range()
+		window_start, window_end = _get_sync_range()
 
-		# Count old unsynced logs for reporting (today-only scheduled mode)
+		# Count unsynced logs before the window for reporting (they are skipped).
 		old_logs = frappe.db.sql(
 			"""
             SELECT COUNT(*) as cnt, COALESCE(SUM(qty_after_transaction_batch_based), 0) as qty
@@ -812,7 +1208,7 @@ def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
             WHERE is_synced = 0 AND is_cancelled = 0
               AND creation < %s
             """,
-			(today_start,),
+			(window_start,),
 			as_dict=True,
 		)
 		old_count = cint(old_logs[0].get("cnt", 0)) if old_logs else 0
@@ -826,8 +1222,9 @@ def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
 					"old_unsynced_mop_log_count": old_count,
 					"old_unsynced_mop_log_qty": old_qty,
 					"old_unsynced_mop_log_message": (
-						f"{old_count} older unsynced MOP Log(s) (qty={old_qty}) were found but skipped "
-						"because EOD Sync is configured to process only today-created logs."
+						f"{old_count} unsynced MOP Log(s) (qty={old_qty}) before the sync window "
+						f"({window_start}) were found but skipped — EOD Sync only processes logs "
+						"created inside the configured window."
 					),
 				},
 				update_modified=False,
@@ -838,7 +1235,7 @@ def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
 			filters={
 				"is_synced": 0,
 				"is_cancelled": 0,
-				"creation": ["between", [today_start, tomorrow_start]],
+				"creation": ["between", [window_start, window_end]],
 			},
 			fields=log_fields,
 			order_by=log_order_by,
@@ -1151,94 +1548,227 @@ def _cancel_sre_snapshots(snapshots):
 			doc.cancel()
 
 
-def _recreate_sres_at(snapshots, new_warehouse, target_operation=None):
-	"""Recreate the snapshotted SREs at ``new_warehouse`` (same voucher/qty/batches).
+def _eod_base_mr_voucher_qty(manufacturing_order, manufacturer):
+	"""Mirror ``stock_reservation_entry_for_mwo``'s voucher_qty base.
 
-	The new SRE is tagged with ``target_operation`` — the latest operation, whose
-	warehouse the stock was just moved to — so downstream processes (e.g. Make
-	Receive Entry, which reads MWO-scoped active SREs) see the reservation against
-	the current operation. Falls back to the original SRE's operation if not given.
+	Returns the Material Request total (``SUM(custom_total_quantity)`` of non-cancelled
+	MRs for the MO) inflated by the manufacturer's Manufacturing Setting
+	``addition_maximum_item__tolerance_percentage``. Returns ``None`` when there is no
+	MR data (caller then falls back to its previous voucher_qty model).
 	"""
-	if not snapshots:
-		return
+	if not manufacturing_order:
+		return None
+	row = frappe.db.sql(
+		"""
+        SELECT sum(custom_total_quantity) FROM `tabMaterial Request`
+        WHERE manufacturing_order=%s AND docstatus!=2
+        """,
+		(manufacturing_order,),
+	)
+	if not (row and row[0] and row[0][0] is not None):
+		return None
+	base = flt(row[0][0])
+	tolerance = None
+	if manufacturer:
+		tolerance = frappe.db.get_value(
+			"Manufacturing Setting",
+			manufacturer,
+			"addition_maximum_item__tolerance_percentage",
+		)
+	if tolerance:
+		base = base + (base * (flt(tolerance) / 100))
+	return base
+
+
+def _free_batch_qty_to_reserve(item_code, warehouse, batch_no):
+	"""Free batch qty that can still be reserved at ``warehouse``.
+
+	ERPNext's ``get_available_qty_to_reserve(item, wh, batch_no=...)`` returns 0
+	under v16 because batch stock lives in the Serial and Batch Bundle (``Stock
+	Ledger Entry.batch_no`` is NULL), so the batch-keyed availability query finds
+	nothing. Computing it SBB-aware — physical batch qty (``get_batch_qty``) minus
+	the qty already reserved for that batch at the warehouse by active SREs — keeps
+	batched WIP from being silently skipped during EOD re-reservation.
+	"""
+	from erpnext.stock.doctype.batch.batch import get_batch_qty
+
+	physical = flt(get_batch_qty(batch_no, warehouse, item_code))
+	if physical <= 0:
+		return 0.0
+	reserved = flt(
+		frappe.db.sql(
+			"""
+			SELECT COALESCE(SUM(sbe.qty), 0)
+			FROM `tabStock Reservation Entry` sre
+			INNER JOIN `tabSerial and Batch Entry` sbe ON sbe.parent = sre.name
+			WHERE sre.docstatus = 1
+			  AND sre.item_code = %s
+			  AND sre.warehouse = %s
+			  AND sbe.batch_no = %s
+			""",
+			(item_code, warehouse, batch_no),
+		)[0][0]
+	)
+	return max(physical - reserved, 0.0)
+
+
+def _reserve_sres_from_eod_se_rows(company, items, sync_log_name=None):
+	"""Build Sales-Order-anchored Stock Reservation Entries from the just-submitted
+	consolidated EOD Stock Entry's rows.
+
+	Replaces the old snapshot-copy re-reservation: instead of cloning the cancelled source
+	SRE, the reservation is built from what the Stock Entry actually moved. Each row carries
+	its own MWO (``custom_manufacturing_work_order``) and the last operation
+	(``manufacturing_operation``); the reservation stays anchored to that MWO's Sales Order
+	(so ERPNext SO delivered/reserved-qty accounting and downstream Make Receive consumption
+	keep working) and lands at the row's ``t_warehouse`` where the stock now sits.
+
+	Mirrors ``stock_reservation_entry_for_mwo`` (doc_events/stock_entry.py) per row, with the
+	EOD divergences: it reads the MWO/operation PER ROW (not the SE header, which the
+	consolidated SE leaves blank) and SKIPS a row when nothing is free at the target rather
+	than throwing. Returns the list of created SRE names.
+	"""
+	if not items:
+		return []
 	from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
 		get_available_qty_to_reserve,
 		get_sre_reserved_qty_for_voucher_detail_no,
 	)
 
-	for snap in snapshots:
-		sre = snap["sre"]
-		# Batch-tracked SRE with no remaining batch qty → nothing to re-reserve.
-		if snap["has_batch_no"] and not snap["sb_entries"]:
+	# Resolve the Sales Order anchor + MR-based voucher_qty cap once per MWO.
+	mwo_cache = {}
+
+	def _resolve_mwo(mwo):
+		if mwo in mwo_cache:
+			return mwo_cache[mwo]
+		mo, mfr = frappe.db.get_value(
+			"Manufacturing Work Order", mwo, ["manufacturing_order", "manufacturer"]
+		) or (None, None)
+		sales_order = sales_order_item = mo_manufacturer = None
+		if mo:
+			sales_order, sales_order_item, mo_manufacturer = frappe.get_cached_value(
+				"Parent Manufacturing Order",
+				mo,
+				["sales_order", "sales_order_item", "manufacturer"],
+			) or (None, None, None)
+		if not sales_order:
+			mwo_cache[mwo] = None
+			return None
+		resolved = {
+			"sales_order": sales_order,
+			"sales_order_item": sales_order_item,
+			"base_mr_voucher_qty": _eod_base_mr_voucher_qty(mo, mfr or mo_manufacturer),
+		}
+		mwo_cache[mwo] = resolved
+		return resolved
+
+	created = []
+	for row in items:
+		mwo = row.get("custom_manufacturing_work_order")
+		if not mwo:
+			continue
+		resolved = _resolve_mwo(mwo)
+		# No Sales Order anchor (e.g. a stock-based MWO) — the stock still moved, but we do
+		# not create a malformed reservation. Skip.
+		if not resolved:
 			continue
 
-		# Clamp to what is actually free at the target, mirroring
-		# stock_reservation_entry_for_mwo. The stock was just transferred here, but part
+		item_code = row.get("item_code")
+		t_warehouse = row.get("t_warehouse")
+		if not (item_code and t_warehouse):
+			continue
+		batch_no = row.get("batch_no")
+		has_batch_no, has_serial_no, stock_uom = frappe.get_cached_value(
+			"Item", item_code, ["has_batch_no", "has_serial_no", "stock_uom"]
+		)
+
+		# Clamp to what is actually free at the target. The stock just landed here, but part
 		# of a batch may already be reserved — never reserve more than is free, and skip
 		# entirely when nothing is free (rather than letting ERPNext throw).
-		if snap["sb_entries"]:
-			clamped_sb = []
-			for sb in snap["sb_entries"]:
-				free = get_available_qty_to_reserve(
-					sre.item_code, new_warehouse, batch_no=sb["batch_no"]
-				)
-				qty = min(flt(sb["qty"]), flt(free))
-				if qty > 1e-9:
-					clamped_sb.append({"batch_no": sb["batch_no"], "qty": qty})
-			if not clamped_sb:
-				continue
-			reserved_qty = sum(flt(s["qty"]) for s in clamped_sb)
-			available = reserved_qty
+		if has_batch_no and batch_no:
+			# v16 keeps batch stock in the Serial and Batch Bundle (SLE.batch_no is NULL),
+			# so ERPNext's get_available_qty_to_reserve(..., batch_no=...) returns 0 and
+			# EVERY batched WIP row would be silently skipped — the new operation would end
+			# up holding physical stock with no Stock Reservation Entry, and Employee IR
+			# Process Loss then fails with "No active Stock Reservation Entry found".
+			# Compute the free batch qty SBB-aware instead.
+			available = _free_batch_qty_to_reserve(item_code, t_warehouse, batch_no)
 		else:
-			clamped_sb = None
-			available = get_available_qty_to_reserve(sre.item_code, new_warehouse)
-			reserved_qty = min(flt(snap["remaining"]), flt(available))
-			if reserved_qty <= 1e-9:
-				continue
+			available = get_available_qty_to_reserve(item_code, t_warehouse)
+		reserved_qty = min(flt(row.get("qty")), flt(available))
+		if reserved_qty <= 1e-9:
+			continue
 
-		# Lift the Sales Order demand cap exactly like the original creator: the SO line
-		# is intentionally over-reserved across components, so size voucher_qty to cover
-		# the current reservation (EIR-injection pattern in stock_reservation_entry_for_mwo).
-		# The source SRE was already cancelled, so it is excluded from this global sum.
+		# Lift the Sales Order demand cap exactly like the original creator: the SO line is
+		# intentionally over-reserved across components, so size voucher_qty to cover the
+		# current reservation. The source SRE was already cancelled, so it is excluded from
+		# this global sum.
 		total_so_reserved = get_sre_reserved_qty_for_voucher_detail_no(
-			sre.item_code, sre.voucher_type, sre.voucher_no, sre.voucher_detail_no
+			item_code,
+			"Sales Order",
+			resolved["sales_order"],
+			resolved["sales_order_item"],
 		)
-		effective_voucher_qty = max(
-			flt(sre.voucher_qty), flt(total_so_reserved) + reserved_qty
-		)
+		floor = flt(total_so_reserved) + reserved_qty
+		base_mr_voucher_qty = resolved["base_mr_voucher_qty"]
+		if base_mr_voucher_qty is not None:
+			effective_voucher_qty = max(flt(base_mr_voucher_qty), floor)
+		else:
+			effective_voucher_qty = floor
 
 		new_sre = frappe.new_doc("Stock Reservation Entry")
-		new_sre.voucher_type = sre.voucher_type
-		new_sre.voucher_no = sre.voucher_no
-		new_sre.voucher_detail_no = sre.voucher_detail_no
+		new_sre.voucher_type = "Sales Order"
+		new_sre.voucher_no = resolved["sales_order"]
+		new_sre.voucher_detail_no = resolved["sales_order_item"]
 		new_sre.voucher_qty = effective_voucher_qty
-		new_sre.item_code = sre.item_code
-		new_sre.warehouse = new_warehouse
+		new_sre.item_code = item_code
+		new_sre.warehouse = t_warehouse
 		new_sre.reserved_qty = reserved_qty
-		new_sre.company = sre.company
-		new_sre.stock_uom = sre.stock_uom
-		new_sre.reservation_based_on = sre.reservation_based_on
-		new_sre.has_batch_no = snap["has_batch_no"]
-		new_sre.has_serial_no = snap["has_serial_no"]
+		new_sre.company = company
+		new_sre.stock_uom = stock_uom
+		new_sre.has_batch_no = cint(has_batch_no)
+		new_sre.has_serial_no = cint(has_serial_no)
 		new_sre.available_qty = max(flt(available), reserved_qty)
-		new_sre.manufacturing_work_order = sre.manufacturing_work_order
-		new_sre.manufacturing_operation = (
-			target_operation or sre.manufacturing_operation
-		)
-		for sb in clamped_sb or []:
-			# Mirror stock_reservation_entry_for_mwo: the batch entry must carry the
-			# (new) warehouse so the reservation binds to the relocated stock.
+		new_sre.manufacturing_work_order = mwo
+		new_sre.manufacturing_operation = row.get("manufacturing_operation")
+		if has_batch_no and batch_no:
+			new_sre.reservation_based_on = "Serial and Batch"
 			new_sre.append(
 				"sb_entries",
 				{
-					"batch_no": sb["batch_no"],
-					"warehouse": new_warehouse,
-					"qty": sb["qty"],
+					"batch_no": batch_no,
+					"warehouse": t_warehouse,
+					"qty": reserved_qty,
 				},
 			)
+		else:
+			new_sre.reservation_based_on = "Qty"
 		new_sre.flags.ignore_permissions = True
 		new_sre.insert(ignore_links=1)
 		new_sre.submit()
+		created.append(new_sre.name)
+
+	return created
+
+
+def _hard_delete_cancelled_snapshots(snapshots):
+	"""Hard-delete the source SREs this run just cancelled (the snapshots).
+
+	Called inside the Phase-2 savepoint AFTER the new reservation succeeds so the cancelled
+	reservation records do not accumulate. Any delete error propagates so the bucket's
+	savepoint rolls back (restoring the cancelled SREs and the submit, never leaving them
+	deleted without a transfer). Mirrors the force-delete pattern in
+	retry_stuck_eod_submit_mwos.py.
+	"""
+	for snap in snapshots or []:
+		name = snap["sre"].name
+		if frappe.db.exists("Stock Reservation Entry", name):
+			frappe.delete_doc(
+				"Stock Reservation Entry",
+				name,
+				force=1,
+				ignore_permissions=True,
+			)
 
 
 # ---------------------------------------------------------------------------
@@ -1274,6 +1804,11 @@ def _build_eod_se_rows(mwo, last_mop_name, last_logs, t_warehouse, sre_map):
 			"custom_manufacturing_work_order": mwo,
 			"use_serial_batch_fields": 1,
 		}
+		# pcs is a reqd Data field defaulting to "1". Only Diamond/Gemstone items are
+		# counted in pieces — set their real count from the MOP Log balance so the EOD
+		# SE reflects actual stone counts. Metal/Finding rows keep the "1" default.
+		if (log.item_code or "")[:1] in ("D", "G"):
+			row["pcs"] = cint(log.pcs_after_transaction_batch_based)
 		if log.batch_no:
 			row["batch_no"] = log.batch_no
 		if getattr(log, "serial_no", None):
@@ -1283,16 +1818,18 @@ def _build_eod_se_rows(mwo, last_mop_name, last_logs, t_warehouse, sre_map):
 
 
 # ---------------------------------------------------------------------------
-# MOP Log sync-marking (today-only safety net, or full history in selective mode)
+# MOP Log sync-marking (window-bounded safety net, or full history in selective mode)
 # ---------------------------------------------------------------------------
 
 
 def _mark_all_mwo_mop_logs_synced(manufacturing_work_orders, selective=False):
 	"""Mark unsynced non-cancelled MOP Logs for the given MWOs as synced.
 
-	Scheduled runs (``selective=False``) only mark today's logs — a safety net so
-	a misconfigured run can never silently bury an old backlog. Selective runs
-	(an enabled MWO filter row) mark the MWO's full unsynced history.
+	Scheduled runs (``selective=False``) only mark logs inside the run's window — a
+	safety net so a misconfigured run can never silently bury logs outside it. The
+	window matches the one used to gather logs (today by default, or the manual
+	From/To). Selective runs (an enabled MWO filter row) mark the MWO's full unsynced
+	history.
 	"""
 	if not manufacturing_work_orders:
 		return
@@ -1308,7 +1845,7 @@ def _mark_all_mwo_mop_logs_synced(manufacturing_work_orders, selective=False):
 			{"mwos": manufacturing_work_orders},
 		)
 		return
-	today_start, tomorrow_start = _get_today_range()
+	window_start, window_end = _get_sync_range()
 	frappe.db.sql(
 		"""
         UPDATE `tabMOP Log`
@@ -1316,13 +1853,13 @@ def _mark_all_mwo_mop_logs_synced(manufacturing_work_orders, selective=False):
         WHERE manufacturing_work_order IN %(mwos)s
           AND is_synced = 0
           AND is_cancelled = 0
-          AND creation >= %(today_start)s
-          AND creation < %(tomorrow_start)s
+          AND creation >= %(window_start)s
+          AND creation <= %(window_end)s
         """,
 		{
 			"mwos": manufacturing_work_orders,
-			"today_start": today_start,
-			"tomorrow_start": tomorrow_start,
+			"window_start": window_start,
+			"window_end": window_end,
 		},
 	)
 
@@ -1387,8 +1924,16 @@ def _save_draft_eod_se(
 	header_mop_name=None,
 	header_manufacturer=None,
 	sync_log_name=None,
+	eod_sync_source="MOP EOD Sync",
 ):
-	"""Create and SAVE (draft only) one Material Transfer to Department Stock Entry."""
+	"""Create and SAVE (draft only) one Material Transfer to Department Stock Entry.
+
+	For the consolidated run, ``mwo`` / ``manufacturing_order`` / ``header_mop_name`` /
+	``header_manufacturer`` are left ``None`` — each item row already carries
+	``custom_manufacturing_work_order`` and ``manufacturing_operation``, and the
+	reservation / MOP-log hooks do not run for this stock entry type, so no header MWO
+	is required. ``eod_sync_source`` tags the draft (e.g. the unresolved "issues" SE).
+	"""
 	se = frappe.new_doc("Stock Entry")
 	se.stock_entry_type = "Material Transfer to Department"
 	se.company = company
@@ -1403,7 +1948,7 @@ def _save_draft_eod_se(
 	se.custom_is_eod_sync_stock_entry = 1
 	if sync_log_name:
 		se.custom_eod_sync_log = sync_log_name
-	se.custom_eod_sync_source = "MOP EOD Sync"
+	se.custom_eod_sync_source = eod_sync_source
 	for item in items:
 		se.append("items", item)
 	se.flags.ignore_permissions = True
@@ -1791,6 +2336,49 @@ def _get_sre_undelivered_batch_qty(
 	if not rows or rows[0][0] is None:
 		return 0.0
 	return flt(rows[0][0], 3)
+
+
+def _check_eod_source_batch_stock(items_to_transfer):
+	"""Non-throwing batch-stock check used by the plan phase.
+
+	Returns ``{(s_warehouse, item_code, batch_no): (required_qty, physical_qty)}`` for
+	every aggregated row whose required transfer qty exceeds physical batch balance
+	(SLE / serial-batch ledger; reservations do NOT create stock). An empty dict means
+	all batch rows have enough physical stock.
+	"""
+	from erpnext.stock.doctype.batch.batch import get_batch_qty
+	from frappe.utils import nowtime, today
+
+	posting_date = today()
+	posting_time = nowtime()
+	needed = {}
+	for item in items_to_transfer:
+		wh = item.get("s_warehouse")
+		item_code = item.get("item_code")
+		batch_no = item.get("batch_no")
+		qty = flt(item.get("qty"), 3)
+		if not wh or not item_code or qty <= 0 or not batch_no:
+			continue
+		key = (wh, item_code, batch_no)
+		needed[key] = flt(needed.get(key, 0) + qty, 3)
+
+	short = {}
+	for (wh, item_code, batch_no), req_qty in needed.items():
+		try:
+			physical_raw = get_batch_qty(
+				batch_no=batch_no,
+				warehouse=wh,
+				item_code=item_code,
+				posting_date=posting_date,
+				posting_time=posting_time,
+				ignore_reserved_stock=True,
+			)
+		except Exception:
+			physical_raw = None
+		physical = flt(physical_raw, 3) if physical_raw is not None else 0.0
+		if req_qty > physical + 1e-6:
+			short[(wh, item_code, batch_no)] = (req_qty, physical)
+	return short
 
 
 def _validate_eod_source_batch_stock(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.js
@@ -3,6 +3,7 @@
 
 frappe.ui.form.on("MOP Settings", {
 	refresh(frm) {
+		_prefill_eod_sync_window(frm);
 		_setup_eod_status_indicator(frm);
 		_setup_eod_sync_button(frm);
 		_apply_permission_restrictions(frm);
@@ -10,6 +11,26 @@ frappe.ui.form.on("MOP Settings", {
 		_setup_open_sync_log_button(frm);
 	},
 });
+
+// Pre-fill the manual EOD Sync window with today's start/end so the user always sees
+// the effective default. A field is reset only when blank or holding a value from a
+// previous day; a same-day custom edit is preserved. Values are set on frm.doc (not via
+// set_value) so the form is not marked dirty.
+function _prefill_eod_sync_window(frm) {
+	const today = frappe.datetime.get_today();
+	const defaults = {
+		eod_sync_from_datetime: today + " 00:00:00",
+		eod_sync_to_datetime: today + " 23:59:59",
+	};
+	Object.entries(defaults).forEach(([field, default_value]) => {
+		const cur = frm.doc[field];
+		const cur_date = cur ? String(cur).slice(0, 10) : null;
+		if (!cur || cur_date < today) {
+			frm.doc[field] = default_value;
+			frm.refresh_field(field);
+		}
+	});
+}
 
 function _is_system_manager() {
 	return frappe.user_roles && frappe.user_roles.includes("System Manager");
@@ -98,12 +119,14 @@ function _apply_permission_restrictions(frm) {
 	const is_sm = _is_system_manager();
 	const is_locked = _is_eod_locked(frm);
 
-	// Non-System Manager cannot change EOD Sync Time or filter table
+	// Non-System Manager cannot change EOD Sync Time, the manual From/To window, or the filter table
 	if (!is_sm) {
-		frm.set_df_property("eod_sync_time", "read_only", 1);
-		frm.refresh_field("eod_sync_time");
-		frm.set_df_property("eod_sync_work_order_filter", "read_only", 1);
-		frm.refresh_field("eod_sync_work_order_filter");
+		["eod_sync_time", "eod_sync_from_datetime", "eod_sync_to_datetime", "eod_sync_work_order_filter"].forEach(
+			(field) => {
+				frm.set_df_property(field, "read_only", 1);
+				frm.refresh_field(field);
+			}
+		);
 	}
 
 	// Disable the EOD Sync button for non-SM or when lock is active

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.json
@@ -9,6 +9,8 @@
         "sync_mop_log",
         "eod_sync_section",
         "eod_sync_time",
+        "eod_sync_from_datetime",
+        "eod_sync_to_datetime",
         "eod_sync_running",
         "eod_sync_started_on",
         "eod_sync_last_completed_on",
@@ -44,6 +46,18 @@
             "fieldtype": "Time",
             "label": "EOD Sync Time",
             "reqd": 1
+        },
+        {
+            "description": "Start of the window scanned by a manual EOD Sync. Defaults to today 00:00. The automatic nightly sync always uses today and ignores this.",
+            "fieldname": "eod_sync_from_datetime",
+            "fieldtype": "Datetime",
+            "label": "EOD Sync From"
+        },
+        {
+            "description": "End of the window scanned by a manual EOD Sync. Defaults to the end of today. The automatic nightly sync always uses today and ignores this.",
+            "fieldname": "eod_sync_to_datetime",
+            "fieldtype": "Datetime",
+            "label": "EOD Sync To"
         },
         {
             "default": "0",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.py
@@ -7,7 +7,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import now_datetime, nowdate
+from frappe.utils import get_datetime, now_datetime, nowdate
 
 # Employee IR injection submits Material Transfer (WORK ORDER) and/or Repack Stock Entries.
 # Both must appear in Stock Entry Type To Reservation or ``stock_reservation_entry_for_mwo``
@@ -21,6 +21,7 @@ class MOPSettings(Document):
 	def validate(self):
 		self._validate_reservation_types()
 		self._validate_eod_sync_time_permission()
+		self._validate_eod_sync_window()
 
 	def _validate_reservation_types(self):
 		rows = self.get("stock_entry_type_to_reservation") or []
@@ -58,6 +59,17 @@ class MOPSettings(Document):
 			),
 		)
 
+	def _validate_eod_sync_window(self):
+		"""Ensure the manual EOD Sync From/To window is ordered when both are set."""
+		from_dt = self.eod_sync_from_datetime
+		to_dt = self.eod_sync_to_datetime
+		if from_dt and to_dt and get_datetime(from_dt) >= get_datetime(to_dt):
+			frappe.throw(
+				_("EOD Sync From ({0}) must be earlier than EOD Sync To ({1}).").format(
+					frappe.bold(from_dt), frappe.bold(to_dt)
+				)
+			)
+
 	@frappe.whitelist()
 	def sync_mop_log(self):
 		"""Enqueue EOD MOP Log sync as a background job (System Manager only)."""
@@ -74,6 +86,13 @@ class MOPSettings(Document):
 				),
 				title=_("EOD Sync In Progress"),
 			)
+
+		# Resolve the From/To window for this manual run. Blank fields fall back to
+		# today's start/end; the scheduler never sets these, so only manual runs can
+		# scan a custom window.
+		today = nowdate()
+		from_datetime = self.eod_sync_from_datetime or f"{today} 00:00:00"
+		to_datetime = self.eod_sync_to_datetime or f"{today} 23:59:59"
 
 		# Create a MOP EOD Sync Log to track this run
 		sync_log = frappe.new_doc("MOP EOD Sync Log")
@@ -102,6 +121,8 @@ class MOPSettings(Document):
 			timeout=7200,
 			enqueue_after_commit=True,
 			sync_log_name=sync_log_name,
+			from_datetime=from_datetime,
+			to_datetime=to_datetime,
 		)
 		frappe.msgprint(
 			_(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_eod_lock.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_eod_lock.py
@@ -406,6 +406,7 @@ class TestDraftSePreservedOnSubmitFailure(FrappeTestCase):
 	@patch(f"{_SYNC_MOD}.frappe.db.release_savepoint")
 	@patch(f"{_SYNC_MOD}.frappe.db.rollback")
 	@patch(f"{_SYNC_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_SYNC_MOD}._check_eod_source_batch_stock", return_value={})
 	@patch(f"{_SYNC_MOD}._validate_eod_source_batch_stock")
 	@patch(f"{_SYNC_MOD}._validate_eod_items_for_mwo_reservation")
 	@patch(
@@ -421,6 +422,7 @@ class TestDraftSePreservedOnSubmitFailure(FrappeTestCase):
 		_mock_sre_map,
 		_mock_item_val,
 		_mock_batch_val,
+		_mock_check_batch,
 		mock_mark_synced,
 		mock_rollback,
 		mock_release,
@@ -520,14 +522,14 @@ class TestConsolidatedErrorLog(FrappeTestCase):
 	@patch(f"{_SYNC_MOD}.release_eod_sync_lock")
 	@patch(f"{_SYNC_MOD}.set_eod_sync_running")
 	@patch(f"{_SYNC_MOD}._reconcile_reservations_for_mwo")
-	@patch(f"{_SYNC_MOD}._process_mwo_group")
+	@patch(f"{_SYNC_MOD}._plan_mwo_group")
 	@patch(f"{_SYNC_MOD}._get_unsynced_mop_groups")
 	@patch(f"{_SYNC_MOD}.frappe.log_error")
 	def test_single_error_log_for_multiple_mwo_failures(
 		self,
 		mock_log_error,
 		mock_get_groups,
-		mock_process,
+		mock_plan,
 		_mock_reconcile,
 		_mock_set_running,
 		_mock_release,
@@ -540,18 +542,20 @@ class TestConsolidatedErrorLog(FrappeTestCase):
 			("Co", "MWO-B"): [],
 		}
 
-		def _inject_failures(group_key, mop_data_list, failures, stats):
+		# Both MWOs fail in planning → no consolidated SE, two failures, one error log.
+		def _inject_failures(group_key, mop_data_list, failures, stats, sync_log_name=None, selective=False):
 			_, mwo = group_key
 			failures.append(
 				{
-					"step": "draft_save",
+					"step": "no_sre_warehouse",
 					"mwo": mwo,
 					"error_message": f"Simulated failure for {mwo}",
 				}
 			)
 			stats["failed_mwos"] += 1
+			return {"kind": "failed", "company": "Co", "manufacturer": "MF-1", "issues_rows": []}
 
-		mock_process.side_effect = _inject_failures
+		mock_plan.side_effect = _inject_failures
 
 		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
 			sync_mop_logs,

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_eod_sync.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Nirali and Contributors
 # See license.txt
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import frappe
@@ -11,18 +12,33 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync impor
 	_apply_mwo_filter_rows,
 	_build_eod_se_rows,
 	_cancel_sre_snapshots,
+	_check_eod_source_batch_stock,
+	_collect_mop_names,
+	_commit_company_issues_se,
+	_commit_company_main_se,
+	_eod_base_mr_voucher_qty,
 	_find_last_operation,
+	_format_batch_short_diagnostics,
 	_get_last_logs_per_item_batch,
+	_get_sync_range,
 	_get_t_warehouse_from_logs,
-	_get_today_range,
 	_get_unsynced_mop_groups,
+	_hard_delete_cancelled_snapshots,
 	_mark_all_mwo_mop_logs_synced,
+	_mop_manufacturer_label,
 	_mwo_realized_by_artifact,
+	_plan_mwo_group,
 	_preload_sre_warehouse_map,
 	_process_mwo_group,
-	_recreate_sres_at,
+	_reconcile_reservations_for_mwo,
+	_reserve_sres_from_eod_se_rows,
 	_resolve_department_warehouse,
+	_resolve_eod_manufacturer_label,
+	_resolve_run_range,
+	_save_draft_eod_se,
 	_snapshot_mwo_sres_for_relocation,
+	_today_range,
+	_validate_eod_items_for_mwo_reservation,
 	_validate_eod_source_batch_stock,
 	recalculate_sync_log_totals,
 	sync_mop_logs,
@@ -488,6 +504,10 @@ class TestProcessMwoGroupHappyPath(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._mark_all_mwo_mop_logs_synced"
 	)
 	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._check_eod_source_batch_stock",
+		return_value={},
+	)
+	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._validate_eod_source_batch_stock"
 	)
 	@patch(
@@ -520,6 +540,7 @@ class TestProcessMwoGroupHappyPath(FrappeTestCase):
 		_mock_sre_map,
 		_mock_item_val,
 		_mock_batch_val,
+		_mock_check_batch,
 		mock_mark_synced,
 		_mock_release,
 		_mock_savepoint,
@@ -630,7 +651,10 @@ class TestSyncMopLogsEntryPoint(FrappeTestCase):
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._reconcile_reservations_for_mwo"
 	)
 	@patch(
-		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._process_mwo_group"
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._commit_company_main_se"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._plan_mwo_group"
 	)
 	@patch(
 		"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync._get_unsynced_mop_groups"
@@ -642,7 +666,8 @@ class TestSyncMopLogsEntryPoint(FrappeTestCase):
 		self,
 		mock_log_error,
 		mock_get_groups,
-		mock_process,
+		mock_plan,
+		mock_commit,
 		_mock_reconcile,
 		_mock_set_running,
 		mock_release,
@@ -655,25 +680,31 @@ class TestSyncMopLogsEntryPoint(FrappeTestCase):
 			key_b: [{"mop_name": "MOP-B", "mop_doc": _mop_doc(), "logs": []}],
 		}
 
-		def _inject(
-			group_key,
-			mop_data_list,
-			failures,
-			stats,
-			sync_log_name=None,
-			selective=False,
-		):
+		# MWO-A plans as resolvable (committed into one SE); MWO-B fails in planning.
+		def _plan(group_key, mop_data_list, failures, stats, sync_log_name=None, selective=False):
 			_, mwo = group_key
 			if mwo == "MWO-A":
-				stats["submitted_ses"].append("SE-A")
-				stats["processed_mwos"] += 1
-			else:
-				failures.append(
-					{"step": "draft_save", "mwo": mwo, "error_message": "fail"}
-				)
-				stats["failed_mwos"] += 1
+				return {
+					"kind": "resolvable",
+					"company": "Co",
+					"manufacturer": "MF-1",
+					"mwo": mwo,
+					"items": [{"item_code": "M-1"}],
+					"t_warehouse": "WH",
+					"mop_data_list": mop_data_list,
+					"last_mop_name": "MOP-A",
+					"child_row_names": [],
+				}
+			failures.append({"step": "no_sre_warehouse", "mwo": mwo, "error_message": "fail"})
+			stats["failed_mwos"] += 1
+			return {"kind": "failed", "company": "Co", "manufacturer": "MF-1", "issues_rows": []}
 
-		mock_process.side_effect = _inject
+		def _commit(company, manufacturer, main_mwos, failures, stats, sync_log_name=None, selective=False):
+			stats["submitted_ses"].append("SE-A")
+			stats["processed_mwos"] += len(main_mwos)
+
+		mock_plan.side_effect = _plan
+		mock_commit.side_effect = _commit
 
 		out = sync_mop_logs()
 
@@ -717,19 +748,37 @@ class TestValidateEodSourceBatchStock(FrappeTestCase):
 
 
 # ---------------------------------------------------------------------------
-# TestTodayRange (verify helper returns correct strings)
+# TestSyncRange (window resolution: today default, custom From/To, flag-aware)
 # ---------------------------------------------------------------------------
 
 
-class TestTodayRange(FrappeTestCase):
-	def test_returns_tuple_of_two_strings(self):
-		result = _get_today_range()
-		self.assertIsInstance(result, tuple)
-		self.assertEqual(len(result), 2)
-		today_start, tomorrow_start = result
-		self.assertIn("00:00:00", today_start)
-		self.assertIn("00:00:00", tomorrow_start)
-		self.assertGreater(tomorrow_start, today_start)
+class TestSyncRange(FrappeTestCase):
+	def test_today_range_is_start_and_end_of_today(self):
+		start, end = _today_range()
+		self.assertIn("00:00:00", start)
+		self.assertIn("23:59:59", end)
+		self.assertEqual(start[:10], end[:10])
+		self.assertGreater(end, start)
+
+	def test_resolve_run_range_defaults_to_today_when_unset(self):
+		self.assertEqual(_resolve_run_range(None, None), _today_range())
+		# A single bound is not enough to override; falls back to today.
+		self.assertEqual(_resolve_run_range("2026-01-01 00:00:00", None), _today_range())
+
+	def test_resolve_run_range_uses_custom_window_when_both_set(self):
+		rng = _resolve_run_range("2026-01-01 08:00:00", "2026-01-01 20:00:00")
+		self.assertEqual(rng, ("2026-01-01 08:00:00", "2026-01-01 20:00:00"))
+
+	def test_get_sync_range_reads_run_flag(self):
+		frappe.flags.eod_sync_range = ("2026-02-02 00:00:00", "2026-02-02 23:59:59")
+		try:
+			self.assertEqual(
+				_get_sync_range(), ("2026-02-02 00:00:00", "2026-02-02 23:59:59")
+			)
+		finally:
+			frappe.flags.eod_sync_range = None
+		# Without the flag it falls back to today.
+		self.assertEqual(_get_sync_range(), _today_range())
 
 
 # ---------------------------------------------------------------------------
@@ -993,6 +1042,54 @@ class TestSyncMopLogsWithSyncLogName(FrappeTestCase):
 
 
 # ---------------------------------------------------------------------------
+# TestSyncMopLogsWindow (manual From/To window flows into the run flag)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncMopLogsWindow(FrappeTestCase):
+	def _run_capturing_window(self, **range_kwargs):
+		"""Run sync_mop_logs with the heavy deps mocked, capturing the window flag
+		that _get_unsynced_mop_groups would see at call time. Returns that window."""
+		captured = {}
+
+		def _capture(*_a, **_k):
+			captured["range"] = getattr(frappe.flags, "eod_sync_range", None)
+			return {}
+
+		patches = [
+			patch(f"{_MOD}.release_eod_sync_lock"),
+			patch(f"{_MOD}.set_eod_sync_running"),
+			patch(f"{_MOD}._reconcile_reservations_for_mwo"),
+			patch(f"{_MOD}._process_mwo_group"),
+			patch(f"{_MOD}.frappe.get_doc", return_value=FrappeDict({"eod_sync_work_order_filter": []})),
+			patch(f"{_MOD}.recalculate_sync_log_totals"),
+			patch(f"{_MOD}.frappe.db.set_value"),
+			patch(f"{_MOD}._get_unsynced_mop_groups", side_effect=_capture),
+		]
+		for p in patches:
+			p.start()
+		try:
+			sync_mop_logs(sync_log_name="SYNC-LOG-WIN", **range_kwargs)
+		finally:
+			for p in patches:
+				p.stop()
+		return captured.get("range")
+
+	def test_custom_window_flows_into_run_flag(self):
+		window = self._run_capturing_window(
+			from_datetime="2026-01-01 08:00:00", to_datetime="2026-01-01 20:00:00"
+		)
+		self.assertEqual(window, ("2026-01-01 08:00:00", "2026-01-01 20:00:00"))
+		# Cleared in finally after the run.
+		self.assertIsNone(getattr(frappe.flags, "eod_sync_range", None))
+
+	def test_no_args_defaults_to_today_window(self):
+		window = self._run_capturing_window()
+		self.assertEqual(window, _today_range())
+		self.assertIsNone(getattr(frappe.flags, "eod_sync_range", None))
+
+
+# ---------------------------------------------------------------------------
 # TestSreRelocation (release reservation at source, re-reserve at target)
 # ---------------------------------------------------------------------------
 
@@ -1055,247 +1152,345 @@ class TestSreRelocation(FrappeTestCase):
 		_cancel_sre_snapshots([{"sre": FrappeDict({"name": "SRE-1"})}])
 		fake.cancel.assert_called_once()
 
-	def test_recreate_noop_on_empty(self):
-		# Must not raise or touch the DB
-		_recreate_sres_at([], "WH-DEPT")
 
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_available_qty_to_reserve",
-		return_value=10.0,
-	)
-	@patch(f"{_MOD}.frappe.new_doc")
-	def test_recreate_builds_and_submits_sre_at_target(self, mock_new_doc, _mock_avail):
-		new_sre = MagicMock()
-		mock_new_doc.return_value = new_sre
-		snap = {
-			"sre": FrappeDict(
-				{
-					"item_code": "M-1",
-					"voucher_type": "Sales Order",
-					"voucher_no": "SO-1",
-					"voucher_detail_no": "row1",
-					"voucher_qty": 5.0,
-					"company": "Test Co",
-					"stock_uom": "Nos",
-					"reservation_based_on": "Qty",
-					"manufacturing_work_order": "MWO-1",
-					"manufacturing_operation": "MOP-A",
-				}
-			),
-			"remaining": 5.0,
-			"has_batch_no": 0,
-			"has_serial_no": 0,
-			"sb_entries": [],
-		}
-		_recreate_sres_at([snap], "WH-DEPT", target_operation="MOP-LAST")
-		self.assertEqual(new_sre.warehouse, "WH-DEPT")
-		self.assertEqual(new_sre.reserved_qty, 5.0)
-		# New SRE is tagged with the latest operation (where the stock now sits)
-		self.assertEqual(new_sre.manufacturing_operation, "MOP-LAST")
-		new_sre.insert.assert_called_once()
-		new_sre.submit.assert_called_once()
+# ---------------------------------------------------------------------------
+# TestReserveFromEodSeRows (build SO-anchored SREs from the submitted SE's rows)
+# ---------------------------------------------------------------------------
 
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_available_qty_to_reserve",
-		return_value=10.0,
-	)
-	@patch(f"{_MOD}.frappe.new_doc")
-	def test_recreate_falls_back_to_original_operation(self, mock_new_doc, _mock_avail):
-		new_sre = MagicMock()
-		mock_new_doc.return_value = new_sre
-		snap = {
-			"sre": FrappeDict(
-				{
-					"item_code": "M-1",
-					"voucher_type": "Sales Order",
-					"voucher_no": "SO-1",
-					"voucher_detail_no": "row1",
-					"voucher_qty": 5.0,
-					"company": "Test Co",
-					"stock_uom": "Nos",
-					"reservation_based_on": "Qty",
-					"manufacturing_work_order": "MWO-1",
-					"manufacturing_operation": "MOP-ORIG",
-				}
-			),
-			"remaining": 5.0,
-			"has_batch_no": 0,
-			"has_serial_no": 0,
-			"sb_entries": [],
-		}
-		_recreate_sres_at([snap], "WH-DEPT")  # no target_operation
-		self.assertEqual(new_sre.manufacturing_operation, "MOP-ORIG")
 
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_available_qty_to_reserve",
-		return_value=10.0,
-	)
-	@patch(f"{_MOD}.frappe.new_doc")
-	def test_recreate_batch_sre_sets_warehouse_on_sb_entry(
-		self, mock_new_doc, _mock_avail
+class TestReserveFromEodSeRows(FrappeTestCase):
+	def _reserve(
+		self,
+		rows,
+		*,
+		avail=10.0,
+		batch_free=None,
+		so_reserved=0.0,
+		base_mr=None,
+		sales_order="SO-1",
+		sales_order_item="SOI-1",
+		mo="MO-1",
+		mfr="MF-1",
+		has_batch_no=0,
+		has_serial_no=0,
+		stock_uom="Nos",
 	):
-		new_sre = MagicMock()
-		mock_new_doc.return_value = new_sre
-		snap = {
-			"sre": FrappeDict(
-				{
-					"item_code": "D-1",
-					"voucher_type": "Sales Order",
-					"voucher_no": "SO-1",
-					"voucher_detail_no": "row1",
-					"voucher_qty": 2.0,
-					"company": "Test Co",
-					"stock_uom": "Nos",
-					"reservation_based_on": "Serial and Batch",
-					"manufacturing_work_order": "MWO-1",
-					"manufacturing_operation": "MOP-A",
-				}
-			),
-			"remaining": 2.0,
-			"has_batch_no": 1,
-			"has_serial_no": 0,
-			"sb_entries": [{"batch_no": "B1", "qty": 2.0}],
-		}
-		_recreate_sres_at([snap], "WH-DEPT", target_operation="MOP-LAST")
+		"""Run _reserve_sres_from_eod_se_rows with every external mocked.
+
+		Returns (created_names, sre_docs); sre_docs is one MagicMock per frappe.new_doc
+		call (i.e. per SRE actually built).
+		"""
+		sre_docs = []
+
+		def _new_doc(_doctype):
+			m = MagicMock()
+			sre_docs.append(m)
+			return m
+
+		def _cached(doctype, name, fields):
+			if doctype == "Parent Manufacturing Order":
+				return (sales_order, sales_order_item, mfr)
+			if doctype == "Item":
+				return (has_batch_no, has_serial_no, stock_uom)
+			raise AssertionError(f"unexpected get_cached_value doctype: {doctype}")
+
+		ep = "erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
+		with patch(f"{_MOD}.frappe.new_doc", side_effect=_new_doc), patch(
+			f"{_MOD}.frappe.get_cached_value", side_effect=_cached
+		), patch(
+			f"{_MOD}.frappe.db.get_value", return_value=(mo, mfr)
+		), patch(
+			f"{_MOD}._eod_base_mr_voucher_qty", return_value=base_mr
+		), patch(
+			ep + "get_available_qty_to_reserve", return_value=avail
+		), patch(
+			# Batched rows resolve free qty via the SBB-aware helper (ERPNext's
+			# batch-keyed availability reads 0 under v16); mirror `avail` unless the
+			# test sets batch_free to diverge them.
+			f"{_MOD}._free_batch_qty_to_reserve",
+			return_value=(avail if batch_free is None else batch_free),
+		), patch(
+			ep + "get_sre_reserved_qty_for_voucher_detail_no", return_value=so_reserved
+		):
+			created = _reserve_sres_from_eod_se_rows("Co", rows)
+		return created, sre_docs
+
+	def test_empty_items_returns_empty(self):
+		self.assertEqual(_reserve_sres_from_eod_se_rows("Co", []), [])
+
+	def test_skips_row_without_mwo(self):
+		rows = [{"item_code": "M-1", "t_warehouse": "WH-D1", "qty": 1.0}]
+		_created, sres = self._reserve(rows)
+		self.assertEqual(sres, [])
+
+	def test_qty_item_so_anchored_at_target(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 5.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		_created, sres = self._reserve(rows, avail=10.0)
+		self.assertEqual(len(sres), 1)
+		sre = sres[0]
+		# Anchored to the MWO's Sales Order, NOT the Stock Entry.
+		self.assertEqual(sre.voucher_type, "Sales Order")
+		self.assertEqual(sre.voucher_no, "SO-1")
+		self.assertEqual(sre.voucher_detail_no, "SOI-1")
+		# Reserved at the row's target warehouse, against the row's MWO + last operation.
+		self.assertEqual(sre.warehouse, "WH-DEPT")
+		self.assertEqual(sre.reserved_qty, 5.0)
+		self.assertEqual(sre.manufacturing_work_order, "MWO-1")
+		self.assertEqual(sre.manufacturing_operation, "MOP-LAST")
+		self.assertEqual(sre.reservation_based_on, "Qty")
+		sre.insert.assert_called_once()
+		sre.submit.assert_called_once()
+
+	def test_batch_item_builds_sb_entry_at_target(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "D-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 2.0,
+				"batch_no": "B1",
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		_created, sres = self._reserve(rows, avail=10.0, has_batch_no=1, stock_uom="Carat")
+		sre = sres[0]
+		self.assertEqual(sre.reservation_based_on, "Serial and Batch")
 		sb_calls = [
 			c
-			for c in new_sre.append.call_args_list
+			for c in sre.append.call_args_list
 			if c.args and c.args[0] == "sb_entries"
 		]
 		self.assertEqual(len(sb_calls), 1)
 		sb_row = sb_calls[0].args[1]
-		# The relocated batch entry must carry the new warehouse (matches canonical)
 		self.assertEqual(sb_row["warehouse"], "WH-DEPT")
 		self.assertEqual(sb_row["batch_no"], "B1")
 		self.assertEqual(sb_row["qty"], 2.0)
 
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_sre_reserved_qty_for_voucher_detail_no",
-		return_value=8.0,
-	)
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_available_qty_to_reserve",
-		return_value=10.0,
-	)
-	@patch(f"{_MOD}.frappe.new_doc")
-	def test_recreate_inflates_voucher_qty_when_so_overreserved(
-		self, mock_new_doc, _mock_avail, _mock_so_reserved
-	):
-		# SO line is over-reserved (total_so_reserved=8.0) and the copied voucher_qty
-		# (5.0) is smaller than reserved+others — the recreate must lift voucher_qty so
-		# ERPNext's allowed-qty cap does not reject the relocation.
-		new_sre = MagicMock()
-		mock_new_doc.return_value = new_sre
-		snap = {
-			"sre": FrappeDict(
-				{
-					"item_code": "M-1",
-					"voucher_type": "Sales Order",
-					"voucher_no": "SO-1",
-					"voucher_detail_no": "row1",
-					"voucher_qty": 5.0,
-					"company": "Test Co",
-					"stock_uom": "Nos",
-					"reservation_based_on": "Qty",
-					"manufacturing_work_order": "MWO-1",
-					"manufacturing_operation": "MOP-A",
-				}
-			),
-			"remaining": 3.0,
-			"has_batch_no": 0,
-			"has_serial_no": 0,
-			"sb_entries": [],
-		}
-		_recreate_sres_at([snap], "WH-DEPT", target_operation="MOP-LAST")
-		self.assertEqual(new_sre.reserved_qty, 3.0)
-		# max(orig 5.0, total_so_reserved 8.0 + reserved 3.0) = 11.0
-		self.assertEqual(new_sre.voucher_qty, 11.0)
-		new_sre.submit.assert_called_once()
+	def test_batch_uses_sbb_free_qty_not_erpnext_zero(self):
+		"""Regression: under v16 ERPNext's batch-keyed availability reads 0, which used
+		to silently skip every batched WIP row (no SRE re-created at the new operation,
+		breaking Employee IR Process Loss). The SBB-aware free qty must drive reservation.
+		"""
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 5.0,
+				"batch_no": "B1",
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		# ERPNext availability = 0 (the v16 quirk) but SBB-aware free qty = 5.0.
+		_created, sres = self._reserve(
+			rows, avail=0.0, batch_free=5.0, has_batch_no=1, stock_uom="Gram"
+		)
+		self.assertEqual(len(sres), 1)
+		self.assertEqual(sres[0].reserved_qty, 5.0)
+		self.assertEqual(sres[0].reservation_based_on, "Serial and Batch")
+		sres[0].submit.assert_called_once()
 
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_sre_reserved_qty_for_voucher_detail_no",
-		return_value=0.0,
-	)
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_available_qty_to_reserve",
-		return_value=2.0,
-	)
-	@patch(f"{_MOD}.frappe.new_doc")
-	def test_recreate_clamps_reserved_to_available(
-		self, mock_new_doc, _mock_avail, _mock_so_reserved
-	):
-		# Only 2.0 free at the target though 5.0 was reserved at source → reserve 2.0,
-		# never throw "Stock not available to reserve".
-		new_sre = MagicMock()
-		mock_new_doc.return_value = new_sre
-		snap = {
-			"sre": FrappeDict(
-				{
-					"item_code": "M-1",
-					"voucher_type": "Sales Order",
-					"voucher_no": "SO-1",
-					"voucher_detail_no": "row1",
-					"voucher_qty": 5.0,
-					"company": "Test Co",
-					"stock_uom": "Nos",
-					"reservation_based_on": "Qty",
-					"manufacturing_work_order": "MWO-1",
-					"manufacturing_operation": "MOP-A",
-				}
-			),
-			"remaining": 5.0,
-			"has_batch_no": 0,
-			"has_serial_no": 0,
-			"sb_entries": [],
-		}
-		_recreate_sres_at([snap], "WH-DEPT")
-		self.assertEqual(new_sre.reserved_qty, 2.0)
-		new_sre.submit.assert_called_once()
+	def test_clamps_reserved_to_available(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 5.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		# Only 2.0 free at the target though 5.0 moved → reserve 2.0, never throw.
+		_created, sres = self._reserve(rows, avail=2.0)
+		self.assertEqual(sres[0].reserved_qty, 2.0)
+		sres[0].submit.assert_called_once()
 
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_sre_reserved_qty_for_voucher_detail_no",
-		return_value=0.0,
-	)
-	@patch(
-		"erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry."
-		"get_available_qty_to_reserve",
-		return_value=0.0,
-	)
-	@patch(f"{_MOD}.frappe.new_doc")
-	def test_recreate_skips_when_nothing_free(
-		self, mock_new_doc, _mock_avail, _mock_so_reserved
-	):
-		# Nothing free at the target → skip the SRE entirely (no throw, no doc created).
-		snap = {
-			"sre": FrappeDict(
-				{
-					"item_code": "M-1",
-					"voucher_type": "Sales Order",
-					"voucher_no": "SO-1",
-					"voucher_detail_no": "row1",
-					"voucher_qty": 5.0,
-					"company": "Test Co",
-					"stock_uom": "Nos",
-					"reservation_based_on": "Qty",
-					"manufacturing_work_order": "MWO-1",
-					"manufacturing_operation": "MOP-A",
-				}
-			),
-			"remaining": 5.0,
-			"has_batch_no": 0,
-			"has_serial_no": 0,
-			"sb_entries": [],
-		}
-		_recreate_sres_at([snap], "WH-DEPT")
-		mock_new_doc.assert_not_called()
+	def test_skips_when_nothing_free(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 5.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		created, sres = self._reserve(rows, avail=0.0)
+		# Nothing free → no SRE built (no frappe.new_doc), no throw.
+		self.assertEqual(sres, [])
+		self.assertEqual(created, [])
+
+	def test_voucher_qty_uses_floor_when_no_mr(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 3.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		# No MR data → voucher_qty = total_so_reserved(8.0) + reserved(3.0) = 11.0
+		_created, sres = self._reserve(rows, avail=10.0, so_reserved=8.0, base_mr=None)
+		self.assertEqual(sres[0].reserved_qty, 3.0)
+		self.assertEqual(sres[0].voucher_qty, 11.0)
+
+	def test_voucher_qty_uses_max_with_mr(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 3.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		# MR base 5010.0 dominates the floor 11.0 → voucher_qty = 5010.0
+		_created, sres = self._reserve(rows, avail=10.0, so_reserved=8.0, base_mr=5010.0)
+		self.assertEqual(sres[0].voucher_qty, 5010.0)
+
+	def test_skips_row_without_sales_order(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 3.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		# MWO's MO has no Sales Order → skip (stock moved, but no malformed reservation).
+		_created, sres = self._reserve(rows, sales_order=None)
+		self.assertEqual(sres, [])
+
+	def test_per_row_mwo_and_operation(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-D1",
+				"qty": 1.0,
+				"manufacturing_operation": "MOP-1",
+			},
+			{
+				"custom_manufacturing_work_order": "MWO-2",
+				"item_code": "M-2",
+				"t_warehouse": "WH-D2",
+				"qty": 1.0,
+				"manufacturing_operation": "MOP-2",
+			},
+		]
+		_created, sres = self._reserve(rows, avail=10.0)
+		self.assertEqual(len(sres), 2)
+		# Each SRE carries its OWN row's MWO/operation/target (not a shared header).
+		self.assertEqual(sres[0].manufacturing_work_order, "MWO-1")
+		self.assertEqual(sres[0].manufacturing_operation, "MOP-1")
+		self.assertEqual(sres[0].warehouse, "WH-D1")
+		self.assertEqual(sres[1].manufacturing_work_order, "MWO-2")
+		self.assertEqual(sres[1].manufacturing_operation, "MOP-2")
+		self.assertEqual(sres[1].warehouse, "WH-D2")
+
+	def test_serial_tracked_qty_reservation(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "S-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 2.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		_created, sres = self._reserve(rows, avail=10.0, has_serial_no=1)
+		sre = sres[0]
+		self.assertEqual(sre.reservation_based_on, "Qty")
+		self.assertEqual(sre.has_serial_no, 1)
+		# No sb_entries appended for a non-batch (serial) item.
+		sb_calls = [
+			c for c in sre.append.call_args_list if c.args and c.args[0] == "sb_entries"
+		]
+		self.assertEqual(sb_calls, [])
+
+	def test_two_rows_same_mwo_make_two_sres(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 1.0,
+				"manufacturing_operation": "MOP-LAST",
+			},
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-2",
+				"t_warehouse": "WH-DEPT",
+				"qty": 1.0,
+				"manufacturing_operation": "MOP-LAST",
+			},
+		]
+		_created, sres = self._reserve(rows, avail=10.0)
+		self.assertEqual(len(sres), 2)
+		self.assertTrue(all(s.manufacturing_work_order == "MWO-1" for s in sres))
+
+	def test_available_exactly_equals_qty(self):
+		rows = [
+			{
+				"custom_manufacturing_work_order": "MWO-1",
+				"item_code": "M-1",
+				"t_warehouse": "WH-DEPT",
+				"qty": 5.0,
+				"manufacturing_operation": "MOP-LAST",
+			}
+		]
+		_created, sres = self._reserve(rows, avail=5.0)
+		self.assertEqual(sres[0].reserved_qty, 5.0)
+
+
+# ---------------------------------------------------------------------------
+# TestHardDeleteCancelledSnapshots (hard-delete this run's cancelled source SREs)
+# ---------------------------------------------------------------------------
+
+
+class TestHardDeleteCancelledSnapshots(FrappeTestCase):
+	@patch(f"{_MOD}.frappe.delete_doc")
+	@patch(f"{_MOD}.frappe.db.exists", return_value=True)
+	def test_deletes_each_snapshot_with_force(self, _mock_exists, mock_delete):
+		snaps = [
+			{"sre": FrappeDict({"name": "SRE-1"})},
+			{"sre": FrappeDict({"name": "SRE-2"})},
+		]
+		_hard_delete_cancelled_snapshots(snaps)
+		self.assertEqual(mock_delete.call_count, 2)
+		mock_delete.assert_any_call(
+			"Stock Reservation Entry", "SRE-1", force=1, ignore_permissions=True
+		)
+		mock_delete.assert_any_call(
+			"Stock Reservation Entry", "SRE-2", force=1, ignore_permissions=True
+		)
+
+	@patch(f"{_MOD}.frappe.delete_doc")
+	@patch(f"{_MOD}.frappe.db.exists", return_value=False)
+	def test_skips_when_sre_absent(self, _mock_exists, mock_delete):
+		_hard_delete_cancelled_snapshots([{"sre": FrappeDict({"name": "SRE-1"})}])
+		mock_delete.assert_not_called()
+
+	@patch(f"{_MOD}.frappe.delete_doc", side_effect=RuntimeError("locked"))
+	@patch(f"{_MOD}.frappe.db.exists", return_value=True)
+	def test_delete_error_propagates(self, _mock_exists, _mock_delete):
+		# Atomic contract: a delete failure must bubble up so the bucket rolls back.
+		with self.assertRaises(RuntimeError):
+			_hard_delete_cancelled_snapshots([{"sre": FrappeDict({"name": "SRE-1"})}])
+
+	def test_empty_or_none_is_noop(self):
+		_hard_delete_cancelled_snapshots([])
+		_hard_delete_cancelled_snapshots(None)
 
 
 # ---------------------------------------------------------------------------
@@ -1513,3 +1708,1041 @@ class TestGetUnsyncedMopGroupsSelective(FrappeTestCase):
 		self.assertNotIn("creation", log_filters)
 		# A pre-today log is still grouped (sync_from_datetime ignored)
 		self.assertIn(("Test Co", "MWO-1"), out)
+
+
+# ---------------------------------------------------------------------------
+# TestEodSeRowPcs (pcs from MOP Log for D/G; metal keeps default)
+# ---------------------------------------------------------------------------
+
+
+class TestEodSeRowPcs(FrappeTestCase):
+	def test_diamond_carries_log_pcs_metal_keeps_default(self):
+		d_log = _log(
+			item_code="D-1",
+			batch_no="BD",
+			qty_after_transaction_batch_based=0.5,
+			pcs_after_transaction_batch_based=7,
+			to_warehouse="WH-DEPT",
+		)
+		g_log = _log(
+			item_code="G-1",
+			batch_no="BG",
+			qty_after_transaction_batch_based=0.2,
+			pcs_after_transaction_batch_based=3,
+			to_warehouse="WH-DEPT",
+		)
+		m_log = _log(
+			item_code="M-1",
+			batch_no="BM",
+			qty_after_transaction_batch_based=2.0,
+			pcs_after_transaction_batch_based=99,
+			to_warehouse="WH-DEPT",
+		)
+		sre_map = {
+			("D-1", "BD"): "WH-SRE",
+			("G-1", "BG"): "WH-SRE",
+			("M-1", "BM"): "WH-SRE",
+		}
+		rows, skipped = _build_eod_se_rows(
+			"MWO-1", "MOP-A", [d_log, g_log, m_log], "WH-DEPT", sre_map
+		)
+		self.assertEqual(skipped, [])
+		by_item = {r["item_code"]: r for r in rows}
+		# Diamond/Gemstone carry the real stone count from the MOP Log balance.
+		self.assertEqual(by_item["D-1"]["pcs"], 7)
+		self.assertEqual(by_item["G-1"]["pcs"], 3)
+		# Metal row leaves pcs unset → Stock Entry Detail default of "1" applies.
+		self.assertNotIn("pcs", by_item["M-1"])
+
+
+# ---------------------------------------------------------------------------
+# TestEodBaseMrVoucherQty (MR total inflated by Manufacturing Setting tolerance)
+# ---------------------------------------------------------------------------
+
+
+class TestEodBaseMrVoucherQty(FrappeTestCase):
+	@patch(f"{_MOD}.frappe.db.get_value", return_value=50000)
+	@patch(f"{_MOD}.frappe.db.sql", return_value=[[10.0]])
+	def test_inflates_mr_total_by_tolerance(self, _mock_sql, _mock_gv):
+		# base 10 + 10 * (50000 / 100) = 5010
+		self.assertAlmostEqual(_eod_base_mr_voucher_qty("MO-1", "MF-1"), 5010.0)
+
+	@patch(f"{_MOD}.frappe.db.get_value", return_value=None)
+	@patch(f"{_MOD}.frappe.db.sql", return_value=[[12.0]])
+	def test_no_tolerance_returns_plain_mr_total(self, _mock_sql, _mock_gv):
+		self.assertAlmostEqual(_eod_base_mr_voucher_qty("MO-1", "MF-1"), 12.0)
+
+	def test_none_mo_returns_none(self):
+		self.assertIsNone(_eod_base_mr_voucher_qty(None, "MF-1"))
+
+	@patch(f"{_MOD}.frappe.db.sql", return_value=[[None]])
+	def test_no_mr_rows_returns_none(self, _mock_sql):
+		self.assertIsNone(_eod_base_mr_voucher_qty("MO-1", "MF-1"))
+
+
+# ---------------------------------------------------------------------------
+# TestEodConsolidation (many MWOs → ONE submitted Stock Entry per bucket)
+# ---------------------------------------------------------------------------
+
+
+class TestEodConsolidation(FrappeTestCase):
+	@patch(f"{_MOD}.frappe.db.set_value")
+	@patch(f"{_MOD}.frappe.db.release_savepoint")
+	@patch(f"{_MOD}.frappe.db.savepoint")
+	@patch(f"{_MOD}._stamp_last_eod_sync")
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._hard_delete_cancelled_snapshots")
+	@patch(f"{_MOD}._reserve_sres_from_eod_se_rows")
+	@patch(f"{_MOD}._snapshot_mwo_sres_for_relocation", return_value=[])
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_two_mwos_consolidated_into_one_submitted_se(
+		self,
+		mock_new_doc,
+		mock_get_doc,
+		_mock_snap,
+		mock_reserve,
+		mock_delete,
+		mock_mark,
+		_mock_stamp,
+		_mock_savepoint,
+		_mock_release,
+		_mock_set_value,
+	):
+		se = FakeStockEntry("SE-CONS-1")
+		mock_new_doc.return_value = se
+		mock_get_doc.return_value = se
+
+		main_mwos = [
+			{
+				"kind": "resolvable",
+				"company": "Co",
+				"manufacturer": "MF-1",
+				"mwo": "MWO-1",
+				"items": [
+					{
+						"item_code": "M-1",
+						"qty": 1.0,
+						"s_warehouse": "WH-SRE",
+						"t_warehouse": "WH-D1",
+					}
+				],
+				"t_warehouse": "WH-D1",
+				"mop_data_list": [{"mop_name": "MOP-1"}],
+				"last_mop_name": "MOP-1",
+				"child_row_names": [],
+			},
+			{
+				"kind": "resolvable",
+				"company": "Co",
+				"manufacturer": "MF-1",
+				"mwo": "MWO-2",
+				"items": [
+					{
+						"item_code": "M-2",
+						"qty": 2.0,
+						"s_warehouse": "WH-SRE",
+						"t_warehouse": "WH-D2",
+					}
+				],
+				"t_warehouse": "WH-D2",
+				"mop_data_list": [{"mop_name": "MOP-2"}],
+				"last_mop_name": "MOP-2",
+				"child_row_names": [],
+			},
+		]
+		failures = []
+		stats = {
+			"processed_mwos": 0,
+			"failed_mwos": 0,
+			"submitted_ses": [],
+			"draft_ses": [],
+		}
+
+		_commit_company_main_se(
+			"Co", "MF-1", main_mwos, failures, stats, sync_log_name=None, selective=False
+		)
+
+		# Exactly ONE Stock Entry is created and submitted for both MWOs.
+		mock_new_doc.assert_called_once()
+		self.assertTrue(se.submitted)
+		self.assertEqual(stats["submitted_ses"], ["SE-CONS-1"])
+		self.assertEqual(stats["processed_mwos"], 2)
+		self.assertEqual(stats["failed_mwos"], 0)
+		self.assertEqual(failures, [])
+		# Both MWOs' rows live on the single SE.
+		self.assertEqual(len(se.items), 2)
+		# The new reservation is built ONCE from the submitted SE's rows (union of MWOs).
+		mock_reserve.assert_called_once()
+		self.assertEqual(len(mock_reserve.call_args.args[1]), 2)
+		# The cancelled source SREs are hard-deleted, once per MWO.
+		self.assertEqual(mock_delete.call_count, 2)
+		# Each MWO's MOP Logs are marked synced (once per MWO).
+		self.assertEqual(mock_mark.call_count, 2)
+		# Consolidated header carries no single MWO; rows carry their own.
+		self.assertIsNone(se.manufacturing_work_order)
+		self.assertEqual(se.manufacturer, "MF-1")
+
+	@patch(f"{_MOD}._check_eod_source_batch_stock", return_value={})
+	@patch(f"{_MOD}._validate_eod_items_for_mwo_reservation")
+	@patch(f"{_MOD}._preload_sre_warehouse_map", return_value={("M-1", "B1"): "WH-SRE"})
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_plan_returns_resolvable_for_clean_mwo(
+		self, _art, _sre, _item_val, _check
+	):
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				qty_after_transaction_batch_based=3.0,
+				to_warehouse="WH-DEPT",
+			)
+		]
+		mop_data_list = [
+			{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}
+		]
+		failures = []
+		stats = {"processed_mwos": 0, "failed_mwos": 0, "submitted_ses": []}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertEqual(result["kind"], "resolvable")
+		self.assertEqual(result["company"], "Test Co")
+		self.assertEqual(len(result["items"]), 1)
+		self.assertEqual(result["items"][0]["s_warehouse"], "WH-SRE")
+		self.assertEqual(failures, [])
+
+	def _single_resolvable_mwo(self):
+		return [
+			{
+				"kind": "resolvable",
+				"company": "Co",
+				"manufacturer": "MF-1",
+				"mwo": "MWO-1",
+				"items": [
+					{
+						"item_code": "M-1",
+						"qty": 1.0,
+						"s_warehouse": "WH-SRE",
+						"t_warehouse": "WH-D1",
+						"custom_manufacturing_work_order": "MWO-1",
+						"manufacturing_operation": "MOP-1",
+					}
+				],
+				"t_warehouse": "WH-D1",
+				"mop_data_list": [{"mop_name": "MOP-1"}],
+				"last_mop_name": "MOP-1",
+				"child_row_names": [],
+			}
+		]
+
+	@patch(f"{_MOD}.frappe.db.set_value")
+	@patch(f"{_MOD}.frappe.db.rollback")
+	@patch(f"{_MOD}.frappe.db.release_savepoint")
+	@patch(f"{_MOD}.frappe.db.savepoint")
+	@patch(f"{_MOD}._stamp_last_eod_sync")
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._hard_delete_cancelled_snapshots")
+	@patch(
+		f"{_MOD}._reserve_sres_from_eod_se_rows",
+		side_effect=RuntimeError("reserve failed"),
+	)
+	@patch(f"{_MOD}._snapshot_mwo_sres_for_relocation", return_value=[])
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_rollback_on_reserve_failure_preserves_cancelled_sres(
+		self,
+		mock_new_doc,
+		mock_get_doc,
+		_mock_snap,
+		_mock_reserve,
+		mock_delete,
+		mock_mark,
+		_mock_stamp,
+		_mock_savepoint,
+		_mock_release,
+		mock_rollback,
+		_mock_set_value,
+	):
+		se = FakeStockEntry("SE-DRAFT-RB")
+		mock_new_doc.return_value = se
+		mock_get_doc.return_value = se
+		failures = []
+		stats = {
+			"processed_mwos": 0,
+			"failed_mwos": 0,
+			"submitted_ses": [],
+			"draft_ses": [],
+		}
+		_commit_company_main_se(
+			"Co",
+			"MF-1",
+			self._single_resolvable_mwo(),
+			failures,
+			stats,
+			sync_log_name=None,
+			selective=False,
+		)
+		# Phase 2 rolled back: reservation failed, so submit + SRE cancels are undone.
+		mock_rollback.assert_any_call(save_point="eod_submit_phase")
+		# On failure the cancelled SREs are NOT deleted and logs are NOT marked synced.
+		mock_delete.assert_not_called()
+		mock_mark.assert_not_called()
+		# Draft SE survives for manual recovery; the MWO is held as failed.
+		self.assertIn("SE-DRAFT-RB", stats["draft_ses"])
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertEqual(stats["submitted_ses"], [])
+
+	@patch(f"{_MOD}.frappe.db.set_value")
+	@patch(f"{_MOD}.frappe.db.rollback")
+	@patch(f"{_MOD}.frappe.db.release_savepoint")
+	@patch(f"{_MOD}.frappe.db.savepoint")
+	@patch(f"{_MOD}._stamp_last_eod_sync")
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(
+		f"{_MOD}._hard_delete_cancelled_snapshots",
+		side_effect=RuntimeError("delete failed"),
+	)
+	@patch(f"{_MOD}._reserve_sres_from_eod_se_rows")
+	@patch(f"{_MOD}._snapshot_mwo_sres_for_relocation", return_value=[])
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_rollback_on_delete_failure_preserves_cancelled_sres(
+		self,
+		mock_new_doc,
+		mock_get_doc,
+		_mock_snap,
+		_mock_reserve,
+		_mock_delete,
+		mock_mark,
+		_mock_stamp,
+		_mock_savepoint,
+		_mock_release,
+		mock_rollback,
+		_mock_set_value,
+	):
+		se = FakeStockEntry("SE-DRAFT-DB")
+		mock_new_doc.return_value = se
+		mock_get_doc.return_value = se
+		failures = []
+		stats = {
+			"processed_mwos": 0,
+			"failed_mwos": 0,
+			"submitted_ses": [],
+			"draft_ses": [],
+		}
+		_commit_company_main_se(
+			"Co",
+			"MF-1",
+			self._single_resolvable_mwo(),
+			failures,
+			stats,
+			sync_log_name=None,
+			selective=False,
+		)
+		# A delete failure also rolls the whole bucket back (cancelled SREs restored).
+		mock_rollback.assert_any_call(save_point="eod_submit_phase")
+		mock_mark.assert_not_called()
+		self.assertIn("SE-DRAFT-DB", stats["draft_ses"])
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertEqual(stats["submitted_ses"], [])
+
+
+# ---------------------------------------------------------------------------
+# TestSyncLogItemSelectValues (guard: every Select value EOD writes is valid)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncLogItemSelectValues(FrappeTestCase):
+	"""Regression for the held-row crash: ``sync_stage="Plan"`` / ``error_type="MWO
+	Held"`` were not valid Select options, so _insert_sync_log_item raised and aborted
+	the whole run. Insert a row for every (sync_stage, error_type, status) combo EOD
+	writes and assert none raise a Select ValidationError."""
+
+	def test_all_eod_select_combos_insert_without_error(self):
+		from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+			_insert_sync_log_item,
+		)
+
+		log = frappe.new_doc("MOP EOD Sync Log")
+		log.status = "Queued"
+		log.trigger_type = "Manual"
+		log.posting_date = frappe.utils.nowdate()
+		log.mop_settings = "MOP Settings"
+		log.flags.ignore_permissions = True
+		log.insert(ignore_permissions=True)
+
+		combos = [
+			("Resolve SRE Warehouse", "Missing SRE", "Failed"),
+			("Resolve SRE Warehouse", "Missing Target Warehouse", "Failed"),
+			("Build Stock Entry Row", "Validation Failed", "Failed"),
+			("Save Draft Stock Entry", "", "Pending"),
+			("Save Draft Stock Entry", "Stock Entry Save Failed", "Failed"),
+			("Submit Stock Entry", "Stock Entry Submit Failed", "Draft Created"),
+			("Completed", "", "Synced"),
+		]
+		for stage, etype, status in combos:
+			_insert_sync_log_item(
+				log.name,
+				{
+					"manufacturing_work_order": "MWO-X",
+					"item_code": "M-1",
+					"qty": 1.0,
+					"status": status,
+					"sync_stage": stage,
+					"error_type": etype,
+				},
+			)
+
+		count = frappe.db.count("MOP EOD Sync Log Item", {"parent": log.name})
+		self.assertEqual(count, len(combos))
+
+
+# ---------------------------------------------------------------------------
+# TestValidateEodItemsForMwoReservation (batch/serial presence guard)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEodItemsForMwoReservation(FrappeTestCase):
+	@patch(f"{_MOD}.frappe.db.get_all", return_value=[])
+	def test_empty_items_no_throw(self, _mock):
+		_validate_eod_items_for_mwo_reservation([])
+
+	@patch(f"{_MOD}.frappe.db.get_all", return_value=[])
+	def test_item_not_found_throws(self, _mock):
+		with self.assertRaises(frappe.ValidationError):
+			_validate_eod_items_for_mwo_reservation([{"item_code": "X", "qty": 1.0}])
+
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_batch_tracked_missing_batch_throws(self, mock_get_all):
+		mock_get_all.return_value = [
+			FrappeDict({"name": "D-1", "has_batch_no": 1, "has_serial_no": 0})
+		]
+		with self.assertRaises(frappe.ValidationError):
+			_validate_eod_items_for_mwo_reservation(
+				[{"item_code": "D-1", "qty": 1.0, "batch_no": None}]
+			)
+
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_serialized_missing_serial_throws(self, mock_get_all):
+		mock_get_all.return_value = [
+			FrappeDict({"name": "S-1", "has_batch_no": 0, "has_serial_no": 1})
+		]
+		with self.assertRaises(frappe.ValidationError):
+			_validate_eod_items_for_mwo_reservation(
+				[{"item_code": "S-1", "qty": 1.0, "serial_no": None}]
+			)
+
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_batch_and_serial_present_no_throw(self, mock_get_all):
+		mock_get_all.return_value = [
+			FrappeDict({"name": "D-1", "has_batch_no": 1, "has_serial_no": 1})
+		]
+		_validate_eod_items_for_mwo_reservation(
+			[{"item_code": "D-1", "qty": 1.0, "batch_no": "B1", "serial_no": "SN1"}]
+		)
+
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_zero_qty_row_skipped(self, mock_get_all):
+		mock_get_all.return_value = [
+			FrappeDict({"name": "D-1", "has_batch_no": 1, "has_serial_no": 0})
+		]
+		# qty<=0 row is skipped, so the missing batch_no does not throw.
+		_validate_eod_items_for_mwo_reservation(
+			[{"item_code": "D-1", "qty": 0.0, "batch_no": None}]
+		)
+
+
+# ---------------------------------------------------------------------------
+# TestCheckEodSourceBatchStock (non-throwing physical batch-stock check)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEodSourceBatchStock(FrappeTestCase):
+	@patch("erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=10.0)
+	def test_sufficient_stock_returns_empty(self, _mock):
+		items = [{"s_warehouse": "W", "item_code": "I", "batch_no": "B", "qty": 5.0}]
+		self.assertEqual(_check_eod_source_batch_stock(items), {})
+
+	@patch("erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=1.0)
+	def test_short_stock_reported(self, _mock):
+		items = [{"s_warehouse": "W", "item_code": "I", "batch_no": "B", "qty": 5.0}]
+		self.assertEqual(
+			_check_eod_source_batch_stock(items), {("W", "I", "B"): (5.0, 1.0)}
+		)
+
+	@patch(
+		"erpnext.stock.doctype.batch.batch.get_batch_qty",
+		side_effect=Exception("ledger error"),
+	)
+	def test_get_batch_qty_exception_treated_as_zero(self, _mock):
+		items = [{"s_warehouse": "W", "item_code": "I", "batch_no": "B", "qty": 5.0}]
+		self.assertEqual(
+			_check_eod_source_batch_stock(items), {("W", "I", "B"): (5.0, 0.0)}
+		)
+
+	@patch("erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=5.0)
+	def test_aggregates_rows_with_same_key(self, _mock):
+		items = [
+			{"s_warehouse": "W", "item_code": "I", "batch_no": "B", "qty": 3.0},
+			{"s_warehouse": "W", "item_code": "I", "batch_no": "B", "qty": 4.0},
+		]
+		# needed 7.0 > physical 5.0
+		self.assertEqual(
+			_check_eod_source_batch_stock(items), {("W", "I", "B"): (7.0, 5.0)}
+		)
+
+	@patch("erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=0.0)
+	def test_rows_without_batch_or_qty_skipped(self, mock_gbq):
+		items = [
+			{"s_warehouse": "W", "item_code": "I", "batch_no": None, "qty": 5.0},
+			{"s_warehouse": "W", "item_code": "I", "batch_no": "B", "qty": 0.0},
+		]
+		self.assertEqual(_check_eod_source_batch_stock(items), {})
+		mock_gbq.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestCommitCompanyIssuesSe (best-effort DRAFT issues SE for failed MWOs)
+# ---------------------------------------------------------------------------
+
+
+class TestCommitCompanyIssuesSe(FrappeTestCase):
+	@patch(f"{_MOD}._save_draft_eod_se")
+	def test_empty_rows_early_return(self, mock_save):
+		stats = {"draft_ses": []}
+		_commit_company_issues_se("Co", "MF-1", [], stats)
+		mock_save.assert_not_called()
+		self.assertEqual(stats["draft_ses"], [])
+
+	@patch(f"{_MOD}.frappe.db.release_savepoint")
+	@patch(f"{_MOD}.frappe.db.savepoint")
+	@patch(f"{_MOD}._save_draft_eod_se", return_value="SE-ISSUES-1")
+	def test_rows_saved_as_unresolved_draft(self, mock_save, _sp, _rel):
+		stats = {"draft_ses": []}
+		_commit_company_issues_se(
+			"Co", "MF-1", [{"item_code": "M-1", "qty": 1.0}], stats, sync_log_name="LOG-1"
+		)
+		mock_save.assert_called_once()
+		self.assertEqual(
+			mock_save.call_args.kwargs["eod_sync_source"], "MOP EOD Sync (Unresolved)"
+		)
+		self.assertEqual(stats["draft_ses"], ["SE-ISSUES-1"])
+
+	@patch(f"{_MOD}.frappe.logger")
+	@patch(f"{_MOD}.frappe.db.rollback")
+	@patch(f"{_MOD}.frappe.db.savepoint")
+	@patch(f"{_MOD}._save_draft_eod_se", side_effect=RuntimeError("save failed"))
+	def test_save_failure_rolls_back_and_swallows(
+		self, _save, _sp, mock_rollback, _logger
+	):
+		stats = {"draft_ses": []}
+		# Best-effort: must NOT raise even when the draft save fails.
+		_commit_company_issues_se(
+			"Co", "MF-1", [{"item_code": "M-1", "qty": 1.0}], stats
+		)
+		mock_rollback.assert_any_call(save_point="eod_issues_phase")
+		self.assertEqual(stats["draft_ses"], [])
+
+
+# ---------------------------------------------------------------------------
+# TestSaveDraftEodSe (header + audit fields, draft-only)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveDraftEodSe(FrappeTestCase):
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_sets_header_and_audit_fields(self, mock_new_doc):
+		se = FakeStockEntry("SE-DRAFT-1")
+		mock_new_doc.return_value = se
+		name = _save_draft_eod_se(
+			"Co",
+			None,
+			None,
+			[{"item_code": "M-1", "qty": 1.0}],
+			header_manufacturer="MF-1",
+			sync_log_name="LOG-1",
+			eod_sync_source="MOP EOD Sync (Unresolved)",
+		)
+		self.assertEqual(name, "SE-DRAFT-1")
+		self.assertEqual(se.stock_entry_type, "Material Transfer to Department")
+		self.assertEqual(se.auto_created, 1)
+		self.assertEqual(se.custom_is_eod_sync_stock_entry, 1)
+		self.assertEqual(se.custom_eod_sync_source, "MOP EOD Sync (Unresolved)")
+		self.assertEqual(se.custom_eod_sync_log, "LOG-1")
+		self.assertEqual(se.manufacturer, "MF-1")
+		self.assertEqual(len(se.items), 1)
+		# Draft only — saved, never submitted.
+		self.assertTrue(se.saved)
+		self.assertFalse(se.submitted)
+
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_header_mop_name_and_mwo_applied(self, mock_new_doc):
+		se = FakeStockEntry("SE-DRAFT-2")
+		mock_new_doc.return_value = se
+		_save_draft_eod_se(
+			"Co",
+			"MWO-1",
+			"MO-1",
+			[{"item_code": "M-1", "qty": 1.0}],
+			header_mop_name="MOP-X",
+		)
+		self.assertEqual(se.manufacturing_operation, "MOP-X")
+		self.assertEqual(se.manufacturing_work_order, "MWO-1")
+		self.assertEqual(se.manufacturing_order, "MO-1")
+
+	@patch(f"{_MOD}.frappe.new_doc")
+	def test_no_sync_log_leaves_log_field_unset(self, mock_new_doc):
+		se = FakeStockEntry("SE-DRAFT-3")
+		mock_new_doc.return_value = se
+		_save_draft_eod_se("Co", None, None, [{"item_code": "M-1", "qty": 1.0}])
+		self.assertIsNone(getattr(se, "custom_eod_sync_log", None))
+
+
+# ---------------------------------------------------------------------------
+# TestMopManufacturerLabel / TestResolveEodManufacturerLabel / TestCollectMopNames
+# ---------------------------------------------------------------------------
+
+
+class TestMopManufacturerLabel(FrappeTestCase):
+	def test_none_returns_none(self):
+		self.assertIsNone(_mop_manufacturer_label(None))
+
+	def test_dict_returns_manufacturer(self):
+		self.assertEqual(_mop_manufacturer_label({"manufacturer": "MF-1"}), "MF-1")
+
+	def test_object_returns_attribute(self):
+		self.assertEqual(
+			_mop_manufacturer_label(SimpleNamespace(manufacturer="MF-2")), "MF-2"
+		)
+
+	def test_missing_manufacturer_returns_none(self):
+		self.assertIsNone(_mop_manufacturer_label({}))
+
+
+class TestResolveEodManufacturerLabel(FrappeTestCase):
+	@patch(f"{_MOD}.frappe.db.get_value", return_value="MF-Q")
+	def test_empty_list_falls_back_to_mwo(self, mock_gv):
+		self.assertEqual(_resolve_eod_manufacturer_label([], "MWO-1"), "MF-Q")
+		mock_gv.assert_called_once()
+
+	def test_multiple_distinct_joined_sorted(self):
+		mop_data_list = [
+			{"mop_doc": _mop_doc(manufacturer="B")},
+			{"mop_doc": _mop_doc(manufacturer="A")},
+		]
+		self.assertEqual(_resolve_eod_manufacturer_label(mop_data_list, "MWO-1"), "A, B")
+
+	def test_none_mop_doc_skipped(self):
+		mop_data_list = [
+			{"mop_doc": None},
+			{"mop_doc": _mop_doc(manufacturer="A")},
+		]
+		self.assertEqual(_resolve_eod_manufacturer_label(mop_data_list, "MWO-1"), "A")
+
+	@patch(f"{_MOD}.frappe.db.get_value", return_value="MF-Q")
+	def test_no_manufacturers_falls_back_to_mwo(self, _mock):
+		mop_data_list = [{"mop_doc": _mop_doc(manufacturer=None)}]
+		self.assertEqual(_resolve_eod_manufacturer_label(mop_data_list, "MWO-1"), "MF-Q")
+
+	def test_empty_and_no_mwo_returns_none(self):
+		self.assertIsNone(_resolve_eod_manufacturer_label([], None))
+
+
+class TestCollectMopNames(FrappeTestCase):
+	def test_empty_returns_empty_string(self):
+		self.assertEqual(_collect_mop_names([]), "")
+
+	def test_single(self):
+		self.assertEqual(_collect_mop_names([{"mop_name": "MOP-A"}]), "MOP-A")
+
+	def test_multiple_sorted(self):
+		self.assertEqual(
+			_collect_mop_names([{"mop_name": "MOP-B"}, {"mop_name": "MOP-A"}]),
+			"MOP-A, MOP-B",
+		)
+
+	def test_entries_without_name_skipped(self):
+		self.assertEqual(
+			_collect_mop_names([{"mop_name": None}, {"mop_name": "MOP-A"}]), "MOP-A"
+		)
+
+
+# ---------------------------------------------------------------------------
+# TestPlanMwoGroupBranches (no-op / failure classification branches)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanMwoGroupBranches(FrappeTestCase):
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_no_last_operation_marks_synced(self, _art, mock_mark):
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": []}]
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertIsNone(result)
+		self.assertEqual(stats["processed_mwos"], 1)
+		mock_mark.assert_called_once()
+
+	@patch(f"{_MOD}._resolve_department_warehouse", return_value=None)
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_no_t_warehouse_fails(self, _art, _dept):
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				to_warehouse=None,
+				qty_after_transaction_batch_based=1.0,
+			)
+		]
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}]
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertIsNone(result)
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertTrue(any(f.get("step") == "no_t_warehouse" for f in failures))
+
+	@patch(f"{_MOD}._validate_eod_items_for_mwo_reservation")
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._preload_sre_warehouse_map", return_value={("M-1", "B1"): "WH-TO"})
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_same_warehouse_genuine_noop(self, _art, _sre, mock_mark, _val):
+		# SRE warehouse == last op to_warehouse → row dropped → genuine no-op.
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				to_warehouse="WH-TO",
+				qty_after_transaction_batch_based=1.0,
+			)
+		]
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}]
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertIsNone(result)
+		self.assertEqual(stats["processed_mwos"], 1)
+		mock_mark.assert_called_once()
+
+	@patch(f"{_MOD}._check_eod_source_batch_stock", return_value={})
+	@patch(f"{_MOD}._validate_eod_items_for_mwo_reservation")
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._preload_sre_warehouse_map", return_value={})
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_missing_sre_fails_without_marking(
+		self, _art, _sre, mock_mark, _val, _check
+	):
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				to_warehouse="WH-TO",
+				qty_after_transaction_batch_based=1.0,
+			)
+		]
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}]
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertEqual(result["kind"], "failed")
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertTrue(any(f.get("step") == "no_sre_warehouse" for f in failures))
+		mock_mark.assert_not_called()
+
+	@patch(
+		f"{_MOD}._check_eod_source_batch_stock",
+		return_value={("WH-SRE", "M-1", "B1"): (5.0, 1.0)},
+	)
+	@patch(f"{_MOD}._validate_eod_items_for_mwo_reservation")
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._preload_sre_warehouse_map", return_value={("M-1", "B1"): "WH-SRE"})
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_batch_short_fails_with_issues_rows(
+		self, _art, _sre, mock_mark, _val, _check
+	):
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				to_warehouse="WH-DEPT",
+				qty_after_transaction_batch_based=5.0,
+			)
+		]
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}]
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertEqual(result["kind"], "failed")
+		self.assertEqual(len(result["issues_rows"]), 1)
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertTrue(any(f.get("step") == "batch_short" for f in failures))
+		mock_mark.assert_not_called()
+
+	@patch(f"{_MOD}._check_eod_source_batch_stock", return_value={})
+	@patch(
+		f"{_MOD}._validate_eod_items_for_mwo_reservation",
+		side_effect=frappe.ValidationError("bad batch data"),
+	)
+	@patch(f"{_MOD}._mark_all_mwo_mop_logs_synced")
+	@patch(f"{_MOD}._preload_sre_warehouse_map", return_value={("M-1", "B1"): "WH-SRE"})
+	@patch(f"{_MOD}._mwo_realized_by_artifact", return_value=None)
+	def test_validation_failure_fails_mwo(self, _art, _sre, mock_mark, _val, _check):
+		logs = [
+			_log(
+				item_code="M-1",
+				batch_no="B1",
+				to_warehouse="WH-DEPT",
+				qty_after_transaction_batch_based=5.0,
+			)
+		]
+		mop_data_list = [{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": logs}]
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		result = _plan_mwo_group(
+			("Test Co", "MWO-1"), mop_data_list, failures, stats, sync_log_name=None
+		)
+		self.assertEqual(result["kind"], "failed")
+		self.assertEqual(stats["failed_mwos"], 1)
+		self.assertTrue(any(f.get("step") == "reservation_validate" for f in failures))
+
+
+# ---------------------------------------------------------------------------
+# TestReconcileReservationsForMwo (audit-first SRE reconciliation)
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileReservationsForMwo(FrappeTestCase):
+	_BAL = (
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log."
+		"get_current_mop_balance_rows"
+	)
+
+	def _sre(self, **o):
+		base = {
+			"name": "SRE-1",
+			"item_code": "M-1",
+			"warehouse": "WH-1",
+			"reserved_qty": 5.0,
+			"delivered_qty": 0.0,
+			"manufacturing_operation": "MOP-A",
+		}
+		base.update(o)
+		return FrappeDict(base)
+
+	@patch(f"{_MOD}.frappe.logger")
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(_BAL, return_value=[])
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_dry_run_logs_no_cancel(self, mock_get_all, _bal, mock_get_doc, _logger):
+		mock_get_all.return_value = [self._sre()]
+		_reconcile_reservations_for_mwo("MWO-1", dry_run=True)
+		mock_get_doc.assert_not_called()
+
+	@patch(f"{_MOD}.frappe.logger")
+	@patch(f"{_MOD}.frappe.db.release_savepoint")
+	@patch(f"{_MOD}.frappe.db.savepoint")
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(_BAL, return_value=[])
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_action_cancels_zero_balance_sre(
+		self, mock_get_all, _bal, mock_get_doc, _sp, _rel, _logger
+	):
+		mock_get_all.return_value = [self._sre()]
+		doc = MagicMock()
+		mock_get_doc.return_value = doc
+		_reconcile_reservations_for_mwo("MWO-1", dry_run=False)
+		mock_get_doc.assert_called_once_with("Stock Reservation Entry", "SRE-1")
+		doc.cancel.assert_called_once()
+
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(_BAL)
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_skips_fully_delivered_sre(self, mock_get_all, mock_bal, mock_get_doc):
+		mock_get_all.return_value = [self._sre(reserved_qty=5.0, delivered_qty=5.0)]
+		_reconcile_reservations_for_mwo("MWO-1")
+		mock_bal.assert_not_called()
+		mock_get_doc.assert_not_called()
+
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(_BAL)
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_skips_sre_without_operation(self, mock_get_all, mock_bal, mock_get_doc):
+		mock_get_all.return_value = [self._sre(manufacturing_operation=None)]
+		_reconcile_reservations_for_mwo("MWO-1")
+		mock_bal.assert_not_called()
+		mock_get_doc.assert_not_called()
+
+	@patch(f"{_MOD}.frappe.logger")
+	@patch(f"{_MOD}.frappe.get_doc")
+	@patch(_BAL)
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_no_cancel_when_balance_present(
+		self, mock_get_all, mock_bal, mock_get_doc, _logger
+	):
+		mock_get_all.return_value = [self._sre()]
+		mock_bal.return_value = [
+			FrappeDict({"item_code": "M-1", "to_warehouse": "WH-1", "qty": 5.0})
+		]
+		_reconcile_reservations_for_mwo("MWO-1", dry_run=False)
+		mock_get_doc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestFormatBatchShortDiagnostics (message assembly over the SRE qb helpers)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBatchShortDiagnostics(FrappeTestCase):
+	@patch(f"{_MOD}._collect_mop_names", return_value="MOP-A")
+	@patch(f"{_MOD}._resolve_eod_manufacturer_label", return_value="MF-1")
+	@patch(f"{_MOD}._list_open_sre_other_warehouses", return_value=[])
+	@patch(f"{_MOD}._list_open_sre_for_batch")
+	def test_lists_open_sre_here(self, mock_here, _other, _mfr, _mops):
+		mock_here.return_value = [{"name": "SRE-1", "warehouse": "WH-1", "open_qty": 3.0}]
+		msg = _format_batch_short_diagnostics(
+			"M-1", "WH-1", "B1", 5.0, 5.0, "MWO-1", [{"mop_name": "MOP-A"}], "Co"
+		)
+		self.assertIn("Company: Co", msg)
+		self.assertIn("Manufacturer: MF-1", msg)
+		self.assertIn("Open Stock Reservation Entry SRE-1", msg)
+
+	@patch(f"{_MOD}._collect_mop_names", return_value="MOP-A")
+	@patch(f"{_MOD}._resolve_eod_manufacturer_label", return_value="MF-1")
+	@patch(f"{_MOD}._list_open_sre_other_warehouses", return_value=[])
+	@patch(f"{_MOD}._list_open_sre_for_batch")
+	def test_stale_sre_hint_when_physical_zero(self, mock_here, _other, _mfr, _mops):
+		mock_here.return_value = [{"name": "SRE-1", "warehouse": "WH-1", "open_qty": 3.0}]
+		msg = _format_batch_short_diagnostics(
+			"M-1", "WH-1", "B1", 5.0, 0.0, "MWO-1", [{"mop_name": "MOP-A"}], "Co"
+		)
+		self.assertIn("physical batch qty is 0", msg)
+
+	@patch(f"{_MOD}._collect_mop_names", return_value="MOP-A")
+	@patch(f"{_MOD}._resolve_eod_manufacturer_label", return_value="MF-1")
+	@patch(f"{_MOD}._list_open_sre_other_warehouses")
+	@patch(f"{_MOD}._list_open_sre_for_batch", return_value=[])
+	def test_other_warehouse_fallback(self, _here, mock_other, _mfr, _mops):
+		mock_other.return_value = [{"name": "SRE-2", "warehouse": "WH-2", "open_qty": 2.0}]
+		msg = _format_batch_short_diagnostics(
+			"M-1", "WH-1", "B1", 5.0, 5.0, "MWO-1", [{"mop_name": "MOP-A"}], "Co"
+		)
+		self.assertIn("other warehouse(s)", msg)
+		self.assertIn("SRE-2", msg)
+
+	@patch(f"{_MOD}._collect_mop_names", return_value="MOP-A")
+	@patch(f"{_MOD}._resolve_eod_manufacturer_label", return_value=None)
+	@patch(f"{_MOD}._list_open_sre_other_warehouses", return_value=[])
+	@patch(f"{_MOD}._list_open_sre_for_batch", return_value=[])
+	def test_manufacturer_not_set_line(self, _here, _other, _mfr, _mops):
+		msg = _format_batch_short_diagnostics(
+			"M-1", "WH-1", "B1", 5.0, 5.0, "MWO-1", [{"mop_name": "MOP-A"}], "Co"
+		)
+		self.assertIn("(not set on Operation / Work Order)", msg)
+
+
+# ---------------------------------------------------------------------------
+# Branch-gap fills for already-tested functions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEodSeRowsSerial(FrappeTestCase):
+	def test_serial_no_included_in_row(self):
+		logs = [
+			_log(
+				item_code="S-1",
+				batch_no=None,
+				serial_no="SN1",
+				to_warehouse="WH-DEPT",
+				qty_after_transaction_batch_based=1.0,
+			)
+		]
+		sre_map = {("S-1", None): "WH-SRE"}
+		rows, skipped = _build_eod_se_rows("MWO-1", "MOP-A", logs, "WH-DEPT", sre_map)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["serial_no"], "SN1")
+		self.assertEqual(skipped, [])
+
+
+class TestSnapshotBatchEdges(FrappeTestCase):
+	def _sre_row(self, **o):
+		base = {
+			"name": "SRE-1",
+			"item_code": "D-1",
+			"warehouse": "WH-SRE",
+			"reserved_qty": 5.0,
+			"delivered_qty": 0.0,
+			"voucher_type": "Sales Order",
+			"voucher_no": "SO-1",
+			"voucher_detail_no": "row1",
+			"voucher_qty": 5.0,
+			"company": "Co",
+			"stock_uom": "Carat",
+			"reservation_based_on": "Serial and Batch",
+			"manufacturing_work_order": "MWO-1",
+			"manufacturing_operation": "MOP-A",
+		}
+		base.update(o)
+		return FrappeDict(base)
+
+	@patch(f"{_MOD}.frappe.get_all")
+	@patch(f"{_MOD}.frappe.get_cached_value", return_value=(1, 0))
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_multiple_sb_entries_captured(self, mock_db_get_all, _cached, mock_get_all):
+		mock_db_get_all.return_value = [self._sre_row()]
+		mock_get_all.return_value = [
+			FrappeDict({"batch_no": "B1", "qty": 3.0, "delivered_qty": 0.0}),
+			FrappeDict({"batch_no": "B2", "qty": 2.0, "delivered_qty": 0.0}),
+		]
+		items = [
+			{"item_code": "D-1", "batch_no": "B1", "s_warehouse": "WH-SRE", "qty": 5.0}
+		]
+		snaps = _snapshot_mwo_sres_for_relocation("MWO-1", items, "WH-DEPT")
+		self.assertEqual(len(snaps), 1)
+		self.assertEqual(
+			snaps[0]["sb_entries"],
+			[{"batch_no": "B1", "qty": 3.0}, {"batch_no": "B2", "qty": 2.0}],
+		)
+
+	@patch(f"{_MOD}.frappe.get_all")
+	@patch(f"{_MOD}.frappe.get_cached_value", return_value=(1, 0))
+	@patch(f"{_MOD}.frappe.db.get_all")
+	def test_fully_delivered_batch_dropped(self, mock_db_get_all, _cached, mock_get_all):
+		mock_db_get_all.return_value = [self._sre_row(delivered_qty=1.0)]
+		mock_get_all.return_value = [
+			FrappeDict({"batch_no": "B1", "qty": 5.0, "delivered_qty": 2.0}),
+			FrappeDict({"batch_no": "B2", "qty": 2.0, "delivered_qty": 2.0}),
+		]
+		items = [
+			{"item_code": "D-1", "batch_no": "B1", "s_warehouse": "WH-SRE", "qty": 5.0}
+		]
+		snaps = _snapshot_mwo_sres_for_relocation("MWO-1", items, "WH-DEPT")
+		# SRE-level remaining = reserved 5 - delivered 1 = 4.
+		self.assertEqual(snaps[0]["remaining"], 4.0)
+		# B1: 5-2=3 kept; B2: 2-2=0 dropped.
+		self.assertEqual(snaps[0]["sb_entries"], [{"batch_no": "B1", "qty": 3.0}])
+
+
+class TestApplyMwoFilterRowsNoOperation(FrappeTestCase):
+	def test_no_operation_filter_includes_all_mops(self):
+		logs = [
+			_log(manufacturing_work_order="MWO-1", manufacturing_operation="MOP-A"),
+			_log(manufacturing_work_order="MWO-1", manufacturing_operation="MOP-B"),
+		]
+		filter_rows = [
+			FrappeDict(
+				{
+					"manufacturing_work_order": "MWO-1",
+					"manufacturing_operation": None,
+					"enabled": 1,
+				}
+			)
+		]
+		included, excluded = _apply_mwo_filter_rows(logs, filter_rows)
+		self.assertEqual(len(included), 2)
+		self.assertEqual(excluded, [])

--- a/jewellery_erpnext/jewellery_erpnext/doctype/stock_reconciliation_template/stock_reconciliation_template_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/stock_reconciliation_template/stock_reconciliation_template_utils.py
@@ -39,6 +39,7 @@ class CustomStockReconciliation(StockReconciliation):
 				self.posting_date,
 				self.posting_time,
 				batch_no=item.batch_no,
+				row=item,
 				inventory_dimensions_dict=inventory_dimensions_dict,
 			)
 

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_material_request_transfer_type.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_material_request_transfer_type.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, Nirali and contributors
+# See license.txt
+
+"""Tests for the ``before_validate`` auto-derivation of ``custom_transfer_type``
+on Material Request.
+
+Rule: the transfer type is auto-derived ONLY when it is blank. A value already
+present (set manually, or defaulted on a prior save) is preserved and never
+overwritten. When it IS derived, the source/target warehouse ``custom_branch``
+values are normalised so a blank ("") and a NULL branch count as the same branch
+(both "no branch" -> Transfer To Department), instead of "" != None forcing
+Transfer To Branch.
+"""
+
+from unittest.mock import patch
+
+from frappe.tests.utils import FrappeTestCase
+
+from jewellery_erpnext.jewellery_erpnext.doc_events import material_request as mr_mod
+
+
+class _MR:
+	def __init__(
+		self,
+		set_from_warehouse=None,
+		set_warehouse=None,
+		custom_transfer_type=None,
+		material_request_type=None,
+	):
+		self.set_from_warehouse = set_from_warehouse
+		self.set_warehouse = set_warehouse
+		self.custom_transfer_type = custom_transfer_type
+		self.material_request_type = material_request_type
+		self.custom_manufacturing_operation = None
+
+
+class TestMaterialRequestTransferType(FrappeTestCase):
+	def _run(self, mr, branches):
+		"""Call before_validate with branch lookups and the unrelated
+		downstream validators stubbed out."""
+
+		def _gv(doctype, name, field):
+			return branches.get(name)
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doc_events.material_request.frappe.db.get_value",
+			side_effect=_gv,
+		), patch.object(mr_mod, "update_pure_qty"), patch.object(
+			mr_mod, "validate_target_item"
+		), patch.object(
+			mr_mod, "validate_warehouse"
+		):
+			mr_mod.before_validate(mr, None)
+		return mr.custom_transfer_type
+
+	def test_existing_value_preserved(self):
+		"""A manually-chosen value is not overwritten even when the branches
+		differ -- the original bug on KGJPL-MR-MT-26-02528."""
+		mr = _MR(
+			set_from_warehouse="Central RM - KGJPL",
+			set_warehouse="Waxing RM - KGJPL",
+			custom_transfer_type="Transfer To Department",
+		)
+		result = self._run(
+			mr, {"Central RM - KGJPL": "", "Waxing RM - KGJPL": None}
+		)
+		self.assertEqual(result, "Transfer To Department")
+
+	def test_blank_same_branch(self):
+		mr = _MR(set_from_warehouse="W1", set_warehouse="W2")
+		result = self._run(mr, {"W1": "BR-A", "W2": "BR-A"})
+		self.assertEqual(result, "Transfer To Department")
+
+	def test_blank_different_branches(self):
+		mr = _MR(set_from_warehouse="W1", set_warehouse="W2")
+		result = self._run(mr, {"W1": "BR-A", "W2": "BR-B"})
+		self.assertEqual(result, "Transfer To Branch")
+
+	def test_blank_branches_empty_vs_null_treated_as_same(self):
+		"""Regression: "" and NULL branch are normalised so two no-branch
+		warehouses default to Transfer To Department, not Transfer To Branch."""
+		mr = _MR(set_from_warehouse="W1", set_warehouse="W2")
+		result = self._run(mr, {"W1": "", "W2": None})
+		self.assertEqual(result, "Transfer To Department")
+
+	def test_manufacture_defaults_to_reserve(self):
+		mr = _MR(material_request_type="Manufacture")
+		result = self._run(mr, {})
+		self.assertEqual(result, "Transfer to Reserve")

--- a/jewellery_erpnext/patches/retry_stuck_eod_submit_mwos.py
+++ b/jewellery_erpnext/patches/retry_stuck_eod_submit_mwos.py
@@ -1,7 +1,7 @@
 """One-off retry for MOP EOD Sync MWOs left stuck after a Phase-2 submit failure.
 
 A partially-completed EOD run (e.g. ``MOP-EOD-SYNC-2026-03606``) left some MWOs with a
-draft Stock Entry because ``_recreate_sres_at`` failed (over-reserved SO line / batch not
+draft Stock Entry because the EOD re-reservation failed (over-reserved SO line / batch not
 free). That re-reservation bug is now fixed, so these MWOs can be re-processed.
 
 Two groups (decided per MWO from the sync log's "Draft Created" child rows):
@@ -89,8 +89,10 @@ def execute(sync_log_name=DEFAULT_SYNC_LOG, dry_run=True):
 		return
 
 	from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+		_commit_company_issues_se,
+		_commit_company_main_se,
 		_get_unsynced_mop_groups,
-		_process_mwo_group,
+		_plan_mwo_group,
 	)
 
 	# EOD-internal writes (SE submit, SRE relocation) must bypass the transaction lock.
@@ -124,14 +126,31 @@ def execute(sync_log_name=DEFAULT_SYNC_LOG, dry_run=True):
 		"artifact_skipped": [],
 		"started_on": frappe.utils.now_datetime(),
 	}
+	main_buckets = {}
+	issues_buckets = {}
 	for group_key, mop_data_list in groups.items():
-		_process_mwo_group(
+		result = _plan_mwo_group(
 			group_key,
 			mop_data_list,
 			failures,
 			stats,
 			sync_log_name=None,
 			selective=True,
+		)
+		if not result:
+			continue
+		bucket_key = (result["company"], result.get("manufacturer"))
+		if result["kind"] == "resolvable":
+			main_buckets.setdefault(bucket_key, []).append(result)
+		elif result["kind"] == "failed" and result.get("issues_rows"):
+			issues_buckets.setdefault(bucket_key, []).extend(result["issues_rows"])
+	for (company, manufacturer), main_mwos in main_buckets.items():
+		_commit_company_main_se(
+			company, manufacturer, main_mwos, failures, stats, sync_log_name=None, selective=True
+		)
+	for (company, manufacturer), issues_rows in issues_buckets.items():
+		_commit_company_issues_se(
+			company, manufacturer, issues_rows, stats, sync_log_name=None
 		)
 	frappe.db.commit()
 


### PR DESCRIPTION
- Added `row=item` parameter to the stock reconciliation process for better item tracking.
- Introduced unit tests for the `before_validate` method in Material Request to ensure correct auto-derivation of `custom_transfer_type` based on warehouse branches.
- Updated the retry logic in the EOD submission patch to handle stuck MWOs more effectively by separating main and issue buckets for processing.