### PR TITLE
feat: Add unit tests and recovery distribution logic for refining ent…

### DIFF
--- a/.github/workflows/refining-tests.yml
+++ b/.github/workflows/refining-tests.yml
@@ -50,6 +50,7 @@ jobs:
           bench --site test_site run-tests --app jewellery_erpnext --doctype "Refining Entry"
           bench --site test_site run-tests --app jewellery_erpnext --doctype "Refinery Price List"
           bench --site test_site run-tests --app jewellery_erpnext --doctype "Product Certification"
+          bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_refining_recovery_distribution
           bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_serialize
           bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_lock_order
           bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_submission_queue_dedup

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_refining_recovery_distribution.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_refining_recovery_distribution.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026, Nirali and Contributors
+# See license.txt
+
+"""Recovery Summary <-> Gold Recovery Details consistency.
+
+Regression cover for the defect where a plain no-op re-save of a Refining Entry inflated
+``refining_loss`` — on one real document from 0.033 g to 0.860 g, on another from 0.000 g to
+1.667 g. That field is not a statistic: ``create_repack_se`` mints exactly that many grams of
+pure-24KT loss dust as a Stock Entry output row, so an inflated value mints gold that was
+never lost.
+
+Root cause: the Recovery Summary was made to adopt the per-karat ``gold_recovery_details``
+table. The table is written once per lifecycle by two button actions that become unreachable
+once the entry leaves "Refining In Progress", while ``calculate_totals`` runs on EVERY save.
+Rows therefore outlive the formula that produced them, and three generations exist in real
+data:
+
+  Era A  loss measured against the GROSS alloy weight (input_weight - recovered)
+  Era B  recovered split GROSS-proportionally but loss/pct scored on the PURE basis
+  Era C  fully pure-proportional — internally consistent
+
+The fix inverts the dependency (parent inputs are authoritative, the table is apportioned FROM
+them) and removes the original ~1 mg multi-touch drift at the writer via exact apportionment.
+
+The math module is deliberately DB-free, so most of this file needs no site. Note it does NOT
+use ``frappe.utils.flt`` for rounding: ``flt(value, precision)`` resolves the rounding method
+through ``frappe.local`` and returns 0.0 with no site bound.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from jewellery_erpnext.refining.doctype.refining_entry.recovery_distribution import (
+	_round,
+	apportion,
+	build_row_targets,
+)
+
+
+class TestApportion(IntegrationTestCase):
+	"""apportion() must be exact — that is its entire reason for existing."""
+
+	def test_parts_sum_to_total_exactly(self):
+		for weights, total in (
+			([1.0], 0.5),
+			([1.0, 1.0], 1.0),
+			([1.0, 2.0, 3.0], 10.0),
+			([12.517, 6.116], 18.6),
+			([431.083, 7.781], 438.863),
+		):
+			parts = apportion(total, weights)
+			self.assertAlmostEqual(sum(parts), total, places=9)
+
+	def test_thirds_do_not_lose_a_milligram(self):
+		# 1/3 each: naive per-row rounding drops a unit; largest-remainder must not.
+		parts = apportion(1.0, [1.0, 1.0, 1.0])
+		self.assertAlmostEqual(sum(parts), 1.0, places=9)
+		self.assertEqual(len(parts), 3)
+
+	def test_degenerate_inputs(self):
+		self.assertEqual(apportion(10.0, []), [])
+		self.assertEqual(apportion(0.0, [1.0, 2.0]), [0.0, 0.0])
+		self.assertEqual(apportion(-5.0, [1.0]), [0.0])
+		self.assertEqual(apportion(10.0, [0.0, 0.0]), [0.0, 0.0])
+
+	def test_deterministic(self):
+		self.assertEqual(
+			apportion(1.0, [1.0, 1.0, 1.0]), apportion(1.0, [1.0, 1.0, 1.0])
+		)
+
+
+class TestBuildRowTargets(IntegrationTestCase):
+	"""Every column must sum back to the parent total, for any number of touches."""
+
+	def _assert_invariants(self, pure, refined_fine, loss):
+		rows = build_row_targets(pure, refined_fine, loss)
+		self.assertAlmostEqual(
+			sum(r["pure_gold_weight"] for r in rows), round(sum(pure), 3), places=9
+		)
+		self.assertAlmostEqual(
+			sum(r["recovered_weight"] for r in rows), refined_fine, places=9
+		)
+		self.assertAlmostEqual(sum(r["loss_weight"] for r in rows), loss, places=9)
+		return rows
+
+	def test_invariants_hold_for_one_to_five_karats(self):
+		for count in range(1, 6):
+			pure = [round(1.0 + index * 3.7, 3) for index in range(count)]
+			total = round(sum(pure), 3)
+			refined_fine = round(total * 0.98, 3)
+			self._assert_invariants(pure, refined_fine, round(total - refined_fine, 3))
+
+	def test_era_b_multi_karat_regression(self):
+		# The real RFN-DST-26-00027 numbers. The stored table read 0.860 + 0.000 with a
+		# 113.52% row; the mass balance says 0.033. Apportioning must reproduce 0.033.
+		rows = self._assert_invariants([12.517, 6.116], 18.600, 0.033)
+		self.assertEqual([r["loss_weight"] for r in rows], [0.022, 0.011])
+		self.assertTrue(all(r["recovery_pct"] <= 100.0 for r in rows))
+
+	def test_era_a_single_karat_regression(self):
+		# RFN-DST-26-00019: stored loss 2.360 (gross basis) / pct 91.51 against a real
+		# mass balance of 0.107 / 99.58.
+		row = build_row_targets([25.557], 25.450, 0.107)[0]
+		self.assertEqual(row["loss_weight"], 0.107)
+		self.assertEqual(row["recovery_pct"], 99.58)
+
+	def test_era_c_consistent_table_is_left_alone(self):
+		# A table the current formula would produce must round-trip unchanged.
+		rows = build_row_targets([1.433], 1.400, 0.033)
+		self.assertEqual(rows[0]["pure_gold_weight"], 1.433)
+		self.assertEqual(rows[0]["recovered_weight"], 1.400)
+		self.assertEqual(rows[0]["loss_weight"], 0.033)
+
+	def test_no_row_can_over_recover(self):
+		# The old per-row max(pure - recovered, 0) allowed one row above 100% while another
+		# absorbed a phantom loss. Apportioning by pure content cannot produce that.
+		rows = build_row_targets([12.517, 6.116], 18.600, 0.033)
+		self.assertTrue(
+			all(r["recovered_weight"] <= r["pure_gold_weight"] for r in rows)
+		)
+
+	def test_recovery_pct_never_shows_100_beside_a_loss(self):
+		rows = build_row_targets([1000.0], 999.999, 0.001)
+		self.assertEqual(rows[0]["recovery_pct"], 99.99)
+
+	def test_full_recovery_shows_exactly_100(self):
+		rows = build_row_targets([10.0, 5.0], 15.0, 0.0)
+		self.assertTrue(all(r["recovery_pct"] == 100.0 for r in rows))
+		self.assertTrue(all(r["loss_weight"] == 0.0 for r in rows))
+
+	def test_r_boundary_around_one(self):
+		# ~1 in 20,000 consistent tables lands here; rare enough to be called impossible,
+		# common enough to matter at production volume. The contract is that the column sums
+		# to the total ROUNDED to the working precision, so compare against that.
+		for refined_fine in (14.9995, 15.0, 15.0005, 14.999, 15.001):
+			rows = build_row_targets([10.0, 5.0], refined_fine, 0.0)
+			self.assertAlmostEqual(
+				sum(r["recovered_weight"] for r in rows),
+				_round(refined_fine, 3),
+				places=9,
+			)
+			self.assertTrue(all(r["recovery_pct"] <= 100.0 for r in rows))
+
+	def test_rounding_is_half_up_not_bankers(self):
+		# Weights are grams of gold; Frappe's `rounded` is half-up by default, and Python's
+		# round() is half-to-even (round(14.9995, 3) == 14.999). The module must follow
+		# Frappe, or a half-milligram would round the other way from the rest of the app.
+		self.assertEqual(_round(14.9995, 3), 15.0)
+		self.assertEqual(_round(0.0005, 3), 0.001)
+		self.assertEqual(_round(2.5, 0), 3.0)
+
+	def test_empty_table(self):
+		self.assertEqual(build_row_targets([], 1.0, 0.0), [])
+
+
+def _entry(**kwargs):
+	"""A RefiningEntry stand-in carrying only what the guards read."""
+	from jewellery_erpnext.refining.doctype.refining_entry.refining_entry import (
+		RefiningEntry,
+	)
+
+	doc = SimpleNamespace(
+		docstatus=0,
+		repack_se=None,
+		transfer_se=None,
+		gold_recovery_details=[],
+		gross_pure_weight=0.0,
+		refined_fine_weight=0.0,
+		actual_recovery=0.0,
+		refining_loss=0.0,
+		recovery_table_out_of_sync=0,
+		SUMMARY_DRIFT_TOLERANCE=RefiningEntry.SUMMARY_DRIFT_TOLERANCE,
+	)
+	doc.__dict__.update(kwargs)
+	doc.get = lambda field, default=None: getattr(doc, field, default)
+	doc.set = lambda field, value: setattr(doc, field, value)
+	return doc
+
+
+class TestMintIdentity(IntegrationTestCase):
+	"""actual_recovery + refining_loss <= gross_pure_weight.
+
+	create_repack_se mints BOTH the recovered pure gold (sum of refined_gold rows, i.e.
+	actual_recovery) and refining_loss grams of pure dust. Checking refining_loss against
+	gross_pure - refined_fine_weight instead would be a tautology, since that IS how
+	refining_loss is defined.
+	"""
+
+	def _run(self, doc):
+		from jewellery_erpnext.refining.doctype.refining_entry.refining_entry import (
+			RefiningEntry,
+		)
+
+		RefiningEntry._validate_mint_identity(doc)
+
+	def test_balanced_entry_passes(self):
+		self._run(
+			_entry(gross_pure_weight=18.633, actual_recovery=18.6, refining_loss=0.033)
+		)
+
+	def test_assay_margin_tolerated(self):
+		self._run(
+			_entry(gross_pure_weight=10.0, actual_recovery=10.05, refining_loss=0.0)
+		)
+
+	def test_over_mint_throws(self):
+		# The real RFN-SRN-26-00002 shape: 2.410 recovered + 0.722 loss against 2.539 in.
+		with self.assertRaises(frappe.ValidationError):
+			self._run(
+				_entry(
+					gross_pure_weight=2.539, actual_recovery=2.410, refining_loss=0.722
+				)
+			)
+
+	def test_inflated_loss_throws(self):
+		# What the reverted behaviour would have booked on RFN-SRN-26-00014.
+		with self.assertRaises(frappe.ValidationError):
+			self._run(
+				_entry(
+					gross_pure_weight=2.445, actual_recovery=0.0, refining_loss=2.660
+				)
+			)
+
+
+class TestSyncRecoveryTable(IntegrationTestCase):
+	"""The save-time heal is deliberately narrow — prove each guard."""
+
+	def _sync(self, doc, purity_map=None):
+		from jewellery_erpnext.refining.doctype.refining_entry.refining_entry import (
+			RefiningEntry,
+		)
+
+		doc._collect_input_purity_map = lambda: (purity_map or {}, {})
+		doc._recovery_table_diverges = lambda: RefiningEntry._recovery_table_diverges(
+			doc
+		)
+		RefiningEntry._sync_recovery_table(doc)
+
+	def test_no_op_without_a_table(self):
+		doc = _entry()
+		self._sync(doc)
+		self.assertEqual(doc.gold_recovery_details, [])
+
+	def test_no_op_on_submitted_document(self):
+		row = SimpleNamespace(
+			purity_percentage=91.9, loss_weight=2.360, update=MagicMock()
+		)
+		doc = _entry(docstatus=1, gold_recovery_details=[row], refining_loss=0.107)
+		self._sync(doc, {91.9: 27.810})
+		row.update.assert_not_called()
+
+	def test_no_op_and_flag_without_a_purity_basis(self):
+		# External pre-receipt: rows carry no purity. Leaving them alone beats blanking them,
+		# but the divergence must still be visible.
+		row = SimpleNamespace(
+			purity_percentage=0.0, loss_weight=2.360, update=MagicMock()
+		)
+		doc = _entry(gold_recovery_details=[row], refining_loss=0.107)
+		self._sync(doc, {})
+		row.update.assert_not_called()
+		self.assertEqual(doc.recovery_table_out_of_sync, 1)
+
+	def test_heals_a_stale_gross_basis_row(self):
+		row = SimpleNamespace(
+			purity_percentage=91.9, loss_weight=2.360, recovery_pct=91.51
+		)
+		row.update = lambda values: row.__dict__.update(values)
+		doc = _entry(
+			gold_recovery_details=[row],
+			gross_pure_weight=25.557,
+			refined_fine_weight=25.450,
+			refining_loss=0.107,
+		)
+		self._sync(doc, {91.9: 27.810})
+		self.assertEqual(row.loss_weight, 0.107)
+		self.assertEqual(row.recovery_pct, 99.58)
+		self.assertEqual(doc.recovery_table_out_of_sync, 0)
+
+
+class TestPreserveSettledSummary(IntegrationTestCase):
+	"""Gold figures must not drift once the Stock Entries are posted."""
+
+	def _run(self, doc, previous):
+		from jewellery_erpnext.refining.doctype.refining_entry.refining_entry import (
+			RefiningEntry,
+		)
+
+		doc.get_doc_before_save = lambda: previous
+		RefiningEntry._preserve_settled_summary(doc)
+
+	def test_unsettled_entry_is_left_to_recompute(self):
+		doc = _entry(gross_pure_weight=3.152, refining_loss=0.131)
+		self._run(doc, _entry(gross_pure_weight=3.021, refining_loss=0.0))
+		self.assertEqual(doc.gross_pure_weight, 3.152)
+		self.assertEqual(doc.recovery_table_out_of_sync, 0)
+
+	def test_settled_entry_keeps_stored_values_and_flags(self):
+		# RFN-SRN-26-00016: recomputed 3.152 against a stored 3.021, with SEs already posted.
+		doc = _entry(
+			repack_se="KGJPL-SE-MF-26-02128",
+			gross_pure_weight=3.152,
+			refining_loss=0.131,
+		)
+		self._run(doc, _entry(gross_pure_weight=3.021, refining_loss=0.0))
+		self.assertEqual(doc.gross_pure_weight, 3.021)
+		self.assertEqual(doc.refining_loss, 0.0)
+		self.assertEqual(doc.recovery_table_out_of_sync, 1)
+
+	def test_settled_entry_without_drift_is_not_flagged(self):
+		doc = _entry(repack_se="SE-1", gross_pure_weight=3.021, refining_loss=0.0)
+		self._run(doc, _entry(gross_pure_weight=3.021, refining_loss=0.0))
+		self.assertEqual(doc.recovery_table_out_of_sync, 0)
+
+	def test_new_document_has_no_previous_version(self):
+		doc = _entry(repack_se="SE-1", gross_pure_weight=1.0)
+		self._run(doc, None)
+		self.assertEqual(doc.gross_pure_weight, 1.0)
+
+
+class TestCalculateTotalsUsesMassBalance(IntegrationTestCase):
+	"""calculate_totals must never read the child table for its loss figure."""
+
+	def test_loss_is_the_mass_balance_not_the_table_sum(self):
+		from jewellery_erpnext.refining.doctype.refining_entry.refining_entry import (
+			RefiningEntry,
+		)
+
+		# Era-B rows summing to 0.860, against a 0.033 mass balance.
+		rows = [
+			SimpleNamespace(
+				pure_gold_weight=12.517, loss_weight=0.860, purity_percentage=91.9
+			),
+			SimpleNamespace(
+				pure_gold_weight=6.116, loss_weight=0.000, purity_percentage=75.4
+			),
+		]
+		for row in rows:
+			row.update = lambda values, row=row: row.__dict__.update(values)
+
+		doc = _entry(gold_recovery_details=rows)
+		doc.refined_gold = [
+			SimpleNamespace(refining_gold_weight=18.6, pure_weight=18.6)
+		]
+		doc._compute_input_pure_weight = lambda: (18.633, 18.633)
+		doc._collect_input_purity_map = lambda: ({91.9: 13.620, 75.4: 8.112}, {})
+		doc.get_doc_before_save = lambda: None
+		# Bind the real collaborators calculate_totals calls on self.
+		doc._preserve_settled_summary = lambda: RefiningEntry._preserve_settled_summary(
+			doc
+		)
+		doc._sync_recovery_table = lambda: RefiningEntry._sync_recovery_table(doc)
+		doc._recovery_table_diverges = lambda: RefiningEntry._recovery_table_diverges(
+			doc
+		)
+
+		with patch.object(frappe, "db", MagicMock()):
+			RefiningEntry.calculate_totals(doc)
+
+		self.assertEqual(doc.refining_loss, 0.033)
+		self.assertEqual(doc.gross_pure_weight, 18.633)
+		# and the table was healed to agree with it
+		self.assertAlmostEqual(sum(r.loss_weight for r in rows), 0.033, places=9)

--- a/jewellery_erpnext/refining/doctype/refining_entry/recovery_distribution.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/recovery_distribution.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, Nirali and contributors
+# For license information, please see license.txt
+
+"""Pure math for the Gold Recovery Details per-karat split.
+
+No Frappe document access, no DB — every function here takes and returns plain numbers, so the
+invariants can be unit-tested without a site.
+
+WHY THIS MODULE EXISTS
+----------------------
+The Recovery Summary (parent) and the per-karat Gold Recovery Details table must agree to the
+milligram. They used to disagree because each row rounded its own share independently
+(sum-of-rounded) while the parent rounded the totals once (round-of-sum) — a drift of roughly
+1 mg per extra karat, the reported "1 mg variation with more than one touch of gold".
+
+That was "fixed" by making the parent adopt the table's columns. It is the wrong direction:
+the table is written once per lifecycle by two button actions that become unreachable when the
+entry leaves "Refining In Progress", while the parent is recomputed on every save. Adopting the
+table let rows written by a superseded formula redefine `refining_loss` — which is minted as
+pure-24KT dust by the repack Stock Entry.
+
+So the dependency runs the other way: the parent totals are authoritative, and the table is
+apportioned FROM them such that each column sums back to its parent total EXACTLY, for any
+number of karats. ``apportion`` is what makes that exact rather than approximate.
+
+LOSS IS APPORTIONED, NOT CLAMPED PER ROW
+----------------------------------------
+``build_row_targets`` splits the loss proportionally to pure content instead of computing a
+per-row ``max(pure - recovered, 0)``. On a consistent table the two are identical
+(``pure_i * (1 - r) == loss * pure_i / P``), but the per-row clamp discards a row's negative
+against another row's positive, so the column can sum to more than the gold that actually went
+missing. That is what let one real entry read 0.860 g of loss where the mass balance said
+0.033 g. Apportioning cannot do that: the parts always sum to the whole.
+"""
+
+from decimal import ROUND_HALF_UP, Decimal
+
+# Deliberately NOT frappe.utils.flt. `flt(value, precision)` resolves the rounding method
+# through frappe.local and returns 0.0 when there is no site bound — which would turn every
+# percentage here into zero in any context that lacks one. This module is pure math by design,
+# so it rounds itself, half-up, matching Frappe's default `rounded`.
+
+
+def _round(value, precision):
+	"""Half-up rounding, independent of any site context."""
+	quantum = Decimal(1).scaleb(-precision)
+	return float(Decimal(repr(float(value))).quantize(quantum, rounding=ROUND_HALF_UP))
+
+
+def flt(value):
+	"""Coerce to float, treating None/"" as 0 — the only part of frappe's flt we need."""
+	try:
+		return float(value or 0)
+	except (TypeError, ValueError):
+		return 0.0
+
+
+def apportion(total, weights, precision=3):
+	"""Split ``total`` across ``weights`` so the parts sum to ``total`` EXACTLY.
+
+	Largest-remainder (Hare quota) in integer units of ``10**-precision``: floor every share,
+	then hand the leftover units out one at a time to the largest fractional remainders. Ties
+	break on index so the result is deterministic.
+
+	Returns a list of floats the same length as ``weights``, with
+	``sum(result) == round(total, precision)`` to the last representable digit. A non-positive
+	total or an all-zero weight vector yields zeros — callers treat that as "nothing to split".
+	"""
+	scale = 10**precision
+	count = len(weights)
+	if count == 0:
+		return []
+
+	total_units = int(_round(flt(total) * scale, 0))
+	weight_sum = sum(flt(w) for w in weights)
+	if total_units <= 0 or weight_sum <= 0:
+		return [0.0] * count
+
+	exact = [flt(w) / weight_sum * total_units for w in weights]
+	units = [int(u) for u in exact]
+	leftover = total_units - sum(units)
+
+	if leftover:
+		order = sorted(range(count), key=lambda i: (-(exact[i] - units[i]), i))
+		for position in range(leftover):
+			units[order[position % count]] += 1
+
+	return [u / scale for u in units]
+
+
+def build_row_targets(pure_weights, refined_fine_weight, refining_loss, precision=3):
+	"""Canonical per-karat columns derived from the authoritative parent totals.
+
+	``pure_weights`` is the per-karat pure gold content in input order. ``refined_fine_weight``
+	and ``refining_loss`` are the parent's own figures — the ones the mass balance and the
+	repack Stock Entry use.
+
+	Returns a list of dicts with ``pure_gold_weight`` / ``recovered_weight`` / ``loss_weight`` /
+	``recovery_pct``, guaranteeing:
+
+	    sum(pure_gold_weight) == round(sum(pure_weights), precision)
+	    sum(recovered_weight) == round(refined_fine_weight, precision)
+	    sum(loss_weight)      == round(refining_loss, precision)
+
+	``recovery_pct`` mirrors the parent's display rule: capped at 99.99 whenever the row still
+	carries a loss, so a row never shows "100.00" next to a non-zero loss column.
+	"""
+	pure = [flt(p) for p in pure_weights]
+	if not pure:
+		return []
+
+	pure_rounded = apportion(sum(pure), pure, precision)
+	recovered = apportion(refined_fine_weight, pure, precision)
+	loss = apportion(refining_loss, pure, precision)
+
+	rows = []
+	for index, pure_value in enumerate(pure_rounded):
+		recovered_value = recovered[index]
+		loss_value = loss[index]
+		pct = _round((recovered_value / pure_value) * 100.0 if pure_value else 0.0, 2)
+		pct = min(pct, 100.0)
+		# Never show "100.00" next to a non-zero loss column — the same display rule the
+		# Recovery Summary applies to recovery_percentage.
+		if loss_value > 0 and pct > 99.99:
+			pct = 99.99
+		rows.append(
+			{
+				"pure_gold_weight": pure_value,
+				"recovered_weight": recovered_value,
+				"loss_weight": loss_value,
+				"recovery_pct": pct,
+			}
+		)
+	return rows

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.json
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.json
@@ -63,6 +63,7 @@
   "expected_recovery",
   "actual_recovery",
   "recovery_percentage",
