### PR TITLE
Fix Parent Manufacturing Order showing as unsaved when opened

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/doc_events/filters_query.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/doc_events/filters_query.py
@@ -1,6 +1,7 @@
 import json
 
 import frappe
+from frappe.utils import cint
 
 # from frappe.query_builder import Case
 # from frappe.query_builder.functions import Locate
@@ -16,6 +17,54 @@ import frappe
 # 	lst = [tuple([row[i]]) for row in data1 for i in row if row.get(i)]
 
 # 	return tuple(lst)
+
+
+GRADE_FIELDS = [
+	"diamond_grade_1",
+	"diamond_grade_2",
+	"diamond_grade_3",
+	"diamond_grade_4",
+]
+
+
+def resolve_diamond_grade(customer, diamond_quality, is_customer_diamond):
+	"""Pick the grade to auto-apply for a customer/quality pair.
+
+	Both the PMO controller (on save) and the form (on field change) must resolve the grade
+	through here. When the two sides disagree, the form overwrites the stored grade every time
+	the record is opened, which marks it dirty without any user edit.
+	"""
+	if not (customer and diamond_quality):
+		return None
+
+	row = frappe.db.get_value(
+		"Customer Diamond Grade",
+		{"parent": customer, "diamond_quality": diamond_quality},
+		GRADE_FIELDS,
+	)
+	if not row:
+		return None
+
+	for grade in row:
+		if not grade:
+			continue
+		is_customer_grade = frappe.db.get_value(
+			"Attribute Value", grade, "is_customer_diamond_quality"
+		)
+		if bool(cint(is_customer_diamond)) == bool(is_customer_grade):
+			return grade
+
+	return None
+
+
+@frappe.whitelist()
+def get_auto_diamond_grade(
+	customer=None, ref_customer=None, diamond_quality=None, is_customer_diamond=0
+):
+	"""Form-side preview of the grade the PMO controller will store on save."""
+	return resolve_diamond_grade(
+		ref_customer or customer, diamond_quality, is_customer_diamond
+	)
 
 
 @frappe.whitelist()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.js
@@ -29,31 +29,6 @@ frappe.ui.form.on("Parent Manufacturing Order", {
 					},
 				};
 			});
-
-			// Only call & set diamond_grade when NOT using custom diamond grade
-			if (!frm.doc.use_custom_diamond_grade) {
-				frappe.call({
-					method: "jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.doc_events.filters_query.get_diamond_grade",
-					args: {
-						doctype: "Diamond Grade",
-						txt: "",
-						searchfield: "diamond_grade",
-						start: 0,
-						page_len: 10,
-						filters: {
-							customer: frm.doc.customer,
-							diamond_quality: frm.doc.diamond_quality,
-							use_custom_diamond_grade: 0,
-							is_customer_diamond: frm.doc.is_customer_diamond ? 1 : 0,
-						},
-					},
-					callback: function (r) {
-						if (r.message && r.message.length > 0) {
-							frm.set_value("diamond_grade", r.message[0][0]);
-						}
-					},
-				});
-			}
 		}
 
 		// Always control read-only dynamically
@@ -104,8 +79,21 @@ frappe.ui.form.on("Parent Manufacturing Order", {
 		}
 	},
 
+	customer(frm) {
+		set_auto_diamond_grade(frm);
+	},
+
+	diamond_quality(frm) {
+		set_auto_diamond_grade(frm);
+	},
+
+	is_customer_diamond(frm) {
+		set_auto_diamond_grade(frm);
+	},
+
 	use_custom_diamond_grade(frm) {
 		frm.set_df_property("diamond_grade", "read_only", !frm.doc.use_custom_diamond_grade);
+		set_auto_diamond_grade(frm);
 	},
 
 	create_customer_transfer: function (frm) {
@@ -184,6 +172,29 @@ frappe.ui.form.on("Parent Manufacturing Order", {
 		}
 	},
 });
