### PR TITLE
feat(refining): Enhance refining entry with new fields and validations

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.js
@@ -10,6 +10,7 @@ frappe.ui.form.on("Manufacturing Operation", {
 			frm.set_df_property("employee_source_table", "hidden", 1);
 		}
 		set_html(frm);
+
 		if (frm.doc.is_last_operation && frm.doc.for_fg && ["Not Started", "WIP"].includes(frm.doc.status)) {
 			frm.add_custom_button(__("Finish"), async () => {
 				await frappe.call({
@@ -304,353 +305,382 @@ frappe.ui.form.on("Manufacturing Operation", {
 	},
 	setup_buttons: (frm) => {
 		frm.add_custom_button(__("Make Receive Entry"), () => {
-			frappe.call({
-				method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.get_make_receive_entry_rows",
-				args: { manufacturing_operation: frm.doc.name },
-				freeze: true,
-				freeze_message: __("Loading Stock Reservation Entries..."),
-				callback: (r) => {
-					const msg = (r && r.message) || {};
-					const rows = Array.isArray(msg) ? msg : msg.rows || [];
-					const skipped = Array.isArray(msg) ? [] : msg.skipped || [];
-					const active_sre_count = Array.isArray(msg) ? rows.length : msg.active_sre_count || 0;
+			open_wo_transfer_dialog(frm, {
+				fetch_method:
+					"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.get_make_receive_entry_rows",
+				create_method:
+					"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.create_mr_wo_stock_entry",
+				no_sre_title: __("Make Receive Entry"),
+				dialog_title: __("Create Material Receive (WORK ORDER)"),
+				primary_action_label: __("Create Material Receive Entry"),
+				create_freeze_message: __("Creating Material Receive Entry..."),
+				created_title: __("Material Receive Stock Entry Created"),
+				existing_title: __("Existing Material Receive Stock Entry"),
+				result_label: __("Material Receive Entry: {0}"),
+			});
+		}).addClass("btn-primary");
 
-					if (!rows.length) {
-						if (active_sre_count === 0) {
-							frappe.msgprint(
-								__(
-									"No active Stock Reservation Entries found for this Manufacturing Work Order."
-								)
-							);
-						} else {
-							const lines = (skipped || []).map((s) =>
-								__("• SRE {0} — Item {1}{2}: SRE remaining {3}, MOP available {4}", [
-									s.sre,
-									s.item_code,
-									s.batch_no ? ` / Batch ${s.batch_no}` : "",
-									s.sre_remaining,
-									s.mop_available_qty,
-								])
-							);
-							frappe.msgprint({
-								title: __("Make Receive Entry"),
-								indicator: "orange",
-								message:
-									__(
-										"Stock Reservation Entries exist, but no receivable MOP balance was found. Please check MOP Log balance for this Manufacturing Operation."
-									) + (lines.length ? "<br><br>" + lines.join("<br>") : ""),
-							});
-						}
-						return;
-					}
-
-					// Per-dialog request id — stamped on the resulting Stock Entry to
-					// short-circuit double-clicks and resubmits server-side.
-					// Frappe JS exposes `get_random(N)`, not `get_random_string`.
-					const request_id = frappe.utils.get_random(36);
-
-					// Spec field names: reserved_* / mop_available_* / available_to_receive_*.
-					// Server endpoint emits these directly; the JS just forwards them
-					// into the dialog and surfaces `qty_to_receive` / `pcs_to_receive`
-					// as the editable inputs.
-					const dialog_data = rows.map((e) => ({
-						stock_reservation_entry: e.stock_reservation_entry,
-						stock_reservation_entry_detail: e.stock_reservation_entry_detail,
-						item_code: e.item_code,
-						s_warehouse: e.s_warehouse,
-						t_warehouse: e.t_warehouse,
-						batch_no: e.batch_no,
-						reserved_qty: e.reserved_qty,
-						reserved_pcs: e.reserved_pcs || 0,
-						delivered_qty: e.delivered_qty,
-						already_received_qty: e.already_received_qty,
-						already_received_pcs: e.already_received_pcs || 0,
-						mop_available_qty: e.mop_available_qty || 0,
-						mop_available_pcs: e.mop_available_pcs || 0,
-						available_to_receive_qty: e.available_to_receive_qty,
-						available_to_receive_pcs: e.available_to_receive_pcs || 0,
-						is_pcs_item: e.is_pcs_item ? 1 : 0,
-						mop_log_reference: e.mop_log_reference || "",
-						warning: e.warning || "",
-						qty_to_receive: 0,
-						pcs_to_receive: 0,
-						stock_uom: e.stock_uom,
-					}));
-
-					const d = new frappe.ui.Dialog({
-						title: __("Create Material Receive (WORK ORDER)"),
-						size: "extra-large",
-						fields: [
-							{
-								fieldname: "receive_entries",
-								label: __("Receive Entry Details"),
-								fieldtype: "Table",
-								cannot_add_rows: 1,
-								cannot_delete_rows: 1,
-								data: dialog_data,
-								get_data: () => dialog_data,
-								fields: [
-									{
-										label: __("SRE"),
-										fieldtype: "Link",
-										fieldname: "stock_reservation_entry",
-										options: "Stock Reservation Entry",
-										read_only: 1,
-									},
-									{
-										label: __("Item Code"),
-										fieldtype: "Link",
-										fieldname: "item_code",
-										options: "Item",
-										in_list_view: 1,
-										read_only: 1,
-									},
-									{
-										label: __("Source Warehouse"),
-										fieldtype: "Link",
-										fieldname: "s_warehouse",
-										options: "Warehouse",
-										read_only: 1,
-									},
-									{
-										label: __("Target Warehouse"),
-										fieldtype: "Link",
-										fieldname: "t_warehouse",
-										options: "Warehouse",
-										read_only: 1,
-									},
-									{
-										label: __("Batch No"),
-										fieldtype: "Link",
-										fieldname: "batch_no",
-										options: "Batch",
-										in_list_view: 1,
-										read_only: 1,
-									},
-									{
-										label: __("Reserved Qty"),
-										fieldtype: "Float",
-										fieldname: "reserved_qty",
-										read_only: 1,
-									},
-									{
-										label: __("Reserved PCS"),
-										fieldtype: "Float",
-										fieldname: "reserved_pcs",
-										read_only: 1,
-									},
-									{
-										label: __("Delivered Qty"),
-										fieldtype: "Float",
-										fieldname: "delivered_qty",
-										read_only: 1,
-									},
-									{
-										label: __("MOP Available Qty"),
-										fieldtype: "Float",
-										fieldname: "mop_available_qty",
-										in_list_view: 0,
-										read_only: 1,
-									},
-									{
-										label: __("MOP Available PCS"),
-										fieldtype: "Float",
-										fieldname: "mop_available_pcs",
-										// in_list_view: 1,
-										read_only: 1,
-									},
-									{
-										label: __("Already Received"),
-										fieldtype: "Float",
-										fieldname: "already_received_qty",
-										read_only: 1,
-									},
-									{
-										label: __("Already Received PCS"),
-										fieldtype: "Float",
-										fieldname: "already_received_pcs",
-										read_only: 1,
-									},
-									{
-										label: __("Available to Receive Qty"),
-										fieldtype: "Float",
-										fieldname: "available_to_receive_qty",
-										in_list_view: 1,
-										read_only: 1,
-									},
-									{
-										label: __("Available to Receive PCS"),
-										fieldtype: "Float",
-										in_list_view: 1,
-										fieldname: "available_to_receive_pcs",
-										read_only: 1,
-									},
-									{
-										label: __("Qty to Receive"),
-										fieldtype: "Float",
-										fieldname: "qty_to_receive",
-										in_list_view: 1,
-										default: 0,
-									},
-									{
-										label: __("PCS to Receive"),
-										fieldtype: "Float",
-										fieldname: "pcs_to_receive",
-										in_list_view: 1,
-										default: 0,
-										// Read-only for non-D/G rows. Frappe Table fields
-										// don't support per-row hidden cells, so we use
-										// read_only_depends_on; server still force-zeros
-										// PCS for non-D/G regardless of dialog value.
-										// read_only_depends_on: "eval:!doc.is_pcs_item",
-									},
-									{
-										label: __("PCS Item"),
-										fieldtype: "Check",
-										fieldname: "is_pcs_item",
-									},
-									{
-										label: __("MOP Log Reference"),
-										fieldtype: "Link",
-										fieldname: "mop_log_reference",
-										options: "MOP Log",
-										read_only: 1,
-									},
-									{
-										label: __("Warning"),
-										fieldtype: "Small Text",
-										fieldname: "warning",
-										in_list_view: 0,
-										read_only: 1,
-									},
-									{
-										label: __("Stock UOM"),
-										fieldtype: "Link",
-										fieldname: "stock_uom",
-										options: "UOM",
-										read_only: 1,
-									},
-								],
-							},
-						],
-						primary_action_label: __("Create Material Receive Entry"),
-						primary_action: (r_) => {
-							const receive_items = [];
-							r_.receive_entries.forEach((e) => {
-								// Qty must be capped by min(SRE remaining, MOP balance);
-								// the server endpoint surfaces that as available_to_receive_qty.
-								if (e.qty_to_receive > e.available_to_receive_qty) {
-									frappe.throw(
-										__(
-											"Row <b>{0}</b> Item <b>{1}</b>: Qty to Receive <b>{2}</b> exceeds Available to Receive Qty <b>{3}</b>",
-											[e.idx, e.item_code, e.qty_to_receive, e.available_to_receive_qty]
-										)
-									);
-								}
-								// PCS validation: D/G rows must respect Available to
-								// Receive PCS; non-D/G rows are force-zeroed regardless
-								// of dialog value. Server revalidates either way.
-								let pcs_to_receive = 0;
-								if (e.is_pcs_item) {
-									pcs_to_receive = e.pcs_to_receive || 0;
-									if (pcs_to_receive < 0) {
-										frappe.throw(
-											__(
-												"Row <b>{0}</b> Item <b>{1}</b>: PCS to Receive must be >= 0",
-												[e.idx, e.item_code]
-											)
-										);
-									}
-									if (
-										e.available_to_receive_pcs &&
-										pcs_to_receive > e.available_to_receive_pcs
-									) {
-										frappe.throw(
-											__(
-												"Row <b>{0}</b> Item <b>{1}</b>: PCS to Receive <b>{2}</b> exceeds Available to Receive PCS <b>{3}</b>",
-												[
-													e.idx,
-													e.item_code,
-													pcs_to_receive,
-													e.available_to_receive_pcs,
-												]
-											)
-										);
-									}
-								}
-								if (e.qty_to_receive && e.qty_to_receive > 0) {
-									receive_items.push({
-										idx: e.idx,
-										stock_reservation_entry: e.stock_reservation_entry,
-										stock_reservation_entry_detail: e.stock_reservation_entry_detail,
-										item_code: e.item_code,
-										s_warehouse: e.s_warehouse,
-										// Server still consumes `qty` and `pcs` keys for
-										// receive_items — the dialog field rename is
-										// cosmetic only.
-										qty: e.qty_to_receive,
-										pcs: pcs_to_receive,
-										batch_no: e.batch_no,
-									});
-								}
-							});
-
-							if (!receive_items.length) {
-								frappe.msgprint(
-									__("No Receive Items selected for Material Receive Stock Entry")
-								);
-								return;
-							}
-
-							d.disable_primary_action();
-							frappe.call({
-								method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.create_mr_wo_stock_entry",
-								args: {
-									se_data: {
-										manufacturing_work_order: frm.doc.manufacturing_work_order,
-										manufacturing_operation: frm.doc.name,
-										manufacturing_order: frm.doc.manufacturing_order,
-										department: frm.doc.department,
-										receive_items: receive_items,
-									},
-									request_id: request_id,
-								},
-								freeze: true,
-								freeze_message: __("Creating Material Receive Entry..."),
-								callback: (resp) => {
-									if (resp && resp.message) {
-										const se_link = frappe.utils.get_form_link(
-											resp.message.doctype,
-											resp.message.docname,
-											true
-										);
-										const title = resp.message.idempotent
-											? __("Existing Material Receive Stock Entry")
-											: __("Material Receive Stock Entry Created");
-										frappe.msgprint({
-											message: __("Material Receive Entry: {0}", [se_link]),
-											title: title,
-											indicator: "green",
-										});
-										frm.reload_doc();
-									}
-								},
-								error: () => {
-									d.enable_primary_action();
-								},
-							});
-
-							d.hide();
-						},
-					});
-
-					d.get_field("receive_entries").grid.wrapper.find(".grid-row-check").hide();
-					d.show();
-				},
+		// Create Scrap Item: same auto-fill + transfer machinery as Make Receive
+		// Entry, but moves the operation's materials into the department Scrap
+		// warehouse via a "Material Transfer (WORK ORDER)" so the stock is
+		// segregated as scrap and excluded from manufacturing/RM pickers.
+		frm.add_custom_button(__("Create Scrap Item"), () => {
+			open_wo_transfer_dialog(frm, {
+				fetch_method:
+					"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.get_make_scrap_entry_rows",
+				create_method:
+					"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation.create_scrap_wo_stock_entry",
+				no_sre_title: __("Create Scrap Item"),
+				dialog_title: __("Create Scrap Item — Material Transfer (WORK ORDER)"),
+				primary_action_label: __("Create Scrap Item"),
+				create_freeze_message: __("Creating Scrap Item Transfer..."),
+				created_title: __("Scrap Item Stock Entry Created"),
+				existing_title: __("Existing Scrap Item Stock Entry"),
+				result_label: __("Scrap Item Entry: {0}"),
 			});
 		}).addClass("btn-primary");
 	},
 });
+
+// Shared dialog body for the "Make Receive Entry" and "Create Scrap Item"
+// buttons. Both fetch auto-filled rows from the MWO's Stock Reservation
+// Entries, render the same editable table, and POST the selected rows to a
+// whitelisted creator. Only the endpoints, warehouse target, and labels differ
+// (passed via `opts`).
+function open_wo_transfer_dialog(frm, opts) {
+	frappe.call({
+		method: opts.fetch_method,
+		args: { manufacturing_operation: frm.doc.name },
+		freeze: true,
+		freeze_message: __("Loading Stock Reservation Entries..."),
+		callback: (r) => {
+			const msg = (r && r.message) || {};
+			const rows = Array.isArray(msg) ? msg : msg.rows || [];
+			const skipped = Array.isArray(msg) ? [] : msg.skipped || [];
+			const active_sre_count = Array.isArray(msg) ? rows.length : msg.active_sre_count || 0;
+
+			if (!rows.length) {
+				if (active_sre_count === 0) {
+					frappe.msgprint(
+						__("No active Stock Reservation Entries found for this Manufacturing Work Order.")
+					);
+				} else {
+					const lines = (skipped || []).map((s) =>
+						__("• SRE {0} — Item {1}{2}: SRE remaining {3}, MOP available {4}", [
+							s.sre,
+							s.item_code,
+							s.batch_no ? ` / Batch ${s.batch_no}` : "",
+							s.sre_remaining,
+							s.mop_available_qty,
+						])
+					);
+					frappe.msgprint({
+						title: opts.no_sre_title,
+						indicator: "orange",
+						message:
+							__(
+								"Stock Reservation Entries exist, but no receivable MOP balance was found. Please check MOP Log balance for this Manufacturing Operation."
+							) + (lines.length ? "<br><br>" + lines.join("<br>") : ""),
+					});
+				}
+				return;
+			}
+
+			// Per-dialog request id — stamped on the resulting Stock Entry to
+			// short-circuit double-clicks and resubmits server-side.
+			// Frappe JS exposes `get_random(N)`, not `get_random_string`.
+			const request_id = frappe.utils.get_random(36);
+
+			// Spec field names: reserved_* / mop_available_* / available_to_receive_*.
+			// Server endpoint emits these directly; the JS just forwards them
+			// into the dialog and surfaces `qty_to_receive` / `pcs_to_receive`
+			// as the editable inputs.
+			const dialog_data = rows.map((e) => ({
+				stock_reservation_entry: e.stock_reservation_entry,
+				stock_reservation_entry_detail: e.stock_reservation_entry_detail,
+				item_code: e.item_code,
+				s_warehouse: e.s_warehouse,
+				t_warehouse: e.t_warehouse,
+				batch_no: e.batch_no,
+				reserved_qty: e.reserved_qty,
+				reserved_pcs: e.reserved_pcs || 0,
+				delivered_qty: e.delivered_qty,
+				already_received_qty: e.already_received_qty,
+				already_received_pcs: e.already_received_pcs || 0,
+				mop_available_qty: e.mop_available_qty || 0,
+				mop_available_pcs: e.mop_available_pcs || 0,
+				available_to_receive_qty: e.available_to_receive_qty,
+				available_to_receive_pcs: e.available_to_receive_pcs || 0,
+				is_pcs_item: e.is_pcs_item ? 1 : 0,
+				mop_log_reference: e.mop_log_reference || "",
+				warning: e.warning || "",
+				qty_to_receive: 0,
+				pcs_to_receive: 0,
+				stock_uom: e.stock_uom,
+			}));
+
+			const d = new frappe.ui.Dialog({
+				title: opts.dialog_title,
+				size: "extra-large",
+				fields: [
+					{
+						fieldname: "receive_entries",
+						label: __("Receive Entry Details"),
+						fieldtype: "Table",
+						cannot_add_rows: 1,
+						cannot_delete_rows: 1,
+						data: dialog_data,
+						get_data: () => dialog_data,
+						fields: [
+							{
+								label: __("SRE"),
+								fieldtype: "Link",
+								fieldname: "stock_reservation_entry",
+								options: "Stock Reservation Entry",
+								read_only: 1,
+							},
+							{
+								label: __("Item Code"),
+								fieldtype: "Link",
+								fieldname: "item_code",
+								options: "Item",
+								in_list_view: 1,
+								read_only: 1,
+							},
+							{
+								label: __("Source Warehouse"),
+								fieldtype: "Link",
+								fieldname: "s_warehouse",
+								options: "Warehouse",
+								read_only: 1,
+							},
+							{
+								label: __("Target Warehouse"),
+								fieldtype: "Link",
+								fieldname: "t_warehouse",
+								options: "Warehouse",
+								read_only: 1,
+							},
+							{
+								label: __("Batch No"),
+								fieldtype: "Link",
+								fieldname: "batch_no",
+								options: "Batch",
+								in_list_view: 1,
+								read_only: 1,
+							},
+							{
+								label: __("Reserved Qty"),
+								fieldtype: "Float",
+								fieldname: "reserved_qty",
+								read_only: 1,
+							},
+							{
+								label: __("Reserved PCS"),
+								fieldtype: "Float",
+								fieldname: "reserved_pcs",
+								read_only: 1,
+							},
+							{
+								label: __("Delivered Qty"),
+								fieldtype: "Float",
+								fieldname: "delivered_qty",
+								read_only: 1,
+							},
+							{
+								label: __("MOP Available Qty"),
+								fieldtype: "Float",
+								fieldname: "mop_available_qty",
+								in_list_view: 0,
+								read_only: 1,
+							},
+							{
+								label: __("MOP Available PCS"),
+								fieldtype: "Float",
+								fieldname: "mop_available_pcs",
+								// in_list_view: 1,
+								read_only: 1,
+							},
+							{
+								label: __("Already Received"),
+								fieldtype: "Float",
+								fieldname: "already_received_qty",
+								read_only: 1,
+							},
+							{
+								label: __("Already Received PCS"),
+								fieldtype: "Float",
+								fieldname: "already_received_pcs",
+								read_only: 1,
+							},
+							{
+								label: __("Available to Receive Qty"),
+								fieldtype: "Float",
+								fieldname: "available_to_receive_qty",
+								in_list_view: 1,
+								read_only: 1,
+							},
+							{
+								label: __("Available to Receive PCS"),
+								fieldtype: "Float",
+								in_list_view: 1,
+								fieldname: "available_to_receive_pcs",
+								read_only: 1,
+							},
+							{
+								label: __("Qty to Receive"),
+								fieldtype: "Float",
+								fieldname: "qty_to_receive",
+								in_list_view: 1,
+								default: 0,
+							},
+							{
+								label: __("PCS to Receive"),
+								fieldtype: "Float",
+								fieldname: "pcs_to_receive",
+								in_list_view: 1,
+								default: 0,
+								// Read-only for non-D/G rows. Frappe Table fields
+								// don't support per-row hidden cells, so we use
+								// read_only_depends_on; server still force-zeros
+								// PCS for non-D/G regardless of dialog value.
+								// read_only_depends_on: "eval:!doc.is_pcs_item",
+							},
+							{
+								label: __("PCS Item"),
+								fieldtype: "Check",
+								fieldname: "is_pcs_item",
+							},
+							{
+								label: __("MOP Log Reference"),
+								fieldtype: "Link",
+								fieldname: "mop_log_reference",
+								options: "MOP Log",
+								read_only: 1,
+							},
+							{
+								label: __("Warning"),
+								fieldtype: "Small Text",
+								fieldname: "warning",
+								in_list_view: 0,
+								read_only: 1,
+							},
+							{
+								label: __("Stock UOM"),
+								fieldtype: "Link",
+								fieldname: "stock_uom",
+								options: "UOM",
+								read_only: 1,
+							},
+						],
+					},
+				],
+				primary_action_label: opts.primary_action_label,
+				primary_action: (r_) => {
+					const receive_items = [];
+					r_.receive_entries.forEach((e) => {
+						// Qty must be capped by min(SRE remaining, MOP balance);
+						// the server endpoint surfaces that as available_to_receive_qty.
+						if (e.qty_to_receive > e.available_to_receive_qty) {
+							frappe.throw(
+								__(
+									"Row <b>{0}</b> Item <b>{1}</b>: Qty to Receive <b>{2}</b> exceeds Available to Receive Qty <b>{3}</b>",
+									[e.idx, e.item_code, e.qty_to_receive, e.available_to_receive_qty]
+								)
+							);
+						}
+						// PCS validation: D/G rows must respect Available to
+						// Receive PCS; non-D/G rows are force-zeroed regardless
+						// of dialog value. Server revalidates either way.
+						let pcs_to_receive = 0;
+						if (e.is_pcs_item) {
+							pcs_to_receive = e.pcs_to_receive || 0;
+							if (pcs_to_receive < 0) {
+								frappe.throw(
+									__("Row <b>{0}</b> Item <b>{1}</b>: PCS to Receive must be >= 0", [
+										e.idx,
+										e.item_code,
+									])
+								);
+							}
+							if (e.available_to_receive_pcs && pcs_to_receive > e.available_to_receive_pcs) {
+								frappe.throw(
+									__(
+										"Row <b>{0}</b> Item <b>{1}</b>: PCS to Receive <b>{2}</b> exceeds Available to Receive PCS <b>{3}</b>",
+										[e.idx, e.item_code, pcs_to_receive, e.available_to_receive_pcs]
+									)
+								);
+							}
+						}
+						if (e.qty_to_receive && e.qty_to_receive > 0) {
+							receive_items.push({
+								idx: e.idx,
+								stock_reservation_entry: e.stock_reservation_entry,
+								stock_reservation_entry_detail: e.stock_reservation_entry_detail,
+								item_code: e.item_code,
+								s_warehouse: e.s_warehouse,
+								// Server still consumes `qty` and `pcs` keys for
+								// receive_items — the dialog field rename is
+								// cosmetic only.
+								qty: e.qty_to_receive,
+								pcs: pcs_to_receive,
+								batch_no: e.batch_no,
+							});
+						}
+					});
+
+					if (!receive_items.length) {
+						frappe.msgprint(__("No Receive Items selected for Material Receive Stock Entry"));
+						return;
+					}
+
+					d.disable_primary_action();
+					frappe.call({
+						method: opts.create_method,
+						args: {
+							se_data: {
+								manufacturing_work_order: frm.doc.manufacturing_work_order,
+								manufacturing_operation: frm.doc.name,
+								manufacturing_order: frm.doc.manufacturing_order,
+								department: frm.doc.department,
+								receive_items: receive_items,
+							},
+							request_id: request_id,
+						},
+						freeze: true,
+						freeze_message: opts.create_freeze_message,
+						callback: (resp) => {
+							if (resp && resp.message) {
+								const se_link = frappe.utils.get_form_link(
+									resp.message.doctype,
+									resp.message.docname,
+									true
+								);
+								const title = resp.message.idempotent
+									? opts.existing_title
+									: opts.created_title;
+								frappe.msgprint({
+									message: __(opts.result_label, [se_link]),
+									title: title,
+									indicator: "green",
+								});
+								frm.reload_doc();
+							}
+						},
+						error: () => {
+							d.enable_primary_action();
+						},
+					});
+
+					d.hide();
+				},
+			});
+
+			d.get_field("receive_entries").grid.wrapper.find(".grid-row-check").hide();
+			d.show();
+		},
+	});
+}
 function initialiseTimer(section, currentIncrement) {
 	const interval = setInterval(function () {
 		var current = setCurrentIncrement(currentIncrement);

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -4365,15 +4365,22 @@ def _build_replacement_sre(original_sre, remaining_qty, sb_remaining=None):
 
 
 @frappe.whitelist()
-def create_mr_wo_stock_entry(se_data, request_id=None, target_warehouse=None):
+def create_mr_wo_stock_entry(
+	se_data,
+	request_id=None,
+	target_warehouse=None,
+	stock_entry_type="Material Receive (WORK ORDER)",
+):
 	"""Refactored Make Receive Entry creator.
 
 	- Re-fetches every Stock Reservation Entry server-side (client values are
 	  advisory only).
 	- Validates available_qty = reserved_qty - delivered_qty (for active SRE)
 	  on each requested row, with float-precision tolerance.
-	- Creates a single Stock Entry of type Material Receive (WORK ORDER)
-	  stamped with custom_request_id for double-submit idempotency.
+	- Creates a single Stock Entry of type ``stock_entry_type`` (default
+	  "Material Receive (WORK ORDER)"; the scrap flow passes
+	  "Material Transfer (WORK ORDER)") stamped with custom_request_id for
+	  double-submit idempotency.
 	- After SE submit, cancels (full) or cancels+recreates (partial) each SRE.
 	- Relies on doc_events/stock_entry.sync_mop_log_for_stock_entry to bridge
 	  MOP Log rows (is_synced=1).
@@ -4405,7 +4412,7 @@ def create_mr_wo_stock_entry(se_data, request_id=None, target_warehouse=None):
 			{
 				"custom_request_id": request_id,
 				"manufacturing_operation": mo.name,
-				"stock_entry_type": "Material Receive (WORK ORDER)",
+				"stock_entry_type": stock_entry_type,
 				"docstatus": ["!=", 2],
 			},
 			"name",
@@ -4653,7 +4660,7 @@ def create_mr_wo_stock_entry(se_data, request_id=None, target_warehouse=None):
 		se_doc = frappe.new_doc("Stock Entry")
 		se_doc.update(
 			{
-				"stock_entry_type": "Material Receive (WORK ORDER)",
+				"stock_entry_type": stock_entry_type,
 				"manufacturing_work_order": mo.manufacturing_work_order,
 				"manufacturing_order": mo.manufacturing_order,
 				"manufacturing_operation": mo.name,
@@ -4794,6 +4801,71 @@ def create_mr_wo_stock_entry(se_data, request_id=None, target_warehouse=None):
 		"sre_actions": sre_outcomes,
 		"idempotent": False,
 	}
+
+
+def _get_department_scrap_warehouse(department):
+	"""Resolve the department's Scrap-type warehouse (the scrap sink used across
+	the app — Gemstone Conversion, Employee IR loss, Refining). Throws an
+	actionable error when the department has none, mirroring
+	gemstone_conversion.get_scrap_warehouse.
+	"""
+	scrap_warehouse = frappe.db.get_value(
+		"Warehouse",
+		{"department": department, "warehouse_type": "Scrap", "disabled": 0},
+		"name",
+	)
+	if not scrap_warehouse:
+		frappe.throw(
+			_(
+				"No Scrap Warehouse found for Department({0}). Configure a Scrap "
+				"Warehouse for this department."
+			).format(department)
+		)
+	return scrap_warehouse
+
+
+@frappe.whitelist()
+def get_make_scrap_entry_rows(manufacturing_operation):
+	"""Auto-fill rows for the Create Scrap Item dialog.
+
+	Identical to Make Receive Entry's row builder, but the target warehouse is
+	the department's Scrap warehouse (not Raw Material) so the dialog previews
+	where the scrapped material will land.
+	"""
+	department = frappe.db.get_value(
+		"Manufacturing Operation", manufacturing_operation, "department"
+	)
+	scrap_warehouse = _get_department_scrap_warehouse(department)
+	return get_make_receive_entry_rows(
+		manufacturing_operation, target_warehouse=scrap_warehouse
+	)
+
+
+@frappe.whitelist()
+def create_scrap_wo_stock_entry(se_data, request_id=None):
+	"""Create Scrap Item creator.
+
+	Reuses the Make Receive Entry machinery (SRE validation, MOP caps,
+	idempotency, SRE cancel/recreate) but moves the operation's materials into
+	the department Scrap warehouse via a "Material Transfer (WORK ORDER)" Stock
+	Entry. Item codes are preserved; segregation into the Scrap warehouse is
+	what keeps the stock out of manufacturing/RM pickers.
+	"""
+	if isinstance(se_data, str):
+		se_data = json.loads(se_data)
+
+	mo_name = se_data.get("manufacturing_operation")
+	if not mo_name:
+		frappe.throw(_("Manufacturing Operation is required"))
+
+	department = frappe.db.get_value("Manufacturing Operation", mo_name, "department")
+	scrap_warehouse = _get_department_scrap_warehouse(department)
+	return create_mr_wo_stock_entry(
+		se_data,
+		request_id=request_id,
+		target_warehouse=scrap_warehouse,
+		stock_entry_type="Material Transfer (WORK ORDER)",
+	)
 
 
 def update_new_mop_wtg(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/recovered_diamond/recovered_diamond.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/recovered_diamond/recovered_diamond.json
@@ -8,7 +8,9 @@
  "field_order": [
   "item",
   "pcs",
-  "weight"
+  "weight",
+  "recovered_pcs",
+  "recovered_weight"
  ],
  "fields": [
   {
@@ -22,13 +24,28 @@
    "fieldname": "pcs",
    "fieldtype": "Int",
    "in_standard_filter": 1,
-   "label": "Pcs"
+   "label": "Pcs",
+   "read_only": 1
   },
   {
    "fieldname": "weight",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Weight "
+   "label": "Weight ",
+   "read_only": 1
+  },
+  {
+   "fieldname": "recovered_pcs",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Recovered Pcs"
+  },
+  {
+   "fieldname": "recovered_weight",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Recovered Weight",
+   "precision": "3"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/jewellery_erpnext/jewellery_erpnext/doctype/recovered_gemstone/recovered_gemstone.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/recovered_gemstone/recovered_gemstone.json
@@ -8,7 +8,9 @@
  "field_order": [
   "item",
   "pcs",
-  "weight"
+  "weight",
+  "recovered_pcs",
+  "recovered_weight"
  ],
  "fields": [
   {
@@ -22,13 +24,28 @@
    "fieldname": "pcs",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Pcs"
+   "label": "Pcs",
+   "read_only": 1
   },
   {
    "fieldname": "weight",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Weight "
+   "label": "Weight ",
+   "read_only": 1
+  },
+  {
+   "fieldname": "recovered_pcs",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Recovered Pcs"
+  },
+  {
+   "fieldname": "recovered_weight",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Recovered Weight",
+   "precision": "3"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.js
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.js
@@ -143,14 +143,26 @@ frappe.ui.form.on("Refining Entry", {
 
 	// --- Physical verification ---
 	physical_quantity(frm) {
-		if (frm.doc.refining_type === "Dust Refining") {
+		if (frm.doc.refining_type !== "Dust Refining") return;
+
+		const recompute = () => {
 			let diff = flt(frm.doc.physical_quantity) - flt(frm.doc.system_quantity);
 			frm.set_value("difference_quantity", diff);
-			if (diff > 0) {
-				frm.set_value("additional_dust_qty", diff);
-			} else {
-				frm.set_value("additional_dust_qty", 0);
-			}
+			frm.set_value("additional_dust_qty", diff > 0 ? diff : 0);
+		};
+
+		// Refinery Change Step 2: auto-fetch System Quantity from the Scrap warehouse
+		// for comparison once a physical quantity is entered.
+		if (frm.doc.warehouse || frm.doc.multiple_department) {
+			frm.call("fetch_dust_balance")
+				.then((r) => {
+					if (r && r.message !== undefined && r.message !== null) {
+						frm.set_value("system_quantity", r.message);
+					}
+				})
+				.finally(recompute);
+		} else {
+			recompute();
 		}
 	},
 
@@ -198,27 +210,30 @@ frappe.ui.form.on("Refining Entry", {
 
 		if (show_dust_btn) {
 			frm.add_custom_button(__("Fetch Dust Balance"), () => {
-				if (!frm.doc.warehouse) {
+				if (!frm.doc.warehouse && !frm.doc.multiple_department) {
 					frappe.msgprint(__("Please select a Source Warehouse first."));
 					return;
 				}
-				frappe.db
-					.get_value(
-						"Bin",
-						{
-							item_code: frm.doc.loss_item,
-							warehouse: frm.doc.warehouse,
-						},
-						"actual_qty"
-					)
-					.then((r) => {
-						let qty = r.message && r.message.actual_qty ? r.message.actual_qty : 0;
-						frm.set_value("system_quantity", qty);
+				frm.call("fetch_dust_balance").then((r) => {
+					if (r && r.message !== undefined && r.message !== null) {
+						frm.set_value("system_quantity", r.message);
 						frappe.show_alert({
-							message: __("System Qty updated to: {0}", [qty]),
+							message: __("System Qty updated to: {0}", [r.message]),
 							indicator: "green",
 						});
-					});
+					}
+				});
+			});
+
+			// Refinery Change Step 3: populate the Material Items table with all
+			// available scrap materials (grouped by item group) from the Scrap warehouse.
+			frm.add_custom_button(__("Fetch Scrap Materials"), () => {
+				if (frm.is_new()) {
+					frappe.msgprint(__("Please save the entry first."));
+					return;
+				}
+				frappe.show_alert(__("Fetching scrap materials..."));
+				frm.call("fetch_dust_materials").then(() => frm.reload_doc());
 			});
 		}
 
@@ -260,7 +275,15 @@ frappe.ui.form.on("Refining Entry", {
 												label: "Item Code",
 												in_list_view: 1,
 												read_only: 1,
-												columns: 3,
+												columns: 2,
+											},
+											{
+												fieldtype: "Data",
+												fieldname: "item_group",
+												label: "Item Group",
+												in_list_view: 1,
+												read_only: 1,
+												columns: 2,
 											},
 											{
 												fieldtype: "Data",
@@ -268,7 +291,15 @@ frappe.ui.form.on("Refining Entry", {
 												label: "Warehouse",
 												in_list_view: 1,
 												read_only: 1,
-												columns: 3,
+												columns: 2,
+											},
+											{
+												fieldtype: "Data",
+												fieldname: "batch_no",
+												label: "Batch",
+												in_list_view: 1,
+												read_only: 1,
+												columns: 2,
 											},
 											{
 												fieldtype: "Float",
@@ -296,7 +327,9 @@ frappe.ui.form.on("Refining Entry", {
 										selected.forEach((row) => {
 											let child = frm.add_child("material_items");
 											child.item_code = row.item_code;
+											child.item_group = row.item_group;
 											child.warehouse = row.warehouse;
+											child.batch_no = row.batch_no;
 											child.qty = row.qty;
 											child.uom = row.uom;
 											child.purity = row.purity;
@@ -467,14 +500,15 @@ frappe.ui.form.on("Refining Entry", {
 	},
 
 	render_raw_material_html(frm) {
-		if (frm.doc.refining_type === "Work Order Refining" && !frm.is_new()) {
+		const field = frm.get_field("raw_material_html");
+		if (!field) return;
+		const types = ["Work Order Refining", "Serial Number Refining", "Dust Refining", "Scrap Refining"];
+		if (!frm.is_new() && types.includes(frm.doc.refining_type)) {
 			frm.call("get_linked_stock_entries_html").then((r) => {
-				if (r.message) {
-					frm.get_field("raw_material_html").$wrapper.html(r.message);
-				}
+				field.$wrapper.html(r.message || "");
 			});
 		} else {
-			frm.get_field("raw_material_html").$wrapper.html("");
+			field.$wrapper.html("");
 		}
 	},
 });

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.js
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.js
@@ -43,10 +43,24 @@ frappe.ui.form.on("Refining Entry", {
 		}));
 	},
 
+	onload(frm) {
+		// Default the Source Department from the logged-in user's Employee record so
+		// refining is scoped to the user's own department (server-side validate is the
+		// authoritative safety net; this is UX only).
+		if (frm.is_new() && !frm.doc.department) {
+			frappe.db.get_value("Employee", { user_id: frappe.session.user }, "department").then((r) => {
+				if (r.message && r.message.department) {
+					frm.set_value("department", r.message.department);
+				}
+			});
+		}
+	},
+
 	refresh(frm) {
 		frm.trigger("set_field_visibility");
 		frm.trigger("add_action_buttons");
 		frm.trigger("render_raw_material_html");
+		frm.trigger("set_recovery_grid_editability");
 
 		// Suppress Frappe Workflow's auto-generated action buttons on submitted docs,
 		// AND on child duplicate entries (which rely entirely on custom processing buttons).
@@ -113,6 +127,22 @@ frappe.ui.form.on("Refining Entry", {
 					}
 				});
 		}
+	},
+
+	set_recovery_grid_editability(frm) {
+		// Only the recovered_pcs / recovered_weight columns are operator-editable, and
+		// only while recovery is being entered (on the child processing entry). The
+		// present pcs/weight columns stay read-only (they are the seeded reference).
+		const editable =
+			!!frm.doc.parent_refining_entry &&
+			["Refining In Progress", "Recovery Entered"].includes(frm.doc.status);
+		["recovered_diamond", "recovered_gemstone"].forEach((table) => {
+			const grid = frm.fields_dict[table] && frm.fields_dict[table].grid;
+			if (!grid) return;
+			grid.update_docfield_property("recovered_pcs", "read_only", editable ? 0 : 1);
+			grid.update_docfield_property("recovered_weight", "read_only", editable ? 0 : 1);
+			grid.refresh();
+		});
 	},
 
 	// --- Barcode scan handlers ---

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.json
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.json
@@ -24,8 +24,11 @@
   "scan_mwo",
   "scan_serial_no",
    "scan_scrap_qr",
+  "scrap_item",
+  "work_order_action",
   "mwo_details",
   "serial_no_details",
+  "raw_material_html",
   "section_break_dust",
   "date_from",
   "date_to",
@@ -205,6 +208,25 @@
    "fieldtype": "Data",
    "label": "Scan Scrap QR",
    "options": "Barcode"
+  },
+  {
+   "depends_on": "eval:doc.refining_type=='Scrap Refining'",
+   "fieldname": "scrap_item",
+   "fieldtype": "Link",
+   "label": "Scrap Item",
+   "options": "Item"
+  },
+  {
+   "depends_on": "eval:doc.refining_type=='Work Order Refining'",
+   "fieldname": "work_order_action",
+   "fieldtype": "Select",
+   "label": "Work Order Action After Refining",
+   "options": "\nCancel Work Order\nTransfer for Recasting"
+  },
+  {
+   "fieldname": "raw_material_html",
+   "fieldtype": "HTML",
+   "label": "Raw Materials"
   },
   {
    "depends_on": "eval:doc.refining_type=='Work Order Refining'",
@@ -570,7 +592,7 @@
    "role": "All"
   }
  ],
- "queue_in_background": 1,
+ "queue_in_background": 0,
  "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt
+from frappe.utils import cint, flt
 
 # Roles allowed to drive the refining department processing actions
 REFINING_ROLES = ["Refining User", "Refining Manager", "System Manager"]
@@ -21,13 +21,16 @@ class RefiningEntry(Document):
 	def validate(self):
 		self.set_naming_series()
 		self.validate_configuration()
+		self.set_source_department_from_user()
 		self.validate_warehouse()
+		self.validate_source_department_match()
 		self.validate_quantities()
 		self.calculate_totals()
 		self.allocate_batches_in_table()
 
 		if self.status == "Recovery Entered":
 			self.validate_recovery_distribution()
+			self.validate_recovered_non_metal()
 
 	def before_submit(self):
 		if not self.refining_warehouse:
@@ -78,6 +81,62 @@ class RefiningEntry(Document):
 			frappe.throw(
 				_("Choose either Multiple Operations OR Multiple Department, not both.")
 			)
+
+	def set_source_department_from_user(self):
+		"""Default the Source Department from the logged-in user's Employee record.
+		This scopes refining to the user's own department (it also drives the source
+		warehouse via validate_warehouse). A manually chosen department is preserved,
+		and a missing Employee record is not an error."""
+		if self.department:
+			return
+		dept = frappe.db.get_value(
+			"Employee", {"user_id": frappe.session.user}, "department"
+		)
+		if dept:
+			self.department = dept
+
+	def validate_source_department_match(self):
+		"""Refining is only allowed for material belonging to the Source Department.
+		- Work Order Refining: every scanned MWO's department must match.
+		- Serial Number Refining: each serial's current warehouse department must match.
+		Enforced defensively here so API-created entries (which bypass the scan
+		handlers) are also validated."""
+		if not self.department:
+			return
+
+		if self.refining_type == "Work Order Refining":
+			for row in self.mwo_details:
+				if not row.manufacturing_work_order:
+					continue
+				mwo_dept = frappe.db.get_value(
+					"Manufacturing Work Order",
+					row.manufacturing_work_order,
+					"department",
+				)
+				if mwo_dept and mwo_dept != self.department:
+					frappe.throw(
+						_(
+							"MWO {0} belongs to department {1}, which does not match "
+							"the Source Department {2}. Refining is not allowed."
+						).format(
+							row.manufacturing_work_order, mwo_dept, self.department
+						)
+					)
+		elif self.refining_type == "Serial Number Refining":
+			for row in self.serial_no_details:
+				if not row.serial_number:
+					continue
+				wh = frappe.db.get_value("Serial No", row.serial_number, "warehouse")
+				sn_dept = (
+					frappe.db.get_value("Warehouse", wh, "department") if wh else None
+				)
+				if sn_dept and sn_dept != self.department:
+					frappe.throw(
+						_(
+							"Serial No {0} belongs to department {1}, which does not "
+							"match the Source Department {2}. Refining is not allowed."
+						).format(row.serial_number, sn_dept, self.department)
+					)
 
 	def validate_warehouse(self):
 		if self.refining_department and not self.refining_warehouse:
@@ -180,7 +239,9 @@ class RefiningEntry(Document):
 				gold.refining_gold_weight
 			)
 
-		self.refining_loss = self.gross_pure_weight - self.refined_fine_weight
+		# Clamp at 0: recovered 24KT gold can slightly exceed the computed pure input
+		# (rounding / assay variance) and must never book a negative loss.
+		self.refining_loss = max(self.gross_pure_weight - self.refined_fine_weight, 0.0)
 
 		if self.expected_recovery > 0:
 			self.recovery_percentage = (
@@ -245,31 +306,58 @@ class RefiningEntry(Document):
 					child.set(k, v)
 
 	def validate_recovery_distribution(self):
-		# Compare like-for-like: recovered GOLD (grams) against GOLD input (grams).
+		# Refining always yields pure 24KT gold, so the recovered gold is compared against
+		# the PURE gold content of the input (gross_pure_weight), not the gross input weight.
 		# Diamonds/gemstones are carried 1:1 from the source/BOM, so they are not part
 		# of this metal ceiling (they are in different units and cannot be "over-recovered").
 		total_recovered_gold = sum(
 			flt(gold.refining_gold_weight) for gold in self.refined_gold
 		)
 
-		if self.refining_type == "Serial Number Refining":
-			# net metal weight is the refinable gold input basis (consistent with
-			# generate_recovery_table / distribute_recovered_gold)
-			gold_input = sum(flt(row.net_weight) for row in self.serial_no_details)
-		else:
-			gold_input = sum(
-				flt(item.qty)
-				for item in self.material_items
-				if self.is_gold_item(item.item_code)
-			)
+		# gross_pure_weight is the pure 24KT-equivalent of the input, set by
+		# calculate_totals / _recalculate_and_persist_totals for both refining types.
+		pure_gold_input = flt(self.gross_pure_weight)
 
-		# Allow a 0.1 margin for precision/rounding differences
-		if total_recovered_gold > gold_input + 0.1:
+		# Allow a 0.1 margin for precision/rounding/assay differences
+		if total_recovered_gold > pure_gold_input + 0.1:
 			frappe.throw(
 				_(
-					"Recovered gold weight ({0}) cannot exceed gold input weight ({1})."
-				).format(flt(total_recovered_gold, 3), flt(gold_input, 3))
+					"Recovered 24KT gold weight ({0}) cannot exceed the pure gold "
+					"input weight ({1})."
+				).format(flt(total_recovered_gold, 3), flt(pure_gold_input, 3))
 			)
+
+	def validate_recovered_non_metal(self):
+		"""At Recovery Entered, the recovered diamond/gemstone amounts entered by the
+		operator cannot exceed the amounts actually present (seeded from the MWO/BOM).
+		Applies to both Work Order and Serial Number refining."""
+		for label, rows in (
+			("Diamond", self.recovered_diamond),
+			("Gemstone", self.recovered_gemstone),
+		):
+			for row in rows:
+				# sub-carat weights use a 0.001 margin (precision 3)
+				if flt(row.recovered_weight) > flt(row.weight) + 0.001:
+					frappe.throw(
+						_(
+							"Recovered {0} weight ({1}) for {2} cannot exceed the "
+							"available weight ({3})."
+						).format(
+							label,
+							flt(row.recovered_weight, 3),
+							row.item,
+							flt(row.weight, 3),
+						)
+					)
+				if cint(row.recovered_pcs) > cint(row.pcs):
+					frappe.throw(
+						_(
+							"Recovered {0} pcs ({1}) for {2} cannot exceed the "
+							"available pcs ({3})."
+						).format(
+							label, cint(row.recovered_pcs), row.item, cint(row.pcs)
+						)
+					)
 
 	# --- Action Handlers (Whitelisted for Client Scripts) ---
 
@@ -346,11 +434,21 @@ class RefiningEntry(Document):
 				"qty",
 				"metal_weight",
 				"manufacturing_operation",
+				"department",
 			],
 			as_dict=True,
 		)
 		if not mwo:
 			frappe.throw(_("Manufacturing Work Order {0} not found.").format(barcode))
+
+		# Refining is only allowed for MWOs of the user's own (Source) department.
+		if self.department and mwo.department and mwo.department != self.department:
+			frappe.throw(
+				_(
+					"MWO {0} belongs to department {1}, which does not match the "
+					"Source Department {2}. Refining is not allowed."
+				).format(mwo.name, mwo.department, self.department)
+			)
 
 		# Check if MWO already added
 		for row in self.mwo_details:
@@ -390,6 +488,19 @@ class RefiningEntry(Document):
 					barcode, self.warehouse
 				)
 			)
+
+		# Refining is only allowed for serials of the user's own (Source) department.
+		if self.department and serial_no.warehouse:
+			sn_dept = frappe.db.get_value(
+				"Warehouse", serial_no.warehouse, "department"
+			)
+			if sn_dept and sn_dept != self.department:
+				frappe.throw(
+					_(
+						"Serial Number {0} belongs to department {1}, which does not "
+						"match the Source Department {2}. Refining is not allowed."
+					).format(barcode, sn_dept, self.department)
+				)
 
 		for row in self.serial_no_details:
 			if row.serial_number == serial_no.name:
@@ -672,6 +783,11 @@ class RefiningEntry(Document):
 		total_input_weight = sum(
 			flt(row.input_weight) for row in self.gold_recovery_details
 		)
+		# Refining yields pure 24KT gold, so the entered recovery is capped by the PURE
+		# gold content of the input, not the gross input weight.
+		total_pure_input_weight = sum(
+			flt(row.pure_gold_weight) for row in self.gold_recovery_details
+		)
 		total_recovered_weight = self.get_recovered_gold_total(total_recovered_weight)
 		if total_input_weight <= 0:
 			frappe.throw(_("Gold input weight is required for proportional recovery."))
@@ -679,11 +795,14 @@ class RefiningEntry(Document):
 			frappe.throw(
 				_("Recovered gold weight is required for proportional recovery.")
 			)
-		if total_recovered_weight > total_input_weight + 0.1:
+		if total_recovered_weight > total_pure_input_weight + 0.1:
 			frappe.throw(
 				_(
-					"Recovered gold weight ({0}) cannot exceed input gold weight ({1})."
-				).format(total_recovered_weight, total_input_weight)
+					"Recovered 24KT gold weight ({0}) cannot exceed the pure gold "
+					"input weight ({1})."
+				).format(
+					flt(total_recovered_weight, 3), flt(total_pure_input_weight, 3)
+				)
 			)
 
 		# Calculate and persist recovery details row by row via db_set
@@ -741,12 +860,9 @@ class RefiningEntry(Document):
 			if metal_purity and not frappe.db.exists("Attribute Value", metal_purity):
 				metal_purity = None
 
-			pure_weight = flt(row.recovered_weight)
-			if row.get("purity_percentage"):
-				pure_weight = flt(row.recovered_weight) * (
-					flt(row.purity_percentage) / 100.0
-				)
-			pure_weight = flt(pure_weight, 3)
+			# The operator-entered recovered gold is already pure 24KT, so the recovered
+			# weight IS the pure fine weight (no input-karat reduction).
+			pure_weight = flt(row.recovered_weight, 3)
 
 			child = self.append(
 				"refined_gold",
@@ -786,7 +902,9 @@ class RefiningEntry(Document):
 				gold.refining_gold_weight
 			)
 
-		refining_loss = gross_pure_weight - refined_fine_weight
+		# Clamp at 0: recovered 24KT gold can slightly exceed the computed pure input
+		# (rounding / assay variance) and must never book a negative loss.
+		refining_loss = max(gross_pure_weight - refined_fine_weight, 0.0)
 		recovery_percentage = (
 			(refined_fine_weight / expected_recovery) * 100.0
 			if expected_recovery > 0
@@ -808,6 +926,7 @@ class RefiningEntry(Document):
 	def verify_recovery(self):
 		self.require_refining_role(REFINING_MANAGER_ROLES, _("verify recovery"))
 		self.validate_recovery_distribution()
+		self.validate_recovered_non_metal()
 		self.db_set("status", "Recovery Verified")
 
 	@frappe.whitelist()
@@ -980,6 +1099,9 @@ class RefiningEntry(Document):
 			docname=self.name,
 		)
 		for dia in self.recovered_diamond:
+			dia_qty = flt(dia.recovered_weight)
+			if dia_qty <= 0:
+				continue
 			conv_item = self.convert_diamond_item_code(dia.item)
 			batch_no = None
 			for b in self.batch_tracking:
@@ -994,7 +1116,7 @@ class RefiningEntry(Document):
 				"items",
 				{
 					"item_code": conv_item,
-					"qty": dia.weight,
+					"qty": dia_qty,
 					"uom": "Carat",
 					"s_warehouse": self.refining_warehouse,
 					"t_warehouse": target_warehouse,
@@ -1011,6 +1133,9 @@ class RefiningEntry(Document):
 			docname=self.name,
 		)
 		for gem in self.recovered_gemstone:
+			gem_qty = flt(gem.recovered_weight)
+			if gem_qty <= 0:
+				continue
 			batch_no = None
 			for b in self.batch_tracking:
 				if b.output_item == gem.item:
@@ -1024,7 +1149,7 @@ class RefiningEntry(Document):
 				"items",
 				{
 					"item_code": gem.item,
-					"qty": gem.weight,
+					"qty": gem_qty,
 					"uom": "Carat",
 					"s_warehouse": self.refining_warehouse,
 					"t_warehouse": target_warehouse,
@@ -1145,6 +1270,80 @@ class RefiningEntry(Document):
 			se.insert(ignore_permissions=True)
 			se.submit()
 			self.db_set("material_transfer_se", se.name)
+
+		# Once the MWO material is physically transferred into the refinery, release its
+		# stock reservations and zero the source MWO / pending-operation weights.
+		if self.refining_type == "Work Order Refining":
+			# Cancel SREs BEFORE touching MOP / Manufacturing Operation rows to respect
+			# the canonical lock order (... -> SRE -> SLE -> MOP Log -> Manufacturing Operation).
+			self._cancel_source_mwo_sres()
+			self._zero_source_mwo_and_mop_weights()
+
+	# Weight buckets zeroed on transfer to the refinery. MWO and Manufacturing Operation
+	# share the same set (MOP additionally carries gemstone_wt_in_gram).
+	_MWO_WEIGHT_FIELDS = (
+		"gross_wt",
+		"net_wt",
+		"finding_wt",
+		"diamond_wt",
+		"gemstone_wt",
+		"other_wt",
+		"received_gross_wt",
+		"received_net_wt",
+		"loss_wt",
+		"diamond_wt_in_gram",
+		"diamond_pcs",
+		"gemstone_pcs",
+	)
+
+	def _cancel_source_mwo_sres(self):
+		"""Cancel the active Stock Reservation Entries linked to each refined MWO.
+		SREs are linked to the MWO via the custom `manufacturing_work_order` Data field
+		(SRE.voucher_no is the shared Sales Order, so we must filter by MWO and pass
+		sre_list explicitly)."""
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+			cancel_stock_reservation_entries,
+		)
+
+		names = []
+		for row in self.mwo_details:
+			if not row.manufacturing_work_order:
+				continue
+			names += frappe.db.get_all(
+				"Stock Reservation Entry",
+				filters={
+					"manufacturing_work_order": row.manufacturing_work_order,
+					"docstatus": 1,
+					"status": ["not in", ("Cancelled", "Delivered")],
+				},
+				pluck="name",
+			)
+		if names:
+			cancel_stock_reservation_entries(sre_list=names, notify=False)
+
+	def _zero_source_mwo_and_mop_weights(self):
+		"""Zero the weight buckets on each refined MWO and its last not-started
+		Manufacturing Operation, since the material has left for the refinery."""
+		zero_map = {field: 0 for field in self._MWO_WEIGHT_FIELDS}
+		for row in self.mwo_details:
+			mwo = row.manufacturing_work_order
+			if not mwo:
+				continue
+			frappe.db.set_value("Manufacturing Work Order", mwo, zero_map)
+
+			# The last operation that has not started manufacturing yet.
+			last_not_started_mop = frappe.db.get_value(
+				"Manufacturing Operation",
+				{"manufacturing_work_order": mwo, "status": "Not Started"},
+				"name",
+				order_by="creation desc",
+			)
+			if last_not_started_mop:
+				mop_zero_map = dict(zero_map)
+				mop_zero_map["gemstone_wt_in_gram"] = 0
+				frappe.db.set_value(
+					"Manufacturing Operation", last_not_started_mop, mop_zero_map
+				)
 
 	def create_dust_opening_receipt_se(self):
 		dust_item = self.loss_item
@@ -1332,13 +1531,17 @@ class RefiningEntry(Document):
 			)
 
 		for dia in self.recovered_diamond:
+			# Output the amount actually recovered by the operator, not the present amount.
+			dia_qty = flt(dia.recovered_weight)
+			if dia_qty <= 0:
+				continue
 			conv_item = self.convert_diamond_item_code(dia.item)
 			new_batch = self._auto_create_batch(conv_item)
 			se.append(
 				"items",
 				{
 					"item_code": conv_item,
-					"qty": dia.weight,
+					"qty": dia_qty,
 					"uom": "Carat",
 					"t_warehouse": self.refining_warehouse,
 					"batch_no": new_batch,
@@ -1353,17 +1556,21 @@ class RefiningEntry(Document):
 						"output_item": conv_item,
 						"output_batch": new_batch,
 						"output_warehouse": self.refining_warehouse,
-						"output_qty": dia.weight,
+						"output_qty": dia_qty,
 					}
 				)
 
 		for gem in self.recovered_gemstone:
+			# Output the amount actually recovered by the operator, not the present amount.
+			gem_qty = flt(gem.recovered_weight)
+			if gem_qty <= 0:
+				continue
 			new_batch = self._auto_create_batch(gem.item)
 			se.append(
 				"items",
 				{
 					"item_code": gem.item,
-					"qty": gem.weight,
+					"qty": gem_qty,
 					"uom": "Carat",
 					"t_warehouse": self.refining_warehouse,
 					"batch_no": new_batch,
@@ -1378,7 +1585,7 @@ class RefiningEntry(Document):
 						"output_item": gem.item,
 						"output_batch": new_batch,
 						"output_warehouse": self.refining_warehouse,
-						"output_qty": gem.weight,
+						"output_qty": gem_qty,
 					}
 				)
 
@@ -1755,7 +1962,13 @@ class RefiningEntry(Document):
 						):
 							self.append(
 								"recovered_diamond",
-								{"item": bi.item_code, "weight": bi.qty, "pcs": 1},
+								{
+									"item": bi.item_code,
+									"weight": bi.qty,
+									"pcs": 1,
+									"recovered_weight": bi.qty,
+									"recovered_pcs": 1,
+								},
 							)
 							diamond_items.add(bi.item_code)
 						elif (
@@ -1764,7 +1977,13 @@ class RefiningEntry(Document):
 						):
 							self.append(
 								"recovered_gemstone",
-								{"item": bi.item_code, "weight": bi.qty, "pcs": 1},
+								{
+									"item": bi.item_code,
+									"weight": bi.qty,
+									"pcs": 1,
+									"recovered_weight": bi.qty,
+									"recovered_pcs": 1,
+								},
 							)
 							gemstone_items.add(bi.item_code)
 		else:
@@ -1775,7 +1994,13 @@ class RefiningEntry(Document):
 				):
 					self.append(
 						"recovered_diamond",
-						{"item": item.item_code, "weight": item.qty, "pcs": 1},
+						{
+							"item": item.item_code,
+							"weight": item.qty,
+							"pcs": 1,
+							"recovered_weight": item.qty,
+							"recovered_pcs": 1,
+						},
 					)
 					diamond_items.add(item.item_code)
 				elif (
@@ -1784,7 +2009,13 @@ class RefiningEntry(Document):
 				):
 					self.append(
 						"recovered_gemstone",
-						{"item": item.item_code, "weight": item.qty, "pcs": 1},
+						{
+							"item": item.item_code,
+							"weight": item.qty,
+							"pcs": 1,
+							"recovered_weight": item.qty,
+							"recovered_pcs": 1,
+						},
 					)
 					gemstone_items.add(item.item_code)
 
@@ -1874,13 +2105,9 @@ class RefiningEntry(Document):
 			if metal_purity and not frappe.db.exists("Attribute Value", metal_purity):
 				metal_purity = None
 
-			pure_weight = flt(row.recovered_weight)
-			if row.get("purity_percentage"):
-				pure_weight = flt(row.recovered_weight) * (
-					flt(row.purity_percentage) / 100.0
-				)
-
-			pure_weight = flt(pure_weight, 3)
+			# The operator-entered recovered gold is already pure 24KT, so the recovered
+			# weight IS the pure fine weight (no input-karat reduction).
+			pure_weight = flt(row.recovered_weight, 3)
 
 			self.append(
 				"refined_gold",

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
@@ -3,8 +3,21 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
 
+# Roles allowed to drive the refining department processing actions
+REFINING_ROLES = ["Refining User", "Refining Manager", "System Manager"]
+
+# Manager-level roles for the approval/finalisation steps (verify, complete,
+# transfer). Per the Refining approval matrix these are restricted to managers;
+# `require_refining_role` still auto-passes for Administrator.
+REFINING_MANAGER_ROLES = ["Refining Manager", "System Manager"]
+
 
 class RefiningEntry(Document):
+	def before_insert(self):
+		# Set the series before autoname runs (autoname happens before validate), so
+		# programmatic/API creation gets the correct per-type series, not just the UI.
+		self.set_naming_series()
+
 	def validate(self):
 		self.set_naming_series()
 		self.validate_configuration()
@@ -17,10 +30,20 @@ class RefiningEntry(Document):
 			self.validate_recovery_distribution()
 
 	def before_submit(self):
+		if not self.refining_warehouse:
+			frappe.throw(
+				_(
+					"Refining Warehouse could not be determined for Refining Department {0}."
+				).format(frappe.bold(self.refining_department))
+			)
 		if self.refining_type == "Dust Refining":
 			if not self.material_items:
 				self.build_material_table()
 			self.ensure_dust_opening_material_row()
+		if not self.material_items:
+			frappe.throw(
+				_("No materials to refine. Add or fetch materials before submitting.")
+			)
 
 	def on_submit(self):
 		if self.parent_refining_entry:
@@ -66,16 +89,18 @@ class RefiningEntry(Document):
 				},
 				"name",
 			)
-		if not self.refining_warehouse:
-			pass
 
 		if self.department:
 			is_final_polish = "Final Polish" in self.department
 			if not self.warehouse or is_final_polish:
-				# Dust and Scrap refining: source is from Scrap warehouse
-				# MWO and Serial Number refining: source is from Manufacturing warehouse
-				if self.refining_type in ("Dust Refining", "Scrap Refining"):
+				# Dust refining: source is from the department Scrap warehouse.
+				# Scrap refining: scrap is now received into the department RM warehouse
+				#   as a designated Scrap Item (per Refinery Change SOP), so source is RM.
+				# MWO and Serial Number refining: source is from Manufacturing warehouse.
+				if self.refining_type == "Dust Refining":
 					wh_type = "Scrap"
+				elif self.refining_type == "Scrap Refining":
+					wh_type = "Raw Material"
 				elif self.refining_type == "Work Order Refining":
 					wh_type = "Manufacturing"
 				elif self.refining_type == "Serial Number Refining":
@@ -83,12 +108,40 @@ class RefiningEntry(Document):
 				else:
 					wh_type = "Manufacturing"
 
-				if is_final_polish and self.refining_type != "Work Order Refining":
+				if is_final_polish and self.refining_type not in (
+					"Work Order Refining",
+					"Scrap Refining",
+				):
 					wh_type = "Scrap"
 
 				self.warehouse = frappe.db.get_value(
 					"Warehouse",
 					{"department": self.department, "warehouse_type": wh_type},
+					"name",
+				)
+
+		# Auto-resolve the Refining Scrap Warehouse where leftover dust is moved
+		# after refining (Refining Scrap Warehouse per SOP). Prefer a Scrap-type
+		# warehouse on the refining department, then any company Scrap warehouse.
+		if not self.scrap_warehouse:
+			self.scrap_warehouse = frappe.db.get_value(
+				"Warehouse",
+				{"department": self.refining_department, "warehouse_type": "Scrap"},
+				"name",
+			)
+			if not self.scrap_warehouse and self.company:
+				self.scrap_warehouse = frappe.db.get_value(
+					"Warehouse",
+					{
+						"company": self.company,
+						"warehouse_type": "Scrap",
+						"is_group": 0,
+						"name": ["like", "%Refin%"],
+					},
+					"name",
+				) or frappe.db.get_value(
+					"Warehouse",
+					{"company": self.company, "warehouse_type": "Scrap", "is_group": 0},
 					"name",
 				)
 
@@ -153,17 +206,24 @@ class RefiningEntry(Document):
 					"Item", item.item_code, "has_batch_no"
 				)
 
+		# Skip the (expensive) rebuild entirely when no batched row needs FIFO
+		# allocation — avoids re-querying batches and reshuffling rows on every save.
+		needs_alloc = any(
+			item_batch_map.get(i.item_code)
+			and not i.batch_no
+			and not self.is_dust_opening_item(i)
+			for i in self.material_items
+		)
+		if not needs_alloc:
+			return
+
 		for item in self.material_items:
 			if self.is_dust_opening_item(item):
 				new_items.append(item)
 				continue
 
 			has_batch = item_batch_map.get(item.item_code)
-			s_wh = (
-				item.warehouse
-				or getattr(self, "source_warehouse", None)
-				or getattr(self, "warehouse", None)
-			)
+			s_wh = item.warehouse or self.warehouse
 
 			if has_batch and not item.batch_no:
 				allocations = self.allocate_fifo_batches(item.item_code, s_wh, item.qty)
@@ -185,28 +245,30 @@ class RefiningEntry(Document):
 					child.set(k, v)
 
 	def validate_recovery_distribution(self):
-		total_recovered = 0.0
-		for gold in self.refined_gold:
-			total_recovered += flt(gold.refining_gold_weight)
+		# Compare like-for-like: recovered GOLD (grams) against GOLD input (grams).
+		# Diamonds/gemstones are carried 1:1 from the source/BOM, so they are not part
+		# of this metal ceiling (they are in different units and cannot be "over-recovered").
+		total_recovered_gold = sum(
+			flt(gold.refining_gold_weight) for gold in self.refined_gold
+		)
 
-		for dia in self.recovered_diamond:
-			total_recovered += flt(dia.weight)
-
-		for gem in self.recovered_gemstone:
-			total_recovered += flt(gem.weight)
-
-		total_input = 0.0
 		if self.refining_type == "Serial Number Refining":
-			total_input = sum(flt(row.gross_weight) for row in self.serial_no_details)
+			# net metal weight is the refinable gold input basis (consistent with
+			# generate_recovery_table / distribute_recovered_gold)
+			gold_input = sum(flt(row.net_weight) for row in self.serial_no_details)
 		else:
-			total_input = sum(flt(item.qty) for item in self.material_items)
+			gold_input = sum(
+				flt(item.qty)
+				for item in self.material_items
+				if self.is_gold_item(item.item_code)
+			)
 
 		# Allow a 0.1 margin for precision/rounding differences
-		if total_recovered > total_input + 0.1:
+		if total_recovered_gold > gold_input + 0.1:
 			frappe.throw(
 				_(
-					"Total recovered weight ({0}) cannot exceed total input weight ({1})."
-				).format(total_recovered, total_input)
+					"Recovered gold weight ({0}) cannot exceed gold input weight ({1})."
+				).format(flt(total_recovered_gold, 3), flt(gold_input, 3))
 			)
 
 	# --- Action Handlers (Whitelisted for Client Scripts) ---
@@ -243,15 +305,48 @@ class RefiningEntry(Document):
 			)
 			self.system_quantity = sum(flt(b.actual_qty) for b in bins)
 
+		# Return the computed value; the caller decides whether to persist it. This keeps
+		# the method usable as a live lookup on physical-quantity entry without forcing a
+		# save (which would conflict with unsaved edits).
+		return flt(self.system_quantity, 3)
+
+	@frappe.whitelist()
+	def fetch_dust_materials(self):
+		"""Populate the Material Items table with all available scrap materials
+		(grouped by item group) from the department Scrap warehouse for Dust Refining.
+		Consumable rows already added manually are preserved."""
+		if self.refining_type != "Dust Refining":
+			frappe.throw(_("This action is only available for Dust Refining."))
+
+		# Preserve any manually added consumable rows
+		consumables = [
+			row.as_dict()
+			for row in self.material_items
+			if row.get("is_consumable") or row.get("source_type") == "Consumable"
+		]
+
+		self.build_material_table()
+
+		for c in consumables:
+			c.pop("name", None)
+			self.append("material_items", c)
+
 		self.save(ignore_permissions=True)
-		return self.system_quantity
+		return len(self.material_items)
 
 	@frappe.whitelist()
 	def scan_mwo_action(self, barcode):
 		mwo = frappe.db.get_value(
 			"Manufacturing Work Order",
 			{"name": barcode},
-			["name", "manufacturing_order", "item_code", "qty", "metal_weight"],
+			[
+				"name",
+				"manufacturing_order",
+				"item_code",
+				"qty",
+				"metal_weight",
+				"manufacturing_operation",
+			],
 			as_dict=True,
 		)
 		if not mwo:
@@ -270,6 +365,7 @@ class RefiningEntry(Document):
 				"item_code": mwo.item_code,
 				"metal_weight": mwo.metal_weight,
 				"pcs": mwo.qty,
+				"manufacturing_operation": mwo.manufacturing_operation,
 			},
 		)
 		self.scan_mwo = ""
@@ -335,7 +431,6 @@ class RefiningEntry(Document):
 		return True
 
 	@frappe.whitelist()
-	@frappe.whitelist()
 	def scan_scrap_qr_action(self, barcode):
 		batch = frappe.db.get_value(
 			"Batch", {"name": barcode}, ["name", "item"], as_dict=True
@@ -361,13 +456,20 @@ class RefiningEntry(Document):
 
 		if self.refining_type == "Work Order Refining":
 			for mwo_row in self.mwo_details:
-				# Fetch materials consumed by this MWO from MOP Log
+				# Fetch materials consumed by this MWO from MOP Log.
+				# Per SOP, only the MWO's CURRENT operation is refined, so scope the
+				# MOP Log to that operation when it is known.
+				mop_filters = {
+					"manufacturing_work_order": mwo_row.manufacturing_work_order,
+					"is_cancelled": 0,
+				}
+				if mwo_row.get("manufacturing_operation"):
+					mop_filters[
+						"manufacturing_operation"
+					] = mwo_row.manufacturing_operation
 				mop_logs = frappe.get_all(
 					"MOP Log",
-					filters={
-						"manufacturing_work_order": mwo_row.manufacturing_work_order,
-						"is_cancelled": 0,
-					},
+					filters=mop_filters,
 					fields=[
 						"item_code",
 						"batch_no",
@@ -445,6 +547,8 @@ class RefiningEntry(Document):
 					"qty": item.qty,
 					"uom": item.uom,
 					"source_type": item.source_type,
+					"is_consumable": item.get("is_consumable"),
+					"item_group": item.get("item_group"),
 					"purity": item.purity,
 					"manufacturing_work_order": item.manufacturing_work_order,
 					"manufacturing_operation": item.manufacturing_operation,
@@ -458,6 +562,7 @@ class RefiningEntry(Document):
 
 	@frappe.whitelist()
 	def receive_materials(self):
+		self.require_refining_role(REFINING_ROLES, _("receive materials"))
 		if self.status != "Submitted":
 			frappe.throw(_("Can only receive materials if status is Submitted."))
 
@@ -484,6 +589,7 @@ class RefiningEntry(Document):
 	@frappe.whitelist()
 	def generate_recovery_table(self, total_recovered_weight=None):
 		"""Distribute gold recovery by input purity proportion."""
+		self.require_refining_role(REFINING_ROLES, _("classify materials"))
 		self.set("gold_recovery_details", [])
 		self.auto_classify_recoverable_non_metal()
 
@@ -559,6 +665,7 @@ class RefiningEntry(Document):
 	@frappe.whitelist()
 	def distribute_recovered_gold(self, total_recovered_weight=None):
 		"""Apply SOP proportional split after actual recovered gold is known."""
+		self.require_refining_role(REFINING_ROLES, _("enter recovered gold"))
 		if not self.gold_recovery_details:
 			self.generate_recovery_table(total_recovered_weight=total_recovered_weight)
 
@@ -699,11 +806,13 @@ class RefiningEntry(Document):
 
 	@frappe.whitelist()
 	def verify_recovery(self):
+		self.require_refining_role(REFINING_MANAGER_ROLES, _("verify recovery"))
 		self.validate_recovery_distribution()
 		self.db_set("status", "Recovery Verified")
 
 	@frappe.whitelist()
 	def complete_refining(self):
+		self.require_refining_role(REFINING_MANAGER_ROLES, _("complete refining"))
 		if self.status != "Recovery Verified":
 			frappe.throw(_("Recovery must be verified before completing."))
 
@@ -730,7 +839,7 @@ class RefiningEntry(Document):
 			docname=self.name,
 		)
 		if self.refining_type == "Work Order Refining":
-			# SOP: Current operation quantity -> 0
+			# SOP: Current operation quantity -> 0 for every refined MWO.
 			for mwo in self.mwo_details:
 				frappe.db.set_value(
 					"Manufacturing Work Order",
@@ -750,6 +859,19 @@ class RefiningEntry(Document):
 						"qty",
 						0,
 					)
+
+			# Work Order cancellation / recasting is advisory only: the chosen action is
+			# recorded on the entry, but the actual Work Order cancel or transfer to the
+			# Casting department is performed manually by Central / Manufacturing.
+			if self.work_order_action:
+				frappe.msgprint(
+					_(
+						"Refining complete. Work Order action '{0}' must be performed "
+						"manually by the Central / Manufacturing department."
+					).format(self.work_order_action),
+					indicator="orange",
+					alert=True,
+				)
 
 		elif self.refining_type == "Serial Number Refining":
 			for sn in self.serial_no_details:
@@ -782,6 +904,9 @@ class RefiningEntry(Document):
 
 	@frappe.whitelist()
 	def transfer_recovered_materials(self):
+		self.require_refining_role(
+			REFINING_MANAGER_ROLES, _("transfer recovered materials")
+		)
 		if self.status != "Completed":
 			frappe.throw(_("Can only transfer if Completed."))
 
@@ -1424,33 +1549,23 @@ class RefiningEntry(Document):
 			from frappe.utils import now_datetime
 
 			ts = now_datetime().strftime("%y%m%d%H%M%S")
-			batch.batch_id = f"{item_code}-RFN-{ts}"
+			# Append a short random suffix to avoid collisions when two batches of the
+			# same item are created within the same second.
+			batch.batch_id = f"{item_code}-RFN-{ts}-{frappe.generate_hash(length=4)}"
 
 		batch.insert()
 		return batch.name
 
 	def _get_available_batch(self, item_code, warehouse):
-		"""Get the most recent available batch for an item in a warehouse (FIFO fallback)."""
-		batches = frappe.db.sql(
-			"""
-			SELECT sle.batch_no, SUM(sle.actual_qty) as qty
-			FROM `tabStock Ledger Entry` sle
-			WHERE sle.item_code = %s
-				AND sle.warehouse = %s
-				AND sle.is_cancelled = 0
-				AND sle.batch_no IS NOT NULL
-				AND sle.batch_no != ''
-			GROUP BY sle.batch_no
-			HAVING SUM(sle.actual_qty) > 0
-			ORDER BY MIN(sle.posting_datetime) DESC
-			LIMIT 1
-			""",
-			(item_code, warehouse),
-			as_dict=True,
+		"""Get an available batch for an item in a warehouse (SBB-aware, FIFO).
+
+		In v16, batch stock lives in the Serial and Batch Bundle, not in
+		Stock Ledger Entry.batch_no, so reuse allocate_fifo_batches which reads both.
+		"""
+		allocs = self.allocate_fifo_batches(
+			item_code, warehouse, 9999999, throw_if_missing=False
 		)
-		if batches:
-			return batches[0].batch_no
-		return None
+		return allocs[0]["batch_no"] if allocs else None
 
 	def _fetch_loss_items_from_dept(self, department):
 		"""Fetch ALL loss items (dust items) from a department's Scrap warehouse."""
@@ -1484,10 +1599,12 @@ class RefiningEntry(Document):
 
 			purity = self.get_item_purity(b.item_code)
 			uom = frappe.db.get_value("Item", b.item_code, "stock_uom") or "Gram"
+			item_group = frappe.db.get_value("Item", b.item_code, "item_group")
 			self.append(
 				"material_items",
 				{
 					"item_code": b.item_code,
+					"item_group": item_group,
 					"warehouse": scrap_wh,
 					"qty": actual_qty,
 					"uom": uom,
@@ -1498,53 +1615,87 @@ class RefiningEntry(Document):
 
 	@frappe.whitelist()
 	def get_scrap_items_balance(self):
-		"""Fetch ALL RM items from Scrap warehouses across all departments to display in Dialog."""
+		"""Fetch available scrap stock from the department warehouse(s).
+
+		Per the Refinery Change SOP, scrap generated during manufacturing is transferred
+		into the department as a designated Scrap Item via the Manufacturing Operation
+		"Create Scrap Item" action, landing in either the department Scrap or Raw Material
+		warehouse. This fetches that stock (optionally filtered by the selected Scrap
+		Item) along with batch details so the user does not have to pick stock manually.
+		"""
 		if self.refining_type != "Scrap Refining":
 			frappe.throw(_("This action is only available for Scrap Refining."))
 
-		scrap_items = []
-		scrap_warehouses = frappe.db.get_all(
-			"Warehouse",
-			filters={
-				"company": self.company,
-				"warehouse_type": "Scrap",
-			},
-			fields=["name"],
-		)
+		# Source from the selected warehouse if known, else all company Raw Material and
+		# Scrap warehouses (the two department sinks scrap can land in).
+		if self.warehouse:
+			rm_warehouses = [frappe._dict(name=self.warehouse)]
+		else:
+			rm_warehouses = frappe.db.get_all(
+				"Warehouse",
+				filters={
+					"company": self.company,
+					"warehouse_type": ["in", ["Raw Material", "Scrap"]],
+					"is_group": 0,
+				},
+				fields=["name"],
+			)
 
-		for wh in scrap_warehouses:
+		bin_filters = {"actual_qty": [">", 0]}
+		if self.scrap_item:
+			bin_filters["item_code"] = self.scrap_item
+
+		scrap_items = []
+		for wh in rm_warehouses:
+			bin_filters["warehouse"] = wh.name
 			bins = frappe.db.get_all(
 				"Bin",
-				filters={"warehouse": wh.name, "actual_qty": [">", 0]},
+				filters=bin_filters,
 				fields=["item_code", "actual_qty"],
 			)
 			for b in bins:
-				actual_qty = flt(b.actual_qty, 3)
+				purity = self.get_item_purity(b.item_code)
+				uom = frappe.db.get_value("Item", b.item_code, "stock_uom") or "Gram"
+				item_group = frappe.db.get_value("Item", b.item_code, "item_group")
+
 				if frappe.db.get_value("Item", b.item_code, "has_batch_no"):
 					allocs = self.allocate_fifo_batches(
 						b.item_code, wh.name, 9999999, throw_if_missing=False
 					)
-					actual_qty = sum([flt(a.get("qty")) for a in allocs])
-
-				if actual_qty <= 0:
-					continue
-
-				purity = self.get_item_purity(b.item_code)
-				uom = frappe.db.get_value("Item", b.item_code, "stock_uom") or "Gram"
-				scrap_items.append(
-					{
-						"item_code": b.item_code,
-						"warehouse": wh.name,
-						"actual_qty": actual_qty,
-						"qty": 0.0,
-						"uom": uom,
-						"purity": purity,
-					}
-				)
+					for a in allocs:
+						aq = flt(a.get("qty"), 3)
+						if aq <= 0:
+							continue
+						scrap_items.append(
+							{
+								"item_code": b.item_code,
+								"item_group": item_group,
+								"warehouse": wh.name,
+								"batch_no": a.get("batch_no"),
+								"actual_qty": aq,
+								"qty": 0.0,
+								"uom": uom,
+								"purity": purity,
+							}
+						)
+				else:
+					actual_qty = flt(b.actual_qty, 3)
+					if actual_qty <= 0:
+						continue
+					scrap_items.append(
+						{
+							"item_code": b.item_code,
+							"item_group": item_group,
+							"warehouse": wh.name,
+							"batch_no": None,
+							"actual_qty": actual_qty,
+							"qty": 0.0,
+							"uom": uom,
+							"purity": purity,
+						}
+					)
 
 		return scrap_items
-
-		self.save(ignore_permissions=True)
 
 	def is_gold_item(self, item_code):
 		variant_of = frappe.db.get_value("Item", item_code, "variant_of")
@@ -1655,7 +1806,6 @@ class RefiningEntry(Document):
 		)
 
 	def get_purity_distribution_maps(self, input_purity_map):
-		# print(input_purity_map)
 		purity_maps = frappe.db.get_all(
 			"Refining Purity Map",
 			fields=[
@@ -1666,7 +1816,6 @@ class RefiningEntry(Document):
 				"metal_purity",
 			],
 		)
-		# print(purity_maps)
 		mapped_percentages = {flt(row.purity_percentage) for row in purity_maps}
 		for purity_percentage in input_purity_map:
 			if purity_percentage in mapped_percentages:
@@ -1751,6 +1900,21 @@ class RefiningEntry(Document):
 				if item.get("source_type") == "Dust" and item.item_code:
 					dust_item = item.item_code
 					break
+		if not dust_item:
+			# For Scrap / Work Order / Serial refining there is no explicit loss item,
+			# so book the remaining quantity (refining loss) against the first input
+			# metal item. SOP: "Remaining quantity -> Dust in Refining Scrap Warehouse".
+			for item in self.material_items:
+				if item.item_code and self.is_gold_item(item.item_code):
+					dust_item = item.item_code
+					break
+		if not dust_item:
+			# Serial refining consumes the FG item (not gold-classified), so fall back to
+			# the recovered metal item code so the loss is still booked as dust.
+			for gold in self.refined_gold:
+				if gold.item_code:
+					dust_item = gold.item_code
+					break
 		return dust_item
 
 	def is_dust_opening_item(self, item):
@@ -1834,6 +1998,15 @@ class RefiningEntry(Document):
 		return item_code
 
 	def get_item_purity(self, item_code):
+		# Memoize within the request: this is called per material row and does up to
+		# three DB lookups, so caching avoids N+1 on large material tables.
+		cache = self.__dict__.setdefault("_purity_cache", {})
+		if item_code in cache:
+			return cache[item_code]
+		cache[item_code] = self._compute_item_purity(item_code)
+		return cache[item_code]
+
+	def _compute_item_purity(self, item_code):
 		purity_records = frappe.db.get_all(
 			"Item Variant Attribute",
 			filters={
@@ -1964,12 +2137,71 @@ class RefiningEntry(Document):
 
 	@frappe.whitelist()
 	def get_linked_stock_entries_html(self):
+		"""Render the source materials as an HTML table.
+
+		For Serial Number refining the FG itself is what physically moves and is repacked,
+		but the SOP asks to display the FG BOM components, so those are shown here for
+		reference. All other types show the consolidated Material Items table.
+		"""
+		from frappe.utils import escape_html
+
+		if self.refining_type == "Serial Number Refining":
+			return self._get_serial_bom_html(escape_html)
+
 		html = "<h4>Raw Materials Consolidate</h4>"
 		if not self.material_items:
 			return html + "<p>No materials found.</p>"
 
-		html += "<table class='table table-bordered'><thead><tr><th>Item Code</th><th>Warehouse</th><th>Qty</th><th>Batch</th></tr></thead><tbody>"
+		html += (
+			"<table class='table table-bordered'><thead><tr>"
+			"<th>Item Code</th><th>Item Group</th><th>Warehouse</th>"
+			"<th>Qty</th><th>UOM</th><th>Batch</th></tr></thead><tbody>"
+		)
 		for item in self.material_items:
-			html += f"<tr><td>{item.item_code}</td><td>{item.warehouse}</td><td>{item.qty}</td><td>{item.batch_no or ''}</td></tr>"
+			html += (
+				f"<tr><td>{escape_html(item.item_code or '')}</td>"
+				f"<td>{escape_html(item.get('item_group') or '')}</td>"
+				f"<td>{escape_html(item.warehouse or '')}</td>"
+				f"<td>{flt(item.qty, 3)}</td>"
+				f"<td>{escape_html(item.uom or '')}</td>"
+				f"<td>{escape_html(item.batch_no or '')}</td></tr>"
+			)
+		html += "</tbody></table>"
+		return html
+
+	def _get_serial_bom_html(self, escape_html):
+		html = "<h4>FG BOM Materials</h4>"
+		if not self.serial_no_details:
+			return html + "<p>No serial numbers added.</p>"
+
+		html += (
+			"<table class='table table-bordered'><thead><tr>"
+			"<th>Serial No</th><th>FG Item</th><th>Component</th>"
+			"<th>Qty</th><th>UOM</th></tr></thead><tbody>"
+		)
+		for sn in self.serial_no_details:
+			bom_name = frappe.db.get_value(
+				"BOM", {"item": sn.item_code, "is_active": 1}, "name"
+			)
+			if not bom_name:
+				html += (
+					f"<tr><td>{escape_html(sn.serial_number or '')}</td>"
+					f"<td>{escape_html(sn.item_code or '')}</td>"
+					"<td colspan='3'>No active BOM found.</td></tr>"
+				)
+				continue
+			bom_items = frappe.get_all(
+				"BOM Item",
+				filters={"parent": bom_name},
+				fields=["item_code", "qty", "uom"],
+			)
+			for bi in bom_items:
+				html += (
+					f"<tr><td>{escape_html(sn.serial_number or '')}</td>"
+					f"<td>{escape_html(sn.item_code or '')}</td>"
+					f"<td>{escape_html(bi.item_code or '')}</td>"
+					f"<td>{flt(bi.qty, 3)}</td>"
+					f"<td>{escape_html(bi.uom or '')}</td></tr>"
+				)
 		html += "</tbody></table>"
 		return html

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
@@ -476,7 +476,7 @@ class RefiningEntry(Document):
 		serial_no = frappe.db.get_value(
 			"Serial No",
 			{"name": barcode, "status": "Active"},
-			["name", "item_code", "warehouse"],
+			["name", "item_code", "warehouse", "custom_bom_no"],
 			as_dict=True,
 		)
 		if not serial_no:
@@ -508,16 +508,27 @@ class RefiningEntry(Document):
 					_("Serial Number {0} is already added.").format(serial_no.name)
 				)
 
-		# fetch BOM details for pure weight, gross weight etc.
-		bom_details = frappe.db.get_value(
-			"BOM",
-			{"item": serial_no.item_code, "is_active": 1},
-			[
-				"name",
-				"metal_and_finding_weight",
-				"gross_weight",
-			],
-			as_dict=True,
+		# Fetch BOM details for pure/gross/net weight from the serial's OWN as-built
+		# BOM (custom_bom_no). Each serialized piece has its own BOM capturing its
+		# actual weights; falling back to any active BOM for the design item would
+		# pull a different piece's weights and mismatch the serial. Only fall back to
+		# the item's active BOM when the serial has no BOM linked.
+		bom_no = serial_no.custom_bom_no or frappe.db.get_value(
+			"BOM", {"item": serial_no.item_code, "is_active": 1}, "name"
+		)
+		bom_details = (
+			frappe.db.get_value(
+				"BOM",
+				bom_no,
+				[
+					"name",
+					"metal_and_finding_weight",
+					"gross_weight",
+				],
+				as_dict=True,
+			)
+			if bom_no
+			else None
 		)
 
 		gross_weight = bom_details.gross_weight if bom_details else 0.0
@@ -570,24 +581,37 @@ class RefiningEntry(Document):
 				# Fetch materials consumed by this MWO from MOP Log.
 				# Per SOP, only the MWO's CURRENT operation is refined, so scope the
 				# MOP Log to that operation when it is known.
-				mop_filters = {
-					"manufacturing_work_order": mwo_row.manufacturing_work_order,
-					"is_cancelled": 0,
-				}
+				#
+				# Net the movements per (item, batch, warehouse) with SUM(qty_change)
+				# so issues/losses at this operation are subtracted, not ignored, and
+				# keep only groups with a positive net balance (HAVING). A per-row
+				# `qty_change > 0` filter would keep only receipts and double-count
+				# material later issued out, making the fetched quantity exceed the
+				# metal the MWO actually holds. Mirrors the canonical holding query in
+				# manufacturing_work_order.py.
+				conditions = [
+					"manufacturing_work_order = %(mwo)s",
+					"is_cancelled = 0",
+				]
+				params = {"mwo": mwo_row.manufacturing_work_order}
 				if mwo_row.get("manufacturing_operation"):
-					mop_filters[
-						"manufacturing_operation"
-					] = mwo_row.manufacturing_operation
-				mop_logs = frappe.get_all(
-					"MOP Log",
-					filters=mop_filters,
-					fields=[
-						"item_code",
-						"batch_no",
-						"to_warehouse as warehouse",
-						"qty_change as qty",
-						"manufacturing_operation",
-					],
+					conditions.append("manufacturing_operation = %(mop)s")
+					params["mop"] = mwo_row.manufacturing_operation
+				mop_logs = frappe.db.sql(
+					"""
+					SELECT
+						item_code,
+						batch_no,
+						to_warehouse as warehouse,
+						SUM(qty_change) as qty,
+						manufacturing_operation
+					FROM `tabMOP Log`
+					WHERE {where}
+					GROUP BY item_code, batch_no, to_warehouse, manufacturing_operation
+					HAVING SUM(qty_change) > 0
+					""".format(where=" AND ".join(conditions)),
+					params,
+					as_dict=True,
 				)
 				for log in mop_logs:
 					if flt(log.qty) > 0:

--- a/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
@@ -30,15 +30,6 @@ class TestRefiningEntry(FrappeTestCase):
 				}
 			).insert(ignore_permissions=True)
 
-		# Ensure refining configuration exists
-		if not frappe.db.get_single_value(
-			"Refining Configuration", "default_refining_warehouse"
-		):
-			config = frappe.get_doc("Refining Configuration")
-			config.default_refining_warehouse = "Refining Dept - _TC"
-			config.enable_audit_logging = 1
-			config.save(ignore_permissions=True)
-
 	def test_dust_refining_creation_and_validation(self):
 		"""Unit Test: Dust Refining - Create Entry, Quantity Validation, Dust Difference Logic"""
 		entry = frappe.get_doc(
@@ -165,9 +156,10 @@ class TestRefiningEntry(FrappeTestCase):
 			}
 		)
 
+		# Gold-classified input item (ML- prefix) so it counts toward gold input
 		entry.append(
 			"material_items",
-			{"item_code": "_Test Scrap Item", "qty": 100.0, "source_type": "Scrap"},
+			{"item_code": "ML-G-18KT-75.4-Y", "qty": 100.0, "source_type": "Scrap"},
 		)
 
 		entry.append(
@@ -182,13 +174,18 @@ class TestRefiningEntry(FrappeTestCase):
 		entry.calculate_totals()
 		self.assertEqual(entry.refined_fine_weight, 90.0)
 
-		# Validation should pass
+		# 90 recovered gold <= 100 gold input -> passes
 		entry.validate_recovery_distribution()
 
-		# Add excess recovery to trigger error
-		entry.append("recovered_diamond", {"item": "Test Diamond", "weight": 20.0})
-
-		# 90 + 20 = 110 > 100 (input)
+		# Recovered gold now exceeds gold input -> error (120 > 100)
+		entry.append(
+			"refined_gold",
+			{
+				"item_code": "24KT Pure Gold",
+				"refining_gold_weight": 30.0,
+				"pure_weight": 30.0,
+			},
+		)
 		self.assertRaises(frappe.ValidationError, entry.validate_recovery_distribution)
 
 	def test_proportional_recovery_weight_distribution(self):
@@ -211,7 +208,8 @@ class TestRefiningEntry(FrappeTestCase):
 		self.assertEqual(recovered_18kt, 47.5)
 
 	def test_dust_item_is_receipt_only(self):
-		"""Unit Test: SOP dust item is not part of material transfer."""
+		"""Unit Test: dust loss item in the refining warehouse is opening-only (receipt),
+		while the same item in the source warehouse is transferred."""
 		entry = frappe.get_doc(
 			{
 				"doctype": "Refining Entry",
@@ -220,7 +218,6 @@ class TestRefiningEntry(FrappeTestCase):
 				"warehouse": "Source Dept - _TC",
 				"refining_warehouse": "Refining Dept - _TC",
 				"loss_item": "_Test Item Dust",
-				"dust_item": "_Test Additional Dust",
 				"system_quantity": 100.0,
 				"physical_quantity": 105.0,
 				"difference_quantity": 5.0,
@@ -228,44 +225,43 @@ class TestRefiningEntry(FrappeTestCase):
 				"status": "Draft",
 			}
 		)
-		loss_row = entry.append(
-			"material_items", {"item_code": "_Test Item Dust", "qty": 100}
-		)
-		dust_row = entry.append(
-			"material_items", {"item_code": "_Test Additional Dust", "qty": 5}
-		)
-
-		self.assertFalse(entry.is_dust_opening_item(loss_row))
-		self.assertTrue(entry.is_dust_opening_item(dust_row))
-		self.assertEqual(entry.get_dust_opening_qty("_Test Additional Dust"), 5.0)
-
-		entry.set("material_items", [])
-		entry.append("material_items", {"item_code": "_Test Item Dust", "qty": 100})
-		entry.ensure_dust_opening_material_row()
-		self.assertEqual(entry.material_items[-1].item_code, "_Test Additional Dust")
-		self.assertEqual(entry.material_items[-1].qty, 5.0)
-
-	def test_audit_log_creation(self):
-		"""Unit Test: Audit System - Log Creation"""
-		entry = frappe.get_doc(
+		# Loss item in the SOURCE warehouse -> transferred (not an opening row)
+		source_row = entry.append(
+			"material_items",
 			{
-				"doctype": "Refining Entry",
-				"refining_type": "Dust Refining",
-				"company": "_Test Company",
-				"loss_item": "_Test Item Dust",
-				"system_quantity": 100.0,
-				"physical_quantity": 100.0,
-				"status": "Draft",
-			}
+				"item_code": "_Test Item Dust",
+				"warehouse": "Source Dept - _TC",
+				"qty": 100,
+			},
 		)
-		entry.insert()
-
-		entry.log_audit_action("State Change Test", "Draft", "Submitted")
-
-		logs = frappe.get_all(
-			"Refining Audit Log", filters={"refining_entry": entry.name}
+		# Loss item in the REFINING warehouse -> dust opening row (receipt only)
+		opening_row = entry.append(
+			"material_items",
+			{
+				"item_code": "_Test Item Dust",
+				"warehouse": "Refining Dept - _TC",
+				"qty": 5,
+			},
 		)
-		self.assertTrue(len(logs) > 0)
+
+		self.assertFalse(entry.is_dust_opening_item(source_row))
+		self.assertTrue(entry.is_dust_opening_item(opening_row))
+		self.assertEqual(entry.get_dust_opening_qty("_Test Item Dust"), 5.0)
+
+		# ensure_dust_opening_material_row appends the opening row when missing
+		entry.set("material_items", [])
+		entry.append(
+			"material_items",
+			{
+				"item_code": "_Test Item Dust",
+				"warehouse": "Source Dept - _TC",
+				"qty": 100,
+			},
+		)
+		entry.ensure_dust_opening_material_row()
+		self.assertTrue(
+			any(entry.is_dust_opening_item(r) for r in entry.material_items)
+		)
 
 	def test_workflow_transitions(self):
 		"""Workflow Tests: Validate State Changes"""

--- a/jewellery_erpnext/refining/doctype/refining_material_line/refining_material_line.json
+++ b/jewellery_erpnext/refining/doctype/refining_material_line/refining_material_line.json
@@ -8,11 +8,13 @@
  "field_order": [
   "item_code",
   "item_name",
+  "item_group",
   "batch_no",
   "warehouse",
   "qty",
   "uom",
   "source_type",
+  "is_consumable",
   "purity",
   "rate",
   "column_break_01",
@@ -34,6 +36,15 @@
    "fieldname": "item_name",
    "fieldtype": "Data",
    "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "item_code.item_group",
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Group",
+   "options": "Item Group",
    "read_only": 1
   },
   {
@@ -69,7 +80,13 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Source Type",
-   "options": "\nMWO\nSerial Number\nDust\nScrap\nLoss Item"
+   "options": "\nMWO\nSerial Number\nDust\nScrap\nLoss Item\nConsumable"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_consumable",
+   "fieldtype": "Check",
+   "label": "Is Consumable"
   },
   {
    "fieldname": "purity",

--- a/jewellery_erpnext/refining/report/daily_dust_and_loss/daily_dust_and_loss.py
+++ b/jewellery_erpnext/refining/report/daily_dust_and_loss/daily_dust_and_loss.py
@@ -74,7 +74,7 @@ def get_data(filters):
 			re.system_quantity AS system_loss_quantity,
 			re.physical_quantity AS physical_dust_quantity,
 			re.difference_quantity,
-			re.dust_item
+			re.loss_item AS dust_item
 		FROM `tabRefining Entry` re
 		LEFT JOIN `tabRefining Material Line` rml ON rml.parent = re.name
 		WHERE {conditions}

--- a/jewellery_erpnext/refining/report/daily_refining_recovery_report/daily_refining_recovery_report.py
+++ b/jewellery_erpnext/refining/report/daily_refining_recovery_report/daily_refining_recovery_report.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe import _
 
+from jewellery_erpnext.refining.report.utils import entry_conditions
+
 
 def execute(filters=None):
 	filters = frappe._dict(filters or {})
@@ -68,23 +70,25 @@ def get_columns():
 
 
 def get_data(filters):
-	conditions = get_conditions(filters)
+	# Use the shared daily date window (default last 1 day) like the other reports,
+	# so this report does not return every submitted entry when no date is given.
+	conditions, values = entry_conditions(filters, default_days=1)
 
 	entries = frappe.db.sql(
 		f"""
 		SELECT
-			name as refining_entry,
-			refining_type,
-			department,
-			status,
-			gross_pure_weight,
-			refined_fine_weight,
-			refining_loss
-		FROM `tabRefining Entry`
-		WHERE docstatus = 1 {conditions}
-		ORDER BY creation DESC
-	""",
-		filters,
+			re.name as refining_entry,
+			re.refining_type,
+			re.department,
+			re.status,
+			re.gross_pure_weight,
+			re.refined_fine_weight,
+			re.refining_loss
+		FROM `tabRefining Entry` re
+		WHERE {conditions}
+		ORDER BY re.creation DESC
+		""",
+		values,
 		as_dict=1,
 	)
 
@@ -97,18 +101,6 @@ def get_data(filters):
 			entry.recovery_efficiency = 0.0
 
 	return entries
-
-
-def get_conditions(filters):
-	filters = frappe._dict(filters or {})
-	conditions = ""
-	if filters.get("posting_date"):
-		conditions += " AND posting_date = %(posting_date)s"
-	if filters.get("refining_type"):
-		conditions += " AND refining_type = %(refining_type)s"
-	if filters.get("department"):
-		conditions += " AND department = %(department)s"
-	return conditions
 
 
 def get_chart(data):

--- a/jewellery_erpnext/refining/report/monthly_dust_reprocessing/monthly_dust_reprocessing.py
+++ b/jewellery_erpnext/refining/report/monthly_dust_reprocessing/monthly_dust_reprocessing.py
@@ -61,7 +61,7 @@ def get_data(filters):
 		SELECT
 			re.name AS refining_entry,
 			re.department,
-			re.dust_item,
+			re.loss_item AS dust_item,
 			re.actual_recovery AS recovery_quantity,
 			re.refining_loss AS remaining_scrap,
 			re.status

--- a/jewellery_erpnext/refining/report/monthly_refining_performance/monthly_refining_performance.py
+++ b/jewellery_erpnext/refining/report/monthly_refining_performance/monthly_refining_performance.py
@@ -57,6 +57,7 @@ def get_data(filters):
 		LEFT JOIN (
 			SELECT parent, SUM(qty) AS total_material_processed
 			FROM `tabRefining Material Line`
+			WHERE IFNULL(is_consumable, 0) = 0
 			GROUP BY parent
 		) ms ON ms.parent = re.name
 		LEFT JOIN (

--- a/jewellery_erpnext/refining/report/weekly_recovery_efficiency/weekly_recovery_efficiency.py
+++ b/jewellery_erpnext/refining/report/weekly_recovery_efficiency/weekly_recovery_efficiency.py
@@ -62,7 +62,8 @@ def get_data(filters):
 			re.expected_recovery,
 			re.actual_recovery
 		FROM `tabRefining Entry` re
-		LEFT JOIN `tabRefining Material Line` rml ON rml.parent = re.name
+		LEFT JOIN `tabRefining Material Line` rml
+			ON rml.parent = re.name AND IFNULL(rml.is_consumable, 0) = 0
 		WHERE {conditions}
 		GROUP BY re.name
 		ORDER BY re.posting_date DESC, re.name DESC

--- a/jewellery_erpnext/refining/report/weekly_refining_summary/weekly_refining_summary.py
+++ b/jewellery_erpnext/refining/report/weekly_refining_summary/weekly_refining_summary.py
@@ -57,6 +57,7 @@ def get_data(filters):
 		LEFT JOIN (
 			SELECT parent, SUM(qty) AS material_refined
 			FROM `tabRefining Material Line`
+			WHERE IFNULL(is_consumable, 0) = 0
 			GROUP BY parent
 		) ms ON ms.parent = re.name
 		LEFT JOIN (


### PR DESCRIPTION

- Added fields for scrap item and work order action in refining_entry.json.
- Introduced raw_material_html field for displaying raw materials.
- Updated RefiningEntry class to include new validations and methods for handling scrap and work order refining.
- Implemented fetch_dust_materials method to populate material items for dust refining.
- Enhanced recovery distribution validation to ensure gold recovery does not exceed input.
- Updated test cases to cover new functionality and ensure proper validation logic.
- Modified reports to reflect changes in data structure, including adjustments for consumable items.