+  "recovery_table_out_of_sync",
   "column_break_totals",
   "gross_pure_weight",
   "refined_fine_weight",
@@ -501,6 +502,15 @@
    "fieldtype": "Float",
    "label": "Refining Loss",
    "precision": "3"
+  },
+  {
+   "default": "0",
+   "description": "Set automatically when the per-karat Gold Recovery Details table can no longer be reconciled with the Recovery Summary, or when the summary was held back because this entry's Stock Entries are already posted. Read-only: clear it by correcting the underlying figures.",
+   "fieldname": "recovery_table_out_of_sync",
+   "fieldtype": "Check",
+   "in_standard_filter": 1,
+   "label": "Recovery Table Out Of Sync",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_totals2",

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
@@ -3,6 +3,10 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, flt
 
+from jewellery_erpnext.refining.doctype.refining_entry.recovery_distribution import (
+	build_row_targets,
+)
+
 # Roles allowed to drive the refining department processing actions
 REFINING_ROLES = ["Refining User", "Refining Manager", "System Manager"]
 
@@ -1041,27 +1045,27 @@ class RefiningEntry(Document):
 		self.refined_fine_weight = flt(self.refined_fine_weight, 3)
 		self.actual_recovery = flt(self.actual_recovery, 3)
 
-		# When the per-karat Gold Recovery Details table is populated, the Recovery
-		# Summary must agree with it EXACTLY. Each table row stores its pure content and
-		# loss already rounded to 3 dp; summing those (sum-of-rounded) can differ from
-		# rounding the full-precision input sum (round-of-sum) by ~0.001 per extra
-		# karat/touch — the reported "1 mg variation with more than one touch of gold"
-		# between the summary loss and the loss column. Derive the summary from the table
-		# so the total and the per-row column never diverge by a stray milligram.
-		if self.gold_recovery_details:
-			self.gross_pure_weight = flt(
-				sum(flt(r.pure_gold_weight, 3) for r in self.gold_recovery_details), 3
-			)
-			self.expected_recovery = self.gross_pure_weight
-			self.refining_loss = flt(
-				sum(flt(r.loss_weight, 3) for r in self.gold_recovery_details), 3
-			)
-		else:
-			# Clamp at 0: recovered 24KT gold can slightly exceed the computed pure input
-			# (rounding / assay variance) and must never book a negative loss.
-			self.refining_loss = flt(
-				max(self.gross_pure_weight - self.refined_fine_weight, 0.0), 3
-			)
+		# The Recovery Summary is derived from the PARENT inputs (material_items x purity,
+		# refined_gold), never from the Gold Recovery Details table.
+		#
+		# It briefly worked the other way round, to make the summary loss agree with the
+		# table's loss column to the milligram. That inverted the dependency: the table is
+		# written once per lifecycle by two button actions that become unreachable once the
+		# entry leaves "Refining In Progress", while this runs on EVERY save. Rows written by
+		# a superseded formula (loss measured against the gross alloy weight, or a gross-
+		# proportional split scored on the pure basis) were then adopted as the truth — and
+		# `refining_loss` is minted as pure-24KT dust by create_repack_se, so a stale column
+		# became phantom gold. One real entry moved 0.033 -> 0.860 g on a no-op save.
+		#
+		# The milligram divergence is real, but it is fixed at the WRITER instead: the table
+		# is apportioned FROM these totals by _sync_recovery_table, so each column sums back
+		# exactly. Clamp at 0: recovered 24KT gold can slightly exceed the computed pure input
+		# (rounding / assay variance) and must never book a negative loss.
+		self.refining_loss = flt(
+			max(self.gross_pure_weight - self.refined_fine_weight, 0.0), 3
+		)
+
+		self._preserve_settled_summary()
 
 		if self.expected_recovery > 0:
 			pct = min(
@@ -1077,6 +1081,144 @@ class RefiningEntry(Document):
 			self.recovery_percentage = pct
 		else:
 			self.recovery_percentage = 0.0
+
+		self._sync_recovery_table()
+
+	# Weights are grams; anything at or below this is rounding noise, not a real move.
+	SUMMARY_DRIFT_TOLERANCE = 0.0005
+
+	def _preserve_settled_summary(self):
+		"""Never silently restate the gold figures of an entry whose stock has already moved.
+
+		``calculate_totals`` runs on every save, and a Refining Entry stays ``docstatus = 0``
+		for its whole lifecycle — the workflow lives in ``status``. So an entry that already
+		posted its repack / transfer Stock Entries is still freely savable, and any later drift
+		in the inputs (an edited material row, a purity master that now resolves differently, a
+		changed formula) would rewrite the very numbers those Stock Entries were posted with.
+
+		When the stock has moved, the stored figures win and the divergence is surfaced via
+		``recovery_table_out_of_sync`` instead of being applied. Fixing it is then a deliberate
+		act, not a side effect of opening the form.
+		"""
+		if not (self.repack_se or self.transfer_se):
+			return
+
+		previous = self.get_doc_before_save()
+		if not previous:
+			return
+
+		drifted = False
+		for field in (
+			"gross_pure_weight",
+			"expected_recovery",
+			"refined_fine_weight",
+			"actual_recovery",
+			"refining_loss",
+		):
+			stored = flt(previous.get(field))
+			if abs(flt(self.get(field)) - stored) > self.SUMMARY_DRIFT_TOLERANCE:
+				self.set(field, stored)
+				drifted = True
+
+		if drifted:
+			# Remembered for the rest of this save: _sync_recovery_table must not clear a
+			# flag raised here when it goes on to heal the table successfully.
+			self._summary_held = True
+			self.recovery_table_out_of_sync = 1
+
+	def _sync_recovery_table(self):
+		"""Re-derive the per-karat columns FROM the authoritative parent totals.
+
+		The Gold Recovery Details rows are written once per lifecycle by two button actions
+		that disappear from the form once the entry leaves "Refining In Progress", so a row can
+		outlive the formula that produced it. Three formula generations exist in the wild —
+		loss measured against the gross alloy weight, a gross-proportional split scored on the
+		pure basis, and the current pure-proportional form — and nothing ever recomputed the
+		older two. Re-deriving here keeps the displayed split honest without waiting for a
+		button the operator can no longer reach.
+
+		Deliberately narrow:
+		  * only the four derived columns, NEVER a parent total — the figures that drive the
+		    repack and scrap Stock Entries are computed from parent inputs and are not touched
+		    here;
+		  * only while ``docstatus == 0``;
+		  * a no-op when there is no table yet, or when no purity basis can be rebuilt (the
+		    external pre-receipt case, where rows carry no purity) — leaving the rows alone
+		    beats blanking them;
+		  * pure math, no role gate — this runs inside ``validate``.
+		"""
+		if self.docstatus != 0 or not self.gold_recovery_details:
+			return
+
+		# The summary was held back because this entry's stock has already moved, so the table
+		# cannot be reconciled to it — leave the flag raised and the rows untouched.
+		if getattr(self, "_summary_held", False):
+			return
+
+		purity_map = self._collect_input_purity_map()[0]
+		if not purity_map or sum(flt(v) for v in purity_map.values()) <= 0:
+			# No basis to rebuild from: flag it rather than silently leaving a stale table
+			# that looks authoritative.
+			if self._recovery_table_diverges():
+				self.recovery_table_out_of_sync = 1
+			return
+
+		pure_weights = [
+			flt(purity_map.get(flt(row.purity_percentage), 0.0))
+			* (flt(row.purity_percentage) / 100.0)
+			for row in self.gold_recovery_details
+		]
+		if sum(pure_weights) <= 0:
+			if self._recovery_table_diverges():
+				self.recovery_table_out_of_sync = 1
+			return
+
+		targets = build_row_targets(
+			pure_weights, self.refined_fine_weight, self.refining_loss
+		)
+		for row, target in zip(self.gold_recovery_details, targets):
+			row.update(target)
+
+		self.recovery_table_out_of_sync = 0
+
+	def _recovery_table_diverges(self):
+		"""True when the table's loss column no longer sums to the summary loss."""
+		if not self.gold_recovery_details:
+			return False
+		column = flt(sum(flt(r.loss_weight) for r in self.gold_recovery_details), 3)
+		return abs(column - flt(self.refining_loss, 3)) > self.SUMMARY_DRIFT_TOLERANCE
+
+	def _validate_mint_identity(self):
+		"""The repack entry mints TWO pure outputs; together they cannot exceed the input.
+
+		``create_repack_se`` produces ``sum(refined_gold.refining_gold_weight)`` (== the parent
+		``actual_recovery``) of pure 24KT gold AND ``refining_loss`` of pure-24KT dust. So the
+		only identity that actually constrains the ledger is
+
+		    actual_recovery + refining_loss <= gross_pure_weight
+
+		Note this is NOT the same as checking ``refining_loss`` against
+		``gross_pure_weight - refined_fine_weight``: that is how ``refining_loss`` is defined,
+		so it can never fail. The gap is real because ``actual_recovery`` sums
+		``refining_gold_weight`` while ``refined_fine_weight`` prefers ``pure_weight``, and the
+		two diverge whenever the operator's entered figures disagree.
+		"""
+		minted = flt(self.actual_recovery) + flt(self.refining_loss)
+		available = flt(self.gross_pure_weight)
+		# Same 0.1 g assay/rounding margin validate_recovery_distribution already allows.
+		if minted > available + 0.1:
+			frappe.throw(
+				_(
+					"Refining would create more pure gold than it consumed: recovered "
+					"{0} g plus loss {1} g exceeds the pure gold input of {2} g. Correct "
+					"the Recovered Gold rows or the Recovery Summary before proceeding."
+				).format(
+					flt(self.actual_recovery, 3),
+					flt(self.refining_loss, 3),
+					flt(available, 3),
+				),
+				title=_("Refining Mass Balance"),
+			)
 
 	def validate_recovery_distribution(self):
 		# Refining always yields pure 24KT gold, so the recovered gold is compared against
@@ -1747,13 +1889,17 @@ class RefiningEntry(Document):
 		)
 		return duplicate.name
 
-	@frappe.whitelist()
-	def generate_recovery_table(self, total_recovered_weight=None):
-		"""Distribute gold recovery in proportion to each karat's PURE gold content."""
-		self.require_refining_role(REFINING_ROLES, _("classify materials"))
-		self.set("gold_recovery_details", [])
-		self.auto_classify_recoverable_non_metal()
+	def _collect_input_purity_map(self):
+		"""Gross input weight per purity percentage, plus a representative item per purity.
 
+		Lifted verbatim out of ``generate_recovery_table`` so the distribution and the
+		save-time table heal share ONE definition of "melted gold input" — including the
+		external ``_is_returned_intact`` filter and the Serial-Number BOM-components-vs-
+		``serial_no_details`` branching. No role gate and no writes: it is safe to call from
+		``validate``.
+
+		Returns ``(input_purity_map, input_item_map)``.
+		"""
 		input_purity_map = {}
 		input_item_map = {}
 		if self.refining_type == "Serial Number Refining":
@@ -1814,6 +1960,17 @@ class RefiningEntry(Document):
 						input_purity_map[pct_flt] += flt(item.qty)
 						input_item_map[pct_flt] = item.item_code
 
+		return input_purity_map, input_item_map
+
+	@frappe.whitelist()
+	def generate_recovery_table(self, total_recovered_weight=None):
+		"""Distribute gold recovery in proportion to each karat's PURE gold content."""
+		self.require_refining_role(REFINING_ROLES, _("classify materials"))
+		self.set("gold_recovery_details", [])
+		self.auto_classify_recoverable_non_metal()
+
+		input_purity_map, input_item_map = self._collect_input_purity_map()
+
 		# Recovered gold is pure 24KT, so it is split in proportion to each karat's
 		# PURE gold content, not its gross input weight. A gross-weight split
 		# over-allocates recovery to low-purity rows — an 18KT (75.4%) row could be
@@ -1827,29 +1984,28 @@ class RefiningEntry(Document):
 			input_purity_map, input_item_map
 		)
 