+
+// Must never be called from refresh: frm.set_value marks the form dirty, so resolving the grade on
+// load makes a freshly opened record show as unsaved. Only run it when the user changes an input;
+// on save the controller resolves the same value through resolve_diamond_grade.
+function set_auto_diamond_grade(frm) {
+	if (frm.doc.use_custom_diamond_grade) {
+		return;
+	}
+	frappe.call({
+		method: "jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.doc_events.filters_query.get_auto_diamond_grade",
+		args: {
+			customer: frm.doc.customer,
+			ref_customer: frm.doc.ref_customer,
+			diamond_quality: frm.doc.diamond_quality,
+			is_customer_diamond: frm.doc.is_customer_diamond ? 1 : 0,
+		},
+		callback: function (r) {
+			if (r.message) {
+				frm.set_value("diamond_grade", r.message);
+			}
+		},
+	});
+}
 
 function filter_departments(frm, field_name) {
 	frm.set_query(field_name, function () {

--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.py
@@ -13,6 +13,9 @@ from jewellery_erpnext.jewellery_erpnext.doc_events.bom import set_item_variant
 from jewellery_erpnext.jewellery_erpnext.doctype.mould.doc_events.utils import (
 	get_current_mould_id,
 )
+from jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.doc_events.filters_query import (
+	resolve_diamond_grade,
+)
 from jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.doc_events.finding_mwo import (
 	create_finding_mwo,
 	create_stock_entry,
@@ -253,8 +256,14 @@ def _validate_metal_item_attributes(item_code, row, bom_table):
 class ParentManufacturingOrder(Document):
 	def before_save(self):
 		if self.is_new() or self.flags.ignore_validations:
+			# update_parent_details (which refreshes ref_customer) is skipped on insert, so there
+			# is no fresher input to wait for. Resolving here stores the grade on the inserted
+			# row instead of leaving the form to write it in on first open.
+			self._set_diamond_grade()
 			return
 		update_parent_details(self)
+		# Must stay AFTER update_parent_details: that refreshes ref_customer, which the grade is
+		# resolved against.
 		self._set_diamond_grade()
 		if not self.diamond_grade and not frappe.db.get_value(
 			"Item", self.item_code, "has_batch_no"
@@ -263,6 +272,10 @@ class ParentManufacturingOrder(Document):
 		self.metal_details()
 
 	def before_submit(self):
+		# frappe runs validate + before_submit on submit and skips before_save, so the grade has
+		# to be resolved here too: without it a PMO that reached submit without a stored grade
+		# silently skips the tracking BOM update below.
+		self._set_diamond_grade()
 		if self.diamond_grade and self.custom_tracking_bom:
 			frappe.db.sql(
 				"""
@@ -274,37 +287,16 @@ class ParentManufacturingOrder(Document):
 			)
 
 	def _set_diamond_grade(self):
-		customer = self.ref_customer or self.customer
-		if not (
-			self.diamond_quality and customer and not self.use_custom_diamond_grade
-		):
+		if self.use_custom_diamond_grade:
 			return
-		diamond_grade_data = frappe.db.get_value(
-			"Customer Diamond Grade",
-			{"parent": customer, "diamond_quality": self.diamond_quality},
-			[
-				"diamond_grade_1",
-				"diamond_grade_2",
-				"diamond_grade_3",
-				"diamond_grade_4",
-			],
+
+		grade = resolve_diamond_grade(
+			self.ref_customer or self.customer,
+			self.diamond_quality,
+			self.is_customer_diamond,
 		)
-
-		if not diamond_grade_data:
-			return
-
-		for row in diamond_grade_data:
-			if not row:
-				continue
-			is_customer_grade = frappe.db.get_value(
-				"Attribute Value", row, "is_customer_diamond_quality"
-			)
-			if self.is_customer_diamond and is_customer_grade:
-				self.diamond_grade = row
-				break
-			elif not self.is_customer_diamond and not is_customer_grade:
-				self.diamond_grade = row
-				break
+		if grade:
+			self.diamond_grade = grade
 
 	def metal_details(self):
 		if self.custom_tracking_bom:


### PR DESCRIPTION
The form resolved diamond_grade inside refresh() and wrote the result back with frm.set_value, which marks the form dirty. Opening a saved record was enough to show it as "Not Saved" without any user edit.

Stop writing during refresh. The grade is now resolved only when the user changes customer, diamond_quality, is_customer_diamond or use_custom_diamond_grade.

The form and the controller also resolved the grade differently, so the value the form wrote on load often disagreed with the stored one: the form filtered by customer while the controller used ref_customer or customer, and the link query applied a first-available fallback the controller had no equivalent of. Both sides now resolve through resolve_diamond_grade, so they cannot drift apart.
