### PR TITLE
feat: validate photoshop images on MWO submission

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_work_order/manufacturing_work_order.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_work_order/manufacturing_work_order.js
@@ -98,7 +98,73 @@ frappe.ui.form.on("Manufacturing Work Order", {
 		// 		});
 		// 	});
 		// }
+
+		// Show "Upload Missing Images" button on Draft MWOs when photoshop check is relevant
+		if (frm.doc.docstatus == 0 && frm.doc.item_code && !frm.doc.__islocal) {
+			frappe.call({
+				method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.manufacturing_work_order.get_missing_photoshop_images",
+				args: {
+					item_code: frm.doc.item_code,
+					master_bom: frm.doc.master_bom || "",
+				},
+				callback: function (r) {
+					if (
+						r.message &&
+						r.message.check_required &&
+						r.message.missing &&
+						Object.keys(r.message.missing).length
+					) {
+						frm.add_custom_button(
+							__("Upload Missing Images"),
+							function () {
+								open_upload_images_dialog(frm);
+							},
+							__("Actions")
+						);
+					}
+				},
+			});
+		}
+
 		set_html(frm);
+	},
+	before_submit: function (frm) {
+		// Client-side intercept: check for missing photoshop images before
+		// submission.  If images are missing, open a dialog to let the user
+		// upload them inline and retry submission after saving.
+		if (!frm.doc.item_code) return;
+
+		frappe.call({
+			method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.manufacturing_work_order.get_missing_photoshop_images",
+			args: {
+				item_code: frm.doc.item_code,
+				master_bom: frm.doc.master_bom || "",
+			},
+			async: false,
+			callback: function (r) {
+				if (
+					r.message &&
+					r.message.check_required &&
+					r.message.missing &&
+					Object.keys(r.message.missing).length
+				) {
+					frappe.validated = false;
+					frappe.msgprint({
+						title: __("Missing Photoshop Images"),
+						indicator: "orange",
+						message: __(
+							"MWO cannot be submitted. Please upload all missing Finished Item " +
+								"and Master BOM images first. Click <b>Upload Missing Images</b> " +
+								"to upload them now."
+						),
+					});
+					// Open the upload dialog automatically
+					setTimeout(function () {
+						open_upload_images_dialog(frm);
+					}, 500);
+				}
+			},
+		});
 	},
 	transfer_to_raw: function (frm) {
 		frm.call({
@@ -228,6 +294,118 @@ frappe.ui.form.on("Manufacturing Work Order", {
 		try_fetch_snc();
 	},
 });
+
+// -------- Upload Missing Images Dialog --------
+
+function open_upload_images_dialog(frm) {
+	frappe.call({
+		method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.manufacturing_work_order.get_missing_photoshop_images",
+		args: {
+			item_code: frm.doc.item_code,
+			master_bom: frm.doc.master_bom || "",
+		},
+		callback: function (r) {
+			if (!r.message || !r.message.missing || !Object.keys(r.message.missing).length) {
+				frappe.msgprint(__("All images are already uploaded."));
+				return;
+			}
+
+			const missing = r.message.missing;
+			const item_fields_map = r.message.item_image_fields || {};
+			const bom_fields_map = r.message.bom_image_fields || {};
+			let dialog_fields = [];
+
+			// Build Finished Item image fields
+			if (missing.item && missing.item.length) {
+				dialog_fields.push({
+					fieldtype: "Section Break",
+					label: __("Finished Item Images ({0})", [frm.doc.item_code]),
+				});
+				for (const label of missing.item) {
+					// Reverse-lookup fieldname from label
+					const fieldname = Object.keys(item_fields_map).find((k) => item_fields_map[k] === label);
+					if (fieldname) {
+						dialog_fields.push({
+							fieldname: "item__" + fieldname,
+							fieldtype: "Attach Image",
+							label: label,
+						});
+					}
+				}
+			}
+
+			// Build BOM image fields
+			if (missing.bom && missing.bom.length) {
+				dialog_fields.push({
+					fieldtype: "Section Break",
+					label: __("Master BOM Images ({0})", [frm.doc.master_bom]),
+				});
+				for (const label of missing.bom) {
+					const fieldname = Object.keys(bom_fields_map).find((k) => bom_fields_map[k] === label);
+					if (fieldname) {
+						dialog_fields.push({
+							fieldname: "bom__" + fieldname,
+							fieldtype: "Attach Image",
+							label: label,
+						});
+					}
+				}
+			}
+
+			const dlg = new frappe.ui.Dialog({
+				title: __("Upload Missing Images"),
+				fields: dialog_fields,
+				size: "large",
+				primary_action_label: __("Upload & Save"),
+				primary_action: function () {
+					const values = dlg.get_values();
+					let item_images = {};
+					let bom_images = {};
+
+					for (const [key, val] of Object.entries(values)) {
+						if (key.startsWith("item__") && val) {
+							item_images[key.replace("item__", "")] = val;
+						} else if (key.startsWith("bom__") && val) {
+							bom_images[key.replace("bom__", "")] = val;
+						}
+					}
+
+					if (!Object.keys(item_images).length && !Object.keys(bom_images).length) {
+						frappe.msgprint(__("Please upload at least one image."));
+						return;
+					}
+
+					frappe.call({
+						method: "jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.manufacturing_work_order.update_photoshop_images",
+						args: {
+							item_code: frm.doc.item_code,
+							master_bom: frm.doc.master_bom || "",
+							item_images: JSON.stringify(item_images),
+							bom_images: JSON.stringify(bom_images),
+						},
+						freeze: true,
+						freeze_message: __("Saving images..."),
+						callback: function (res) {
+							if (res.message && res.message.success) {
+								frappe.show_alert({
+									message: __(
+										"Images updated on Item Master and/or Master BOM successfully."
+									),
+									indicator: "green",
+								});
+								dlg.hide();
+								frm.reload_doc();
+							}
+						},
+					});
+				},
+			});
+			dlg.show();
+		},
+	});
+}
+
+// -------- HTML helpers --------
 
 function set_html(frm) {
 	if (frm.doc.__islocal && !frm.doc.is_last_operation) {

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_work_order/manufacturing_work_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_work_order/manufacturing_work_order.py
@@ -52,6 +52,9 @@ class ManufacturingWorkOrder(Document):
 				{"reference_doctype": self.doctype, "reference_docname": self.name},
 			)
 
+	def before_submit(self):
+		self.validate_photoshop_images()
+
 	def on_submit(self):
 		if self.for_fg:
 			self.validate_other_work_orders()
@@ -744,6 +747,48 @@ class ManufacturingWorkOrder(Document):
 		se.submit()
 		return se.name
 
+	def validate_photoshop_images(self):
+		"""Block submission if the Finished Item has 'Is Photoshop Images' enabled
+		and any of the six finish images on the Item or Master BOM are missing."""
+		if not self.item_code:
+			return
+
+		is_photoshop = frappe.db.get_value(
+			"Item", self.item_code, "custom_is_photoshop_images"
+		)
+		if not is_photoshop:
+			return
+
+		missing = _get_missing_photoshop_images(self.item_code, self.master_bom)
+		if not missing:
+			return
+
+		msg_parts = []
+		if missing.get("item"):
+			labels = ", ".join([f"<b>{label}</b>" for label in missing["item"]])
+			msg_parts.append(
+				_("Finished Item ({0}) is missing images: {1}").format(
+					self.item_code, labels
+				)
+			)
+		if missing.get("bom"):
+			labels = ", ".join([f"<b>{label}</b>" for label in missing["bom"]])
+			msg_parts.append(
+				_("Master BOM ({0}) is missing images: {1}").format(
+					self.master_bom, labels
+				)
+			)
+
+		frappe.throw(
+			_(
+				"MWO cannot be submitted. Please ensure all six Finished Item images "
+				"and all required Master BOM images are uploaded before submitting the "
+				"Manufacturing Work Order. Missing images must be updated first.<br><br>"
+				"{0}"
+			).format("<br>".join(msg_parts)),
+			title=_("Missing Photoshop Images"),
+		)
+
 	@frappe.whitelist()
 	def create_mfg_entry(self):
 		create_se_entry(self)
@@ -1076,3 +1121,104 @@ def create_mr_for_split_work_order(docname, company, manufacturer):
 	new_mr.flags.ignore_validate = True
 	new_mr.save()
 	frappe.msgprint("Material Request is created !!")
+
+
+# ---------- Photoshop Image Validation Helpers ----------
+
+# Finished Item image field map:  fieldname -> label
+ITEM_IMAGE_FIELDS = {
+	"finish_front_view": "Finish Front View",
+	"finish__back_view": "Finish Back View",
+	"finish_left_view": "Finish Left View",
+	"finish_right_view": "Finish Right View",
+	"finish_top_view": "Finish Top View",
+	"finish_bottom_view": "Finish Bottom View",
+}
+
+# Master BOM image field map:  fieldname -> label
+BOM_IMAGE_FIELDS = {
+	"front_view_finish": "BOM Finish Images Front View",
+	"back_view_finish": "BOM Finish Images Back View",
+	"left_view_finish": "BOM Finish Images Left View",
+	"right_view_finish": "BOM Finish Images Right View",
+	"top_view_finish": "BOM Finish Images Top View",
+	"bottom_view_finish": "BOM Finish Images Bottom View",
+}
+
+
+def _get_missing_photoshop_images(item_code, master_bom):
+	"""Return dict with keys 'item' and/or 'bom', each a list of
+	missing image labels.  Returns empty dict when nothing is missing."""
+	missing = {}
+
+	# --- Check Finished Item images ---
+	item_values = frappe.db.get_value(
+		"Item", item_code, list(ITEM_IMAGE_FIELDS.keys()), as_dict=True
+	)
+	if item_values:
+		missing_item = [
+			ITEM_IMAGE_FIELDS[f] for f in ITEM_IMAGE_FIELDS if not item_values.get(f)
+		]
+		if missing_item:
+			missing["item"] = missing_item
+
+	# --- Check Master BOM images ---
+	if master_bom:
+		bom_values = frappe.db.get_value(
+			"BOM", master_bom, list(BOM_IMAGE_FIELDS.keys()), as_dict=True
+		)
+		if bom_values:
+			missing_bom = [
+				BOM_IMAGE_FIELDS[f] for f in BOM_IMAGE_FIELDS if not bom_values.get(f)
+			]
+			if missing_bom:
+				missing["bom"] = missing_bom
+
+	return missing
+
+
+@frappe.whitelist()
+def get_missing_photoshop_images(item_code, master_bom=None):
+	"""Whitelisted helper called from the client to fetch missing images
+	before MWO submission so the user can upload them inline."""
+	is_photoshop = frappe.db.get_value("Item", item_code, "custom_is_photoshop_images")
+	if not is_photoshop:
+		return {"check_required": False}
+
+	missing = _get_missing_photoshop_images(item_code, master_bom)
+	return {
+		"check_required": True,
+		"missing": missing,
+		"item_image_fields": ITEM_IMAGE_FIELDS,
+		"bom_image_fields": BOM_IMAGE_FIELDS,
+	}
+
+
+@frappe.whitelist()
+def update_photoshop_images(
+	item_code, master_bom=None, item_images=None, bom_images=None
+):
+	"""Update missing images on the Item Master and/or Master BOM.
+
+	Called from the MWO upload dialog.  `item_images` and `bom_images`
+	are JSON dicts of {fieldname: file_url}.
+	"""
+	import json
+
+	if isinstance(item_images, str):
+		item_images = json.loads(item_images)
+	if isinstance(bom_images, str):
+		bom_images = json.loads(bom_images)
+
+	if item_images:
+		valid = {k: v for k, v in item_images.items() if k in ITEM_IMAGE_FIELDS and v}
+		if valid:
+			frappe.db.set_value("Item", item_code, valid, update_modified=True)
+
+	if bom_images and master_bom:
+		valid = {k: v for k, v in bom_images.items() if k in BOM_IMAGE_FIELDS and v}
+		if valid:
+			frappe.db.set_value("BOM", master_bom, valid, update_modified=True)
+
+	frappe.db.commit()
+	return {"success": True}


### PR DESCRIPTION
Block Manufacturing Work Order submission when the Finished Item has 'Is Photoshop Images' enabled but any of the six finish-view images are missing on either the Item (Design Code) or its Master BOM (Design Code BOM). Adds an MWO dialog to upload the missing images and write them back to the Item master and Master BOM.