+		# Build the row basis first, then apportion every column off the totals in one pass so
+		# the columns sum EXACTLY to the summary regardless of how many karats are present
+		# (see recovery_distribution.build_row_targets — this is the real fix for the "1 mg
+		# variation with more than one touch of gold").
+		row_basis = []
 		for pmap in purity_maps:
 			pmap_pct = flt(pmap.purity_percentage)
 			input_weight = input_purity_map.get(pmap_pct, 0)
 			if input_weight <= 0:
 				continue
+			row_basis.append((pmap, input_weight, input_weight * (pmap_pct / 100.0)))
 
-			pure_gold_weight = input_weight * (pmap_pct / 100.0)
-			recovered_weight = self.get_proportional_recovery_weight(
-				pure_gold_weight, total_pure_input_weight, total_recovered_weight
-			)
-			row_loss = flt(
-				max(flt(pure_gold_weight, 3) - flt(recovered_weight, 3), 0), 3
-			)
-			row_pct = flt(
-				(flt(recovered_weight, 3) / flt(pure_gold_weight, 3)) * 100.0
-				if flt(pure_gold_weight, 3)
-				else 0.0,
-				2,
-			)
-			# Never let 2-decimal display rounding show "100.00" next to a non-zero
-			# loss (same guard as calculate_totals).
-			if row_loss > 0 and row_pct > 99.99:
-				row_pct = 99.99
+		total_loss = max(
+			flt(total_pure_input_weight, 3) - flt(total_recovered_weight, 3), 0.0
+		)
+		targets = build_row_targets(
+			[pure for _pmap, _input, pure in row_basis],
+			total_recovered_weight,
+			total_loss,
+		)
+
+		for (pmap, input_weight, _pure), target in zip(row_basis, targets):
 			self.append(
 				"gold_recovery_details",
 				{
@@ -1857,11 +2013,7 @@ class RefiningEntry(Document):
 					"purity_percentage": pmap.purity_percentage,
 					"item_code": pmap.item_template,
 					"input_weight": flt(input_weight, 3),
-					"pure_gold_weight": flt(pure_gold_weight, 3),
-					"recovered_weight": flt(recovered_weight, 3),
-					# Loss is only meaningful when recovered < pure gold content
-					"loss_weight": row_loss,
-					"recovery_pct": row_pct,
+					**target,
 				},
 			)
 
@@ -1919,60 +2071,29 @@ class RefiningEntry(Document):
 		# Split in proportion to each row's PURE gold content (see
 		# generate_recovery_table): a gross-weight split let a low-purity row
 		# "recover" more pure gold than it contained (recovery % above 100).
-		# Pre-compute each row's split at FULL precision, then round. loss_weight and
-		# recovery_pct are derived from the FULL-precision share vs the FULL-precision
-		# pure content so a sub-milligram rounding artifact reads as 0.000 loss / 100%
-		# (previously a pure that rounded up while its recovery rounded down showed a
-		# contradictory 0.001 loss on a 100.00%-recovered row). The rounding remainder
-		# is pushed onto the largest row so the persisted recovered weights still sum
-		# to the entered total.
-		full_share = {
-			id(row): self.get_proportional_recovery_weight(
-				flt(row.pure_gold_weight),
-				total_pure_input_weight,
-				total_recovered_weight,
-			)
-			for row in self.gold_recovery_details
-		}
-		row_weights = {rid: flt(v, 3) for rid, v in full_share.items()}
-		remainder = flt(flt(total_recovered_weight, 3) - sum(row_weights.values()), 3)
-		if remainder and row_weights:
-			largest = max(row_weights, key=row_weights.get)
-			row_weights[largest] = flt(row_weights[largest] + remainder, 3)
+		#
+		# Apportioned with the largest-remainder method rather than rounded row by row, so
+		# every column sums back to its total EXACTLY for any number of karats. That is the
+		# real fix for the "1 mg variation with more than one touch of gold": the drift was
+		# sum-of-rounded vs round-of-sum, and it is removed here at the WRITER instead of by
+		# making the Recovery Summary adopt whatever the table happens to hold.
+		#
+		# Loss is apportioned too, NOT computed per row as max(pure - recovered, 0): that
+		# clamp discards one row's negative against another's positive, so the column could
+		# sum to more gold than actually went missing (one real entry read 0.860 g against a
+		# 0.033 g mass balance).
+		pure_weights = [flt(row.pure_gold_weight) for row in self.gold_recovery_details]
+		total_loss = max(
+			flt(total_pure_input_weight, 3) - flt(total_recovered_weight, 3), 0.0
+		)
+		targets = build_row_targets(pure_weights, total_recovered_weight, total_loss)
 
-		for row in self.gold_recovery_details:
-			recovered_weight = row_weights[id(row)]
-			pure_full = flt(row.pure_gold_weight)
-			pure_gold_weight = flt(pure_full, 3)
-			# Compute loss and recovery % using the rounded display values so the
-			# percentage exactly matches the weights the user sees on screen.
-			loss_weight = flt(max(pure_gold_weight - recovered_weight, 0), 3)
-			recovery_pct = flt(
-				(recovered_weight / pure_gold_weight) * 100.0
-				if pure_gold_weight
-				else 0.0,
-				2,
-			)
-			# Never let 2-decimal display rounding show "100.00" next to a non-zero
-			# loss (same guard as calculate_totals).
-			if loss_weight > 0 and recovery_pct > 99.99:
-				recovery_pct = 99.99
-
+		for row, target in zip(self.gold_recovery_details, targets):
 			# Update in-memory for downstream use
-			row.recovered_weight = recovered_weight
-			row.loss_weight = loss_weight
-			row.recovery_pct = recovery_pct
-			row.pure_gold_weight = pure_gold_weight
+			row.update(target)
 
 			# Persist directly to DB, bypassing validate_update_after_submit
-			row.db_set(
-				{
-					"recovered_weight": recovered_weight,
-					"loss_weight": loss_weight,
-					"recovery_pct": recovery_pct,
-					"pure_gold_weight": pure_gold_weight,
-				}
-			)
+			row.db_set(dict(target))
 
 		# Rebuild refined_gold child table via DB operations
 		self._rebuild_refined_gold_via_db()
@@ -2033,22 +2154,11 @@ class RefiningEntry(Document):
 		refined_fine_weight = flt(refined_fine_weight, 3)
 		actual_recovery = flt(actual_recovery, 3)
 
-		# Keep the Recovery Summary in lockstep with the per-karat Gold Recovery Details
-		# table (sum-of-rounded, not round-of-sum) so the summary loss and the table's
-		# loss column never differ by a stray milligram when multiple karats/touches are
-		# present. See calculate_totals for the rounding rationale.
-		if self.gold_recovery_details:
-			gross_pure_weight = flt(
-				sum(flt(r.pure_gold_weight, 3) for r in self.gold_recovery_details), 3
-			)
-			expected_recovery = gross_pure_weight
-			refining_loss = flt(
-				sum(flt(r.loss_weight, 3) for r in self.gold_recovery_details), 3
-			)
-		else:
-			# Clamp at 0: recovered 24KT gold can slightly exceed the computed pure input
-			# (rounding / assay variance) and must never book a negative loss.
-			refining_loss = flt(max(gross_pure_weight - refined_fine_weight, 0.0), 3)
+		# Derived from the PARENT inputs, never from the Gold Recovery Details table — the
+		# table is apportioned FROM these totals instead (see calculate_totals for why the
+		# other direction was wrong). Clamp at 0: recovered 24KT gold can slightly exceed the
+		# computed pure input (rounding / assay variance) and must never book a negative loss.
+		refining_loss = flt(max(gross_pure_weight - refined_fine_weight, 0.0), 3)
 		recovery_percentage = min(
 			(refined_fine_weight / expected_recovery) * 100.0
 			if expected_recovery > 0
@@ -2070,6 +2180,23 @@ class RefiningEntry(Document):
 				"recovery_percentage": flt(recovery_percentage, 2),
 			}
 		)
+
+		# This path bypasses validate (db_set), so heal the table explicitly and persist the
+		# rows the same way distribute_recovered_gold does. db_set is a no-op on an unsaved
+		# row (name is None), so only persist rows that already exist.
+		self._sync_recovery_table()
+		for row in self.gold_recovery_details:
+			if not row.name:
+				continue
+			row.db_set(
+				{
+					"pure_gold_weight": flt(row.pure_gold_weight, 3),
+					"recovered_weight": flt(row.recovered_weight, 3),
+					"loss_weight": flt(row.loss_weight, 3),
+					"recovery_pct": flt(row.recovery_pct, 2),
+				}
+			)
+		self.db_set("recovery_table_out_of_sync", cint(self.recovery_table_out_of_sync))
 
 	@frappe.whitelist()
 	def verify_recovery(self):
@@ -2725,6 +2852,9 @@ class RefiningEntry(Document):
 		# this savepoint discards the auto-created batches, the inserted draft, the submit, and
 		# every cascade side effect in one shot. Only work done inside create_repack_se is
 		# rolled back — complete_refining's earlier writes precede the savepoint and survive.
+		# This entry mints pure gold AND pure dust; refuse before either reaches the ledger.
+		self._validate_mint_identity()
+
 		repack_savepoint = "refining_repack_attempt"
 		frappe.db.savepoint(repack_savepoint)
 
@@ -3139,6 +3269,7 @@ class RefiningEntry(Document):
 				po.delete(ignore_permissions=True)
 
 	def create_scrap_transfer_se(self):
+		self._validate_mint_identity()
 		scrap_warehouse = self.scrap_warehouse
 		dust_item = self.get_dust_item()
 		if scrap_warehouse and dust_item:
@@ -3687,19 +3818,13 @@ class RefiningEntry(Document):
 			or (item_code and item_code.upper().startswith("GB-"))
 		)
 
-	def is_finding_item(self, item_code):
-		"""Findings (clasps, jump rings, chain parts) — authoritative signal is a
-		"Finding …" item group ("Finding - V/T", "Finding DNU"); variant_of ships as F/FL.
-		NOTE: findings carry a gold purity, so is_gold_item() ALSO matches them. Findings
-		are treated as meltable gold (melted and recovered as pure gold), NOT returned
-		intact — see _is_returned_intact."""
-		variant_of = frappe.db.get_value("Item", item_code, "variant_of")
-		item_group = frappe.db.get_value("Item", item_code, "item_group")
-		return (
-			(item_group and "Finding" in item_group)
-			or variant_of in ("F", "FL")
-			or (item_code and item_code.upper().startswith(("F-", "FL-")))
-		)
+	# is_finding_item() was removed here deliberately, not lost. Findings classification had
+	# exactly one consumer — _is_returned_intact — and that stopped calling it when findings
+	# became meltable gold (they are melted and recovered as pure 24KT, so they are NOT handed
+	# back intact). It then had zero callers bench-wide. Refining draws no distinction between
+	# a finding and any other gold alloy row; only diamonds and gemstones are returned. If a
+	# finding-specific rule is ever needed again, restore it from git history rather than
+	# assuming the classification was still live.
 
 	def _is_returned_intact(self, item_code):
 		"""External refining (ALL types): diamonds and gemstones travel to the refiner


### PR DESCRIPTION
Add unit tests and recovery distribution logic for refining entries

- Introduced a new test suite for refining recovery distribution to ensure consistency between Recovery Summary and Gold Recovery Details.
- Implemented the `apportion` function to accurately distribute total values across weights, ensuring exact sums.
- Created `build_row_targets` to derive per-karat columns from authoritative parent totals, maintaining strict adherence to mass balance.
- Added rounding functionality to ensure compliance with Frappe's rounding standards.
- Enhanced validation checks in the refining entry process to prevent over-recovery and ensure accurate loss calculations.