### PR TITLE
Add tests for warehouse allocation and reservation handling in SNC

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
@@ -25,7 +25,9 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 
 class SerialNumberCreator(Document):
 	def validate(self):
-		pass
+		# Runs on draft save AND on submit (_submit -> save), so a document created
+		# before this existed repairs itself the next time it is saved or submitted.
+		split_source_rows_by_reservation(self)
 
 	def before_insert(self):
 		validate_not_metal_only(self)
@@ -215,7 +217,7 @@ def _warehouses_with_physical_batch(item_code, batch_no):
 	return out
 
 
-def _pick_source_warehouse(item_code, batch_no, requested_qty, candidates):
+def _pick_source_warehouse(item_code, batch_no, requested_qty, candidates, used=None):
 	"""First candidate warehouse whose physical batch qty covers ``requested_qty``.
 
 	Mirror of ``pc_tagging_stock_sync._pick_source_warehouse``. ``candidates`` is an
@@ -224,16 +226,22 @@ def _pick_source_warehouse(item_code, batch_no, requested_qty, candidates):
 	validator to check). For batch lines, returns the first candidate whose physical
 	batch qty + ``TOLERANCE`` >= ``requested_qty``; ``None`` if none qualifies (the
 	caller decides how to handle that).
+
+	``used`` is an optional ``{warehouse: qty}`` ledger of what sibling rows of the same
+	(item, batch) group have already claimed, subtracted from each candidate's physical
+	qty. Two rows of a warehouse-split group would otherwise both resolve to the largest
+	reserved warehouse and overdraw it. Left ``None`` the function behaves exactly as it
+	did before the ledger existed.
 	"""
 	if not candidates:
 		return None
 	if not batch_no:
 		return candidates[0]
 	for wh in candidates:
-		if (
-			flt(_physical_batch_qty(item_code, batch_no, wh) or 0) + TOLERANCE
-			>= requested_qty
-		):
+		available = flt(_physical_batch_qty(item_code, batch_no, wh) or 0) - flt(
+			(used or {}).get(wh, 0)
+		)
+		if available + TOLERANCE >= requested_qty:
 			return wh
 	return None
 
@@ -276,12 +284,369 @@ def _sre_reserves_batch(sre_name, batch_no):
 	return (not sre_batches) or (batch_no in sre_batches)
 
 
+def _pmo_mwo_names(doc):
+	"""``(pmo, [submitted MWO names])`` for this SNC's Parent Manufacturing Order.
+
+	This is the ONLY scope reservations are ever read from. Stock reserved for a
+	different job — even the same item and batch, even in the same warehouse — must
+	never be drawn on here. Falls back to the SNC's own MWO when the PMO has no
+	submitted work orders.
+	"""
+	mwo_name = cstr(getattr(doc, "manufacturing_work_order", None) or "").strip()
+	pmo = (
+		frappe.db.get_value("Manufacturing Work Order", mwo_name, "manufacturing_order")
+		if mwo_name
+		else None
+	)
+	names = (
+		frappe.get_all(
+			"Manufacturing Work Order",
+			{"manufacturing_order": pmo, "docstatus": 1},
+			pluck="name",
+		)
+		if pmo
+		else []
+	)
+	return pmo, (names or ([mwo_name] if mwo_name else []))
+
+
+def _active_sres_for(item_code, batch_no, mwo_names, warehouse=None, exclude=None):
+	"""``[(sre_dict, remaining_qty)]`` for live reservations of ``(item, batch)``.
+
+	Sorted remaining desc, then warehouse asc — deterministic regardless of DB row order.
+
+	Only ACTIVE reservations are candidates. A fully-delivered SRE (status
+	"Delivered"/"Cancelled" or ``delivered_qty >= reserved_qty``) is already consumed:
+	its warehouse is stale (the batch was physically moved out), its qty must not be
+	summed, and it must never be re-consumed. Remaining qty — not the status label — is
+	the authoritative "still active" guard; it also covers the Partially Delivered /
+	Partially Used / Closed states the coarse status filter does not catch.
+
+	``remaining`` is BATCH-scoped: a Serial-and-Batch reservation is capped by that
+	batch's own undelivered child qty, so an SRE covering three batches cannot lend its
+	whole header qty to one of them. A Qty-based SRE has no batch children and reserves
+	at item level, so it keeps the header remainder — the original behaviour, mirroring
+	``_sre_reserves_batch``.
+	"""
+	if not mwo_names:
+		return []
+
+	filters = {
+		"item_code": item_code,
+		"docstatus": 1,
+		"status": ["not in", ["Cancelled", "Delivered"]],
+		"manufacturing_work_order": ["in", mwo_names],
+	}
+	if warehouse:
+		filters["warehouse"] = warehouse
+
+	sres = frappe.get_all(
+		"Stock Reservation Entry",
+		filters=filters,
+		fields=["name", "warehouse", "reserved_qty", "delivered_qty"],
+	)
+	if exclude:
+		sres = [s for s in sres if s["name"] not in exclude]
+	if not sres:
+		return []
+
+	# One bulk child query for the whole set, instead of a _sre_reserves_batch
+	# round-trip per SRE.
+	children = {}
+	for child in frappe.get_all(
+		"Serial and Batch Entry",
+		filters={
+			"parent": ["in", [s["name"] for s in sres]],
+			"parenttype": "Stock Reservation Entry",
+		},
+		fields=["parent", "batch_no", "qty", "delivered_qty"],
+	):
+		children.setdefault(child["parent"], []).append(child)
+
+	out = []
+	for sre in sres:
+		header_remaining = flt(sre["reserved_qty"]) - flt(sre["delivered_qty"])
+		kids = children.get(sre["name"])
+		if kids:
+			if batch_no and batch_no not in {k["batch_no"] for k in kids}:
+				continue
+			scoped = sum(
+				flt(k["qty"]) - flt(k["delivered_qty"])
+				for k in kids
+				if not batch_no or k["batch_no"] == batch_no
+			)
+			remaining = min(header_remaining, scoped)
+		else:
+			remaining = header_remaining
+		if remaining <= TOLERANCE:
+			continue
+		out.append((sre, flt(remaining, 3)))
+
+	out.sort(key=lambda t: (-t[1], t[0]["warehouse"] or ""))
+	return out
+
+
+def _reserved_warehouse_caps(item_code, batch_no, mwo_names):
+	"""``[(warehouse, cap_qty, [sre_names])]`` — where this job may draw the batch from.
+
+	``cap = min(sum of reserved-remaining in that warehouse, physical batch qty there)``.
+	The physical cap stops the allocator promising stock the negative-batch validator
+	would reject at submit; the reservation cap stops it eating another job's metal. A
+	warehouse that merely HOLDS the batch without a reservation for this PMO never
+	appears in the result at all — that exclusion is structural, not a filter.
+
+	Sorted capacity desc, then warehouse asc.
+	"""
+	per_wh = {}
+	for sre, remaining in _active_sres_for(item_code, batch_no, mwo_names):
+		wh = sre["warehouse"]
+		if not wh:
+			continue
+		entry = per_wh.setdefault(wh, {"reserved": 0.0, "sres": []})
+		entry["reserved"] += remaining
+		entry["sres"].append(sre["name"])
+
+	caps = []
+	for wh, entry in per_wh.items():
+		cap = flt(entry["reserved"], 3)
+		if batch_no:
+			cap = min(cap, _physical_batch_qty(item_code, batch_no, wh))
+		cap = flt(cap, 3)
+		if cap > TOLERANCE:
+			caps.append((wh, cap, entry["sres"]))
+
+	caps.sort(key=lambda t: (-t[1], t[0]))
+	return caps
+
+
+def _allocate_qty_across_warehouses(total_qty, caps):
+	"""Greedy split of ``total_qty`` over ``caps`` → ``[(warehouse, qty)]`` or ``None``.
+
+	``None`` means the reservations cannot cover the full qty. The caller then leaves the
+	row alone so the existing single-warehouse resolution — and its fail-fast throw —
+	still applies. Splitting a partially-reserved row would either strand the residue on
+	an unreserved warehouse (another job's stock) or silently under-consume.
+
+	Never emits a zero/negative row, and the allocations sum to the caller's
+	``total_qty`` exactly: the sub-milligram residue between ``total_qty`` and its 3dp
+	rounding is folded back into the first allocation, so the per-item totals
+	``calulate_id_wise_sum_up`` checks cannot drift.
+	"""
+	total = flt(total_qty, 3)
+	if total <= TOLERANCE or not caps:
+		return None
+
+	allocations = []
+	need = total
+	for wh, cap, _sres in caps:
+		if need <= TOLERANCE:
+			break
+		take = flt(min(flt(cap, 3), need), 3)
+		if take <= TOLERANCE:
+			continue
+		allocations.append([wh, take])
+		need = flt(need - take, 3)
+
+	if need > TOLERANCE or not allocations:
+		return None
+
+	residue = flt(total_qty) - sum(a[1] for a in allocations)
+	if residue:
+		allocations[0][1] = allocations[0][1] + residue
+
+	return [(wh, qty) for wh, qty in allocations]
+
+
+def _allocate_pcs_across_rows(item_code, total_pcs, allocations):
+	"""Distribute ``total_pcs`` over split rows, preserving the per-item total.
+
+	Two regimes, matching the D/G-vs-other boundary ``_append_fg_rows_aggregated``
+	already draws:
+
+	* Diamond/Gemstone (``D``/``G`` prefix) — fg_details SUMS pcs across rows, and each
+	  warehouse holds a distinct set of physical stones, so split proportionally to the
+	  allocated weight (integer largest-remainder, total preserved, and no qty-bearing
+	  row left at 0 while the count allows).
+	* Metal / findings / everything else — fg_details takes ``max()``, so the whole count
+	  goes on the largest allocation and the rest get 0. That preserves both the sum and
+	  the max, and it is physically honest: a 0.02 g residue in another warehouse is not
+	  "a piece".
+
+	Never returns ``None`` for a row: ``Stock Entry Detail.pcs`` is a Data field with
+	``default: "1"``, so a ``None`` would silently become 1 and inflate the count.
+	"""
+	count = len(allocations)
+	if count <= 1:
+		return [flt(total_pcs)] * count
+
+	total = flt(total_pcs)
+	if total <= 0:
+		return [0.0] * count
+
+	is_stone = (item_code or "")[:1].upper() in ("D", "G")
+	whole = cint(total)
+	if not is_stone or whole != total or whole < count:
+		# Metal/other, a fractional count, or fewer stones than rows: keep the count
+		# whole on the largest allocation rather than inventing fractional stones.
+		parts = [0.0] * count
+		parts[0] = total
+		return parts
+
+	total_qty = sum(flt(qty) for _wh, qty in allocations) or 1
+	exact = [whole * flt(qty) / total_qty for _wh, qty in allocations]
+	parts = [int(x) for x in exact]
+	for idx in sorted(range(count), key=lambda i: -(exact[i] - parts[i]))[
+		: whole - sum(parts)
+	]:
+		parts[idx] += 1
+
+	# A warehouse that physically holds part of the batch holds at least one stone.
+	for idx in range(count):
+		if parts[idx]:
+			continue
+		donor = max(range(count), key=lambda i: parts[i])
+		if parts[donor] > 1:
+			parts[donor] -= 1
+			parts[idx] = 1
+
+	return [flt(p) for p in parts]
+
+
+def _reserved_summary_text(item_code, batch_no, mwo_names):
+	"""``"WH A: 3.557, WH B: 0.02 (total 3.577)"`` — what THIS job has reserved."""
+	caps = _reserved_warehouse_caps(item_code, batch_no, mwo_names)
+	if not caps:
+		return "none"
+	total = flt(sum(cap for _wh, cap, _sres in caps), 3)
+	return ", ".join(f"{wh}: {cap}" for wh, cap, _sres in caps) + f" (total {total})"
+
+
+def _group_source_pcs(item_code, rows):
+	"""Pcs total for an (item, batch) group, mirroring ``_append_fg_rows_aggregated``."""
+	values = [flt(row.pcs or 0) for row in rows]
+	if not values:
+		return 0.0
+	if (item_code or "")[:1].upper() in ("D", "G"):
+		return flt(sum(values))
+	return flt(max(values))
+
+
+def _same_allocation(rows, allocations):
+	"""True when the source rows already match the allocation exactly."""
+	if len(rows) != len(allocations):
+		return False
+	for row, (wh, qty) in zip(rows, allocations):
+		if row.s_warehouse != wh or flt(row.qty, 3) != flt(qty, 3):
+			return False
+	return True
+
+
+def split_source_rows_by_reservation(doc):
+	"""Key ``source_table`` by (item, batch, **warehouse**) instead of (item, batch).
+
+	One (item, batch) can legitimately be reserved for this job across SEVERAL
+	warehouses — e.g. 3.557 g of a 22KT batch in Waxing WO plus a 0.02 g remainder in
+	Model Making WO. A single row carrying the combined 3.577 g cannot name one source
+	warehouse, and ``_pick_source_warehouse`` rightly refuses to draw the whole amount
+	from a warehouse holding only part of it. Splitting the row per reserved warehouse
+	is the only representation that matches the physical stock.
+
+	``fg_details`` is deliberately untouched: it stays aggregated per item, which is what
+	``calulate_id_wise_sum_up`` and the FG BOM expect. Only the source rows change, and
+	the split preserves the per-item qty total, so that check still balances.
+
+	Runs from ``validate`` so it applies on a plain draft save — the operator sees the
+	split before submitting — AND on submit. ``_save`` persists child rows through
+	``update_children()`` before ``on_submit`` fires, so the split rows already carry
+	names when ``to_prepare_data_for_make_mnf_stock_entry`` writes back to them.
+
+	Idempotent: the allocation is recomputed from the GROUP total, never from the
+	individual rows, and nothing is consumed until submit — so a second pass sees the
+	same reservations and physical qtys, produces the same allocation, and writes
+	nothing. Convergent too: if the reservations later collapse onto one warehouse the
+	group merges back to a single row.
+	"""
+	if doc.docstatus == 2 or doc.flags.get("ignore_snc_source_split"):
+		return
+	if not doc.source_table or not doc.manufacturing_work_order:
+		return
+
+	_pmo, mwo_names = _pmo_mwo_names(doc)
+	if not mwo_names:
+		return
+
+	groups = {}
+	for row in doc.source_table:
+		groups.setdefault((row.row_material, row.batch_no), []).append(row)
+
+	new_rows = []
+	changed = False
+	for (item_code, batch_no), rows in groups.items():
+		if not item_code:
+			new_rows.extend(rows)
+			continue
+
+		group_qty = flt(sum(flt(row.qty) for row in rows), 3)
+		caps = _reserved_warehouse_caps(item_code, batch_no, mwo_names)
+		allocations = _allocate_qty_across_warehouses(group_qty, caps)
+
+		if not allocations or _same_allocation(rows, allocations):
+			new_rows.extend(rows)
+			continue
+
+		changed = True
+		pcs_parts = _allocate_pcs_across_rows(
+			item_code, _group_source_pcs(item_code, rows), allocations
+		)
+		template = rows[0]
+		for idx, ((wh, qty), pcs) in enumerate(zip(allocations, pcs_parts)):
+			if idx < len(rows):
+				# Reuse the existing child so its name survives — an UPDATE rather than a
+				# delete + re-insert, which keeps db_set write-backs and version history
+				# addressing the same rows.
+				row = rows[idx]
+				row.qty = qty
+				row.pcs = pcs
+				row.s_warehouse = wh
+			else:
+				row = {
+					"row_material": item_code,
+					"batch_no": batch_no,
+					"qty": qty,
+					"pcs": pcs,
+					"s_warehouse": wh,
+					"uom": template.uom,
+					"inventory_type": template.inventory_type,
+					"customer": template.customer,
+					"sub_setting_type": template.sub_setting_type,
+					"sed_item": template.sed_item,
+					"is_customer_item": template.is_customer_item,
+					"default_bom_rm": template.default_bom_rm,
+					"bom_qty": template.bom_qty,
+					"bom_pcs": template.bom_pcs,
+				}
+			new_rows.append(row)
+		# Surplus rows (reservations collapsed onto fewer warehouses) are dropped here.
+
+	if not changed:
+		return
+
+	doc.set("source_table", [])
+	for row in new_rows:
+		doc.append("source_table", row)
+	# Re-appended child Documents keep their old idx, so renumber explicitly.
+	for idx, row in enumerate(doc.source_table, start=1):
+		row.idx = idx
+
+
 def to_prepare_data_for_make_mnf_stock_entry(self):
 	"""Use source_table (batch-wise) for stock entry creation.
 
-	source_table has one row per (item_code, batch_no) with all batch detail
-	needed for the manufacturing stock entry (s_warehouse, inventory_type, etc.).
-	fg_details is kept for BOM creation (aggregated item/qty/pcs).
+	source_table has one row per (item_code, batch_no, s_warehouse) with all batch
+	detail needed for the manufacturing stock entry (inventory_type, pcs, etc.). One
+	(item, batch) can span several rows when the job's reservation for it is spread over
+	more than one warehouse — see ``split_source_rows_by_reservation``. fg_details is
+	kept for BOM creation (aggregated item/qty/pcs).
 	"""
 
 	# Build row_data from source_table (batch-wise) for stock entry
@@ -317,6 +682,13 @@ def to_prepare_data_for_make_mnf_stock_entry(self):
 				"pcs": row.pcs,
 				"s_warehouse": row.s_warehouse,
 				"sub_setting_type": row.sub_setting_type,
+				# 1:1 back-link to the SNC Source Table child. Warehouse write-backs key
+				# on this: sibling rows of a warehouse-split group share item AND batch,
+				# so an (item, batch) match would overwrite every sibling's warehouse with
+				# whichever row was resolved last. create_manufacturing_entry reads the
+				# keys it needs individually (it never **-splats the dict), so the extra
+				# key is inert downstream.
+				"snc_source_row": row.name,
 			}
 		)
 
@@ -355,317 +727,321 @@ def to_prepare_data_for_make_mnf_stock_entry(self):
 		preallocate_series_for_docs(
 			*series_stubs(self.company, "Repack", "Manufacture")
 		)
-		lock_bins([(r["item_code"], r.get("s_warehouse")) for r in row_data])
+		_pmo, all_pmo_mwos = _pmo_mwo_names(self)
+
+		# Group the source rows by (item, batch). One (item, batch) can span several rows
+		# when the job's reservation for it is spread over more than one warehouse. Every
+		# row of such a group sees the SAME reservations, so reservation consumption and
+		# loss must be accounted ONCE per group: per-row accounting would consume the same
+		# SREs repeatedly and book a phantom Repack(Loss) for every sibling.
+		row_groups = {}
+		for row in row_data:
+			if not row.get("s_warehouse"):
+				continue
+			row_groups.setdefault((row["item_code"], row.get("batch_no")), []).append(
+				row
+			)
+
+		# Pre-lock every Bin this cascade may draw from — each row's own warehouse plus
+		# every reserved warehouse a row could still be re-pointed at below.
+		group_caps = {}
+		lock_targets = [(r["item_code"], r.get("s_warehouse")) for r in row_data]
+		for (item_code, batch_no), rows in row_groups.items():
+			caps = _reserved_warehouse_caps(item_code, batch_no, all_pmo_mwos)
+			group_caps[(item_code, batch_no)] = caps
+			lock_targets.extend((item_code, wh) for wh, _cap, _sres in caps)
+		lock_bins(lock_targets)
+
+		src_by_name = {r.name: r for r in self.source_table}
+
+		def _write_back_warehouse(row):
+			"""Persist the resolved warehouse onto THIS row's source_table child.
+
+			Keyed on the child row name, not (item, batch): sibling rows of a split group
+			share item and batch, so an (item, batch) match would overwrite every sibling's
+			warehouse with whichever row happened to be resolved last.
+			"""
+			st_row = src_by_name.get(row.get("snc_source_row"))
+			if st_row and st_row.s_warehouse != row["s_warehouse"]:
+				st_row.s_warehouse = row["s_warehouse"]
+				st_row.db_set("s_warehouse", row["s_warehouse"])
 
 		bins_to_update = set()
-		for row in row_data:
-			if row.get("s_warehouse"):
-				pmo = frappe.db.get_value(
-					"Manufacturing Work Order",
-					self.manufacturing_work_order,
-					"manufacturing_order",
-				)
-				# sales_order = frappe.db.get_value(
-				# 	"Parent Manufacturing Order", pmo, "sales_order"
-				# )
+		consumed_sres = set()
+		for (item_code, batch_no), rows in row_groups.items():
+			group_qty = flt(sum(flt(r["qty"]) for r in rows), 3)
+			sre_reserved_qty_total = 0.0
+			used = {}
 
-				sre_reserved_qty_total = 0.0
+			# ── PRIORITY 1: SRE — capture warehouse + consume reservations ──
+			# Scoped to the MWOs of this PMO only; stock reserved for another job is
+			# never a candidate, however much of the batch it holds.
+			active_sres = _active_sres_for(
+				item_code, batch_no, all_pmo_mwos, exclude=consumed_sres
+			)
+			sre_matched = bool(active_sres)
 
-				# ── PRIORITY 1: SRE — capture warehouse + consume reservations ──
-				# Find all MWOs linked to this PMO for comprehensive SRE lookup
-				all_pmo_mwos = frappe.get_all(
-					"Manufacturing Work Order",
-					{"manufacturing_order": pmo, "docstatus": 1},
-					pluck="name",
-				)
-				if not all_pmo_mwos:
-					all_pmo_mwos = [self.manufacturing_work_order]
+			if sre_matched:
+				sre_warehouses = [
+					wh for wh, _cap, _sres in group_caps[(item_code, batch_no)]
+				]
 
-				# Only ACTIVE reservations are candidates. A fully-delivered SRE
-				# (status "Delivered"/"Cancelled" or delivered_qty >= reserved_qty) is
-				# already consumed: its warehouse is stale (the batch was physically
-				# moved out), its qty must not be summed, and it must never be
-				# re-consumed. Pulling status/qty fields here lets us filter without a
-				# get_doc round-trip per SRE.
-				linked_sres = frappe.get_all(
-					"Stock Reservation Entry",
-					filters={
-						"item_code": row["item_code"],
-						"docstatus": 1,
-						"status": ["not in", ["Cancelled", "Delivered"]],
-						"manufacturing_work_order": ["in", all_pmo_mwos],
-					},
-					fields=["name", "warehouse", "reserved_qty", "delivered_qty"],
-				)
-
-				row_batch = row.get("batch_no")
-
-				# Keep only SREs that reserve THIS row's batch AND still have
-				# undelivered qty. remaining-qty (not the status label) is the
-				# authoritative "still active" guard — it also covers Partially
-				# Delivered / Partially Used / Closed states the coarse status filter
-				# above does not catch.
-				active_sres = []
-				for sre in linked_sres:
-					if row_batch and not _sre_reserves_batch(sre["name"], row_batch):
-						continue
-					remaining = flt(sre["reserved_qty"]) - flt(sre["delivered_qty"])
-					if remaining <= TOLERANCE:
-						continue
-					active_sres.append((sre, remaining))
-
-				sre_matched = bool(active_sres)
-
-				if sre_matched:
-					# Deterministic order independent of DB row order: remaining-qty
-					# desc, then warehouse name asc as tie-break.
-					active_sres.sort(key=lambda t: (-t[1], t[0]["warehouse"] or ""))
-
-					# Build an ordered, deduped candidate warehouse list and pick the
-					# first that PHYSICALLY covers the full row qty. Active-SRE
-					# warehouses come first (highest remaining first) — the live
-					# reservation is the authoritative physical location — and the
-					# original source_table s_warehouse is appended as a last-resort
-					# fallback. For batch rows _pick_source_warehouse skips any
-					# candidate that cannot cover the qty: this is what stops a stale
-					# reservation pointing at a partially-stocked warehouse from being
-					# adopted and driving the Manufacture entry negative. For non-batch
-					# (qty-based) rows there is no batch validator, so the first
-					# candidate (the top active-SRE warehouse) is adopted — preserving
-					# the previous behaviour of trusting the reservation warehouse.
+				# Largest row first, so the biggest requirement claims the warehouse that
+				# can actually hold it before a small sibling nibbles at it.
+				for row in sorted(rows, key=lambda r: -flt(r["qty"])):
+					# Candidate order: the row's OWN warehouse first when it still carries
+					# a live reservation — that is the allocation
+					# split_source_rows_by_reservation sized this row against — then the
+					# remaining reserved warehouses by capacity, then the row's own
+					# warehouse as the last-resort fallback. Without the first entry a
+					# 0.02 g sibling would resolve to the 3.557 g warehouse: both rows
+					# would target it and the Manufacture entry would go negative. For
+					# single-row groups the first entry never applies, so resolution is
+					# exactly what it was before.
+					own = row.get("s_warehouse")
 					candidates = []
-					for sre, _rem in active_sres:
-						if sre["warehouse"] and sre["warehouse"] not in candidates:
-							candidates.append(sre["warehouse"])
-					if row.get("s_warehouse") and row["s_warehouse"] not in candidates:
-						candidates.append(row["s_warehouse"])
+					if len(rows) > 1 and own in sre_warehouses:
+						candidates.append(own)
+					for wh in sre_warehouses:
+						if wh not in candidates:
+							candidates.append(wh)
+					if own and own not in candidates:
+						candidates.append(own)
 
 					resolved_wh = _pick_source_warehouse(
-						row["item_code"], row_batch, flt(row["qty"], 3), candidates
+						item_code, batch_no, flt(row["qty"], 3), candidates, used=used
 					)
 					if resolved_wh:
 						row["s_warehouse"] = resolved_wh
-					elif row_batch:
-						# No candidate physically covers the full qty — fail fast with
-						# an actionable message instead of a cryptic BatchNegativeStock
-						# error on the auto-created Manufacture entry.
-						holders = _warehouses_with_physical_batch(
-							row["item_code"], row_batch
+						used[resolved_wh] = flt(
+							flt(used.get(resolved_wh, 0)) + flt(row["qty"], 3), 3
 						)
+					elif batch_no:
+						# No candidate physically covers the qty — fail fast with an
+						# actionable message instead of a cryptic BatchNegativeStock error
+						# on the auto-created Manufacture entry.
+						holders = _warehouses_with_physical_batch(item_code, batch_no)
 						holders_str = (
 							", ".join(f"{wh}: {qty}" for wh, qty in holders) or "none"
 						)
 						frappe.throw(
 							_(
 								"Batch {0} of {1} does not have {2} available in any "
-								"reserved/source warehouse. Physical stock — {3}."
+								"reserved/source warehouse.<br><br>"
+								"<b>Reserved for this job</b> — {3}.<br>"
+								"<b>Physical stock (all warehouses)</b> — {4}.<br><br>"
+								"Stock in a warehouse without a reservation for this job "
+								"cannot be consumed here."
 							).format(
-								row_batch,
-								row["item_code"],
+								batch_no,
+								item_code,
 								flt(row["qty"], 3),
+								_reserved_summary_text(
+									item_code, batch_no, all_pmo_mwos
+								),
 								holders_str,
 							)
 						)
 
-					# Sum REMAINING qty (not reserved_qty) over active SREs so a
-					# partially-delivered reservation does not inflate loss_qty into a
-					# phantom Repack(Loss).
-					sre_reserved_qty_total = sum(rem for _sre, rem in active_sres)
+				# Sum REMAINING qty (not reserved_qty) over the group's active SREs so a
+				# partially-delivered reservation does not inflate loss_qty into a phantom
+				# Repack(Loss). Summed once for the GROUP — the split rows share these
+				# reservations, so per-row summing would multiply the loss by the number of
+				# siblings.
+				sre_reserved_qty_total = sum(rem for _sre, rem in active_sres)
 
-					# Consume ONLY the active SREs (mark Delivered). A fully-delivered
-					# SRE is excluded above and is never re-consumed.
-					from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
-						consume_stock_reservation_entry,
+				# Consume ONLY the active SREs (mark Delivered). A fully-delivered SRE is
+				# excluded above and is never re-consumed; consumed_sres additionally stops
+				# an item-level (Qty-based) reservation, which matches every batch, from
+				# being consumed twice by two different batch groups.
+				from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
+					consume_stock_reservation_entry,
+				)
+
+				for sre, _rem in active_sres:
+					frappe.clear_document_cache("Bin")
+					sre_doc = frappe.get_doc("Stock Reservation Entry", sre["name"])
+					consume_stock_reservation_entry(sre_doc, update_bin=False)
+					consumed_sres.add(sre["name"])
+					if sre_doc.item_code and sre_doc.warehouse:
+						bins_to_update.add((sre_doc.item_code, sre_doc.warehouse))
+					frappe.clear_document_cache("Bin")
+
+				# Persist the corrected source warehouses back to source_table
+				for row in rows:
+					_write_back_warehouse(row)
+
+			if not sre_matched:
+				# ── PRIORITY 2: Product Certification Receive ──
+				pc_receive_data = frappe.db.sql(
+					"""
+					SELECT se_item.t_warehouse, se_item.qty
+					FROM `tabStock Entry` se
+					JOIN `tabStock Entry Detail` se_item ON se.name = se_item.parent
+					JOIN `tabProduct Certification` pc ON se.product_certification = pc.name
+					WHERE pc.type = 'Receive'
+					  AND se.docstatus = 1
+					  AND EXISTS(
+					      SELECT 1 FROM `tabProduct Details` pd
+					      WHERE pd.parent = pc.name
+					        AND (pd.manufacturing_work_order = %(mwo)s
+					             OR pd.parent_manufacturing_order = %(pmo)s)
+					  )
+					  AND se_item.item_code = %(item_code)s
+					ORDER BY se.creation DESC LIMIT 1
+				""",
+					{
+						"mwo": self.manufacturing_work_order,
+						"pmo": pmo,
+						"item_code": item_code,
+					},
+					as_dict=1,
+				)
+
+				if pc_receive_data:
+					candidate_wh = pc_receive_data[0].t_warehouse
+					# Only use the PC Receive warehouse if the batch actually has stock
+					# there. A later SE (e.g. pc_tagging_stock_sync return) may have
+					# moved it back to Tagging, creating a different batch_no. Using
+					# the stale PC WH in that case causes BatchNegativeStockError.
+					batch_qty_at_candidate = (
+						flt(get_batch_qty(batch_no, candidate_wh, item_code))
+						if batch_no
+						else flt(pc_receive_data[0].qty)
 					)
-
-					for sre, _rem in active_sres:
-						frappe.clear_document_cache("Bin")
-						sre_doc = frappe.get_doc("Stock Reservation Entry", sre["name"])
-						consume_stock_reservation_entry(sre_doc, update_bin=False)
-						if sre_doc.item_code and sre_doc.warehouse:
-							bins_to_update.add((sre_doc.item_code, sre_doc.warehouse))
-						frappe.clear_document_cache("Bin")
-
-					# Persist the corrected source warehouse back to source_table
-					for st_row in self.source_table:
-						if st_row.row_material == row[
-							"item_code"
-						] and st_row.batch_no == row.get("batch_no"):
-							st_row.s_warehouse = row["s_warehouse"]
-							st_row.db_set(
-								"s_warehouse",
-								row["s_warehouse"],
-							)
-
-				if not sre_matched:
-					# ── PRIORITY 2: Product Certification Receive ──
-					pc_receive_data = frappe.db.sql(
-						"""
-						SELECT se_item.t_warehouse, se_item.qty
-						FROM `tabStock Entry` se
-						JOIN `tabStock Entry Detail` se_item ON se.name = se_item.parent
-						JOIN `tabProduct Certification` pc ON se.product_certification = pc.name
-						WHERE pc.type = 'Receive'
-						  AND se.docstatus = 1
-						  AND EXISTS(
-						      SELECT 1 FROM `tabProduct Details` pd
-						      WHERE pd.parent = pc.name
-						        AND (pd.manufacturing_work_order = %(mwo)s
-						             OR pd.parent_manufacturing_order = %(pmo)s)
-						  )
-						  AND se_item.item_code = %(item_code)s
-						ORDER BY se.creation DESC LIMIT 1
-					""",
-						{
-							"mwo": self.manufacturing_work_order,
-							"pmo": pmo,
-							"item_code": row["item_code"],
-						},
-						as_dict=1,
-					)
-
-					if pc_receive_data:
-						candidate_wh = pc_receive_data[0].t_warehouse
-						batch_no = row.get("batch_no")
-						# Only use the PC Receive warehouse if the batch actually has stock
-						# there. A later SE (e.g. pc_tagging_stock_sync return) may have
-						# moved it back to Tagging, creating a different batch_no. Using
-						# the stale PC WH in that case causes BatchNegativeStockError.
-						batch_qty_at_candidate = (
-							flt(get_batch_qty(batch_no, candidate_wh, row["item_code"]))
-							if batch_no
-							else flt(pc_receive_data[0].qty)
-						)
-						if batch_qty_at_candidate > 0:
-							sre_reserved_qty_total = flt(pc_receive_data[0].qty)
+					if batch_qty_at_candidate > 0:
+						sre_reserved_qty_total = flt(pc_receive_data[0].qty)
+						for row in rows:
 							row["s_warehouse"] = candidate_wh
-							for st_row in self.source_table:
-								if (
-									st_row.row_material == row["item_code"]
-									and st_row.batch_no == batch_no
-								):
-									st_row.s_warehouse = candidate_wh
-									st_row.db_set(
-										"s_warehouse",
-										candidate_wh,
-									)
-					else:
-						# ── PRIORITY 3: Stock Entry linked to PMO ──
-						se_wh = frappe.db.sql(
-							"""
-							SELECT sed.t_warehouse, sed.s_warehouse
-							FROM `tabStock Entry Detail` sed
-							JOIN `tabStock Entry` se ON se.name = sed.parent
-							WHERE se.manufacturing_order = %s
-							  AND sed.item_code = %s
-							  AND se.docstatus = 1
-							ORDER BY se.creation DESC
-							LIMIT 1
-						""",
-							(self.parent_manufacturing_order, row["item_code"]),
-							as_dict=True,
-						)
+							_write_back_warehouse(row)
+				else:
+					# ── PRIORITY 3: Stock Entry linked to PMO ──
+					se_wh = frappe.db.sql(
+						"""
+						SELECT sed.t_warehouse, sed.s_warehouse
+						FROM `tabStock Entry Detail` sed
+						JOIN `tabStock Entry` se ON se.name = sed.parent
+						WHERE se.manufacturing_order = %s
+						  AND sed.item_code = %s
+						  AND se.docstatus = 1
+						ORDER BY se.creation DESC
+						LIMIT 1
+					""",
+						(self.parent_manufacturing_order, item_code),
+						as_dict=True,
+					)
 
-						if se_wh:
-							fallback_wh = se_wh[0].t_warehouse or se_wh[0].s_warehouse
-							if fallback_wh:
+					if se_wh:
+						fallback_wh = se_wh[0].t_warehouse or se_wh[0].s_warehouse
+						if fallback_wh:
+							for row in rows:
 								row["s_warehouse"] = fallback_wh
-								for st_row in self.source_table:
-									if st_row.row_material == row[
-										"item_code"
-									] and st_row.batch_no == row.get("batch_no"):
-										st_row.s_warehouse = row["s_warehouse"]
-										st_row.db_set(
-											"s_warehouse",
-											row["s_warehouse"],
-										)
+								_write_back_warehouse(row)
 
-				loss_qty = sre_reserved_qty_total - flt(row["qty"])
+			# Group-level, so a warehouse split yields the SAME loss the single row would
+			# have produced (3.557 + 0.02 consumed against 3.577 reserved -> zero loss).
+			loss_qty = flt(sre_reserved_qty_total - group_qty, 3)
 
-				if loss_qty > 0:
-					variant_of = frappe.db.get_value(
-						"Item", row["item_code"], "variant_of"
-					)
-					loss_warehouse = None
-					variant_loss_details = frappe.db.get_value(
-						"Variant Loss Warehouse",
-						{
-							"parent": self.manufacturer,
-							"variant": variant_of or row["item_code"],
-						},
-						[
-							"loss_warehouse",
-							"consider_department_warehouse",
-							"warehouse_type",
-						],
-						as_dict=1,
-					)
+			if loss_qty > 0:
+				variant_of = frappe.db.get_value("Item", item_code, "variant_of")
+				loss_warehouse = None
+				variant_loss_details = frappe.db.get_value(
+					"Variant Loss Warehouse",
+					{
+						"parent": self.manufacturer,
+						"variant": variant_of or item_code,
+					},
+					[
+						"loss_warehouse",
+						"consider_department_warehouse",
+						"warehouse_type",
+					],
+					as_dict=1,
+				)
 
-					if variant_loss_details:
-						if variant_loss_details.get("loss_warehouse"):
-							loss_warehouse = variant_loss_details.get("loss_warehouse")
-						elif variant_loss_details.get(
-							"consider_department_warehouse"
-						) and variant_loss_details.get("warehouse_type"):
-							loss_warehouse = frappe.db.get_value(
-								"Warehouse",
-								{
-									"disabled": 0,
-									"department": self.department,
-									"warehouse_type": variant_loss_details.get(
-										"warehouse_type"
-									),
-								},
-							)
-
-					if loss_warehouse:
-						# Duplicate guard: skip if a Repack entry already exists for this SNC + item
-						existing_loss_se = frappe.db.sql(
-							"""
-							SELECT se.name
-							FROM `tabStock Entry` se
-							JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
-							WHERE se.custom_serial_number_creator = %s
-							  AND se.stock_entry_type = 'Repack'
-							  AND se.docstatus != 2
-							  AND sed.item_code = %s
-							LIMIT 1
-							""",
-							(self.name, row["item_code"]),
+				if variant_loss_details:
+					if variant_loss_details.get("loss_warehouse"):
+						loss_warehouse = variant_loss_details.get("loss_warehouse")
+					elif variant_loss_details.get(
+						"consider_department_warehouse"
+					) and variant_loss_details.get("warehouse_type"):
+						loss_warehouse = frappe.db.get_value(
+							"Warehouse",
+							{
+								"disabled": 0,
+								"department": self.department,
+								"warehouse_type": variant_loss_details.get(
+									"warehouse_type"
+								),
+							},
 						)
-						if existing_loss_se:
-							frappe.msgprint(
-								_(
-									"Repack (Loss) Stock Entry already exists for {0}"
-								).format(row["item_code"])
-							)
-						else:
-							se_loss = frappe.new_doc("Stock Entry")
-							se_loss.stock_entry_type = "Repack"
-							se_loss.purpose = "Repack"
-							se_loss.company = self.company
-							se_loss.custom_serial_number_creator = self.name
+
+				if loss_warehouse:
+					# Duplicate guard: skip if a Repack entry already exists for this
+					# SNC + item + batch. Keying on item alone would silently swallow a
+					# genuine loss on a second batch of the same item and strand the metal
+					# in WIP.
+					existing_loss_se = frappe.db.sql(
+						"""
+						SELECT se.name
+						FROM `tabStock Entry` se
+						JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
+						WHERE se.custom_serial_number_creator = %s
+						  AND se.stock_entry_type = 'Repack'
+						  AND se.docstatus != 2
+						  AND sed.item_code = %s
+						  AND sed.batch_no <=> %s
+						LIMIT 1
+						""",
+						(self.name, item_code, batch_no),
+					)
+					if existing_loss_se:
+						frappe.msgprint(
+							_(
+								"Repack (Loss) Stock Entry already exists for {0} (batch {1})"
+							).format(item_code, batch_no or "-")
+						)
+					else:
+						# Draw the loss from whatever reserved capacity the group did not
+						# consume. A split group can leave residue in more than one
+						# warehouse, and Repack cannot take more of a batch out of a
+						# warehouse than it physically holds.
+						residual = []
+						for wh, cap, _sres in group_caps.get((item_code, batch_no), []):
+							left = flt(flt(cap, 3) - flt(used.get(wh, 0)), 3)
+							if left > TOLERANCE:
+								residual.append((wh, left, _sres))
+						loss_alloc = _allocate_qty_across_warehouses(
+							loss_qty, residual
+						) or [(rows[0]["s_warehouse"], loss_qty)]
+
+						se_loss = frappe.new_doc("Stock Entry")
+						se_loss.stock_entry_type = "Repack"
+						se_loss.purpose = "Repack"
+						se_loss.company = self.company
+						se_loss.custom_serial_number_creator = self.name
+						for loss_wh, loss_row_qty in loss_alloc:
 							se_loss.append(
 								"items",
 								{
-									"item_code": row["item_code"],
-									"qty": loss_qty,
-									"s_warehouse": row["s_warehouse"],
+									"item_code": item_code,
+									"qty": loss_row_qty,
+									"s_warehouse": loss_wh,
 									"t_warehouse": loss_warehouse,
-									"batch_no": row.get("batch_no"),
-									"inventory_type": row.get("inventory_type"),
-									"customer": row.get("customer"),
+									"batch_no": batch_no,
+									"inventory_type": rows[0].get("inventory_type"),
+									"customer": rows[0].get("customer"),
 									"use_serial_batch_fields": 1,
 								},
 							)
-							se_loss.insert(ignore_permissions=True)
-							se_loss.submit()
+						se_loss.insert(ignore_permissions=True)
+						se_loss.submit()
 
-				# (perf/lock-hold) Removed a per-row global frappe.clear_cache() here: it
-				# wiped the entire cache on every source row, forcing cold re-reads for the
-				# rest of the held-lock window. The only per-row staleness that matters (Bin
-				# qty after SRE consume) is already handled by the scoped
-				# clear_document_cache("Bin") at the consume step above.
+			# (perf/lock-hold) Removed a per-row global frappe.clear_cache() here: it
+			# wiped the entire cache on every source row, forcing cold re-reads for the
+			# rest of the held-lock window. The only per-row staleness that matters (Bin
+			# qty after SRE consume) is already handled by the scoped
+			# clear_document_cache("Bin") at the consume step above.
 
 		if bins_to_update:
 			from erpnext.stock.utils import get_or_make_bin

--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/serial_number_creator.py
@@ -378,9 +378,17 @@ def _active_sres_for(item_code, batch_no, mwo_names, warehouse=None, exclude=Non
 			remaining = min(header_remaining, scoped)
 		else:
 			remaining = header_remaining
+		# Round to the site's 3dp stock precision BEFORE the liveness test, so the
+		# threshold and the returned value agree. Filtering on the raw remainder and
+		# returning the rounded one lets a remainder in (TOLERANCE, 0.0005) come back
+		# as 0.0: the caller would see a "live" reservation that contributes no
+		# capacity, marking sre_matched True — which consumes the SRE and skips the
+		# PC-Receive / Stock-Entry warehouse fallbacks on the strength of nothing.
+		# ``_reserved_warehouse_caps`` already rounds-then-filters; match it.
+		remaining = flt(remaining, 3)
 		if remaining <= TOLERANCE:
 			continue
-		out.append((sre, flt(remaining, 3)))
+		out.append((sre, remaining))
 
 	out.sort(key=lambda t: (-t[1], t[0]["warehouse"] or ""))
 	return out

--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/test_serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/test_serial_number_creator.py
@@ -832,6 +832,43 @@ class TestActiveSresFor(IntegrationTestCase):
 		self.assertEqual(_active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]), [])
 
 	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_remainder_rounding_to_zero_is_not_live(self, mock_get_all):
+		# A remainder inside (TOLERANCE, 0.0005) rounds to 0.000 at the site's 3dp stock
+		# precision. Returning it would make sre_matched True on a reservation with no
+		# capacity: the SRE would be consumed and the PC-Receive / Stock-Entry warehouse
+		# fallbacks skipped for nothing. Unreachable while the qty columns are
+		# decimal(21,3), but the threshold must not depend on that.
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 3.5,
+					"delivered_qty": 3.4997,
+				}
+			],
+			[],
+		)
+		self.assertEqual(_active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]), [])
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_smallest_real_remainder_is_live(self, mock_get_all):
+		# The smallest remainder the schema can actually produce (0.001) must survive.
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 3.5,
+					"delivered_qty": 3.499,
+				}
+			],
+			[],
+		)
+		out = _active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"])
+		self.assertEqual([rem for _sre, rem in out], [0.001])
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
 	def test_qty_based_sre_uses_header_remaining(self, mock_get_all):
 		mock_get_all.side_effect = self._mock_get_all(
 			[

--- a/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/test_serial_number_creator.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/serial_number_creator/test_serial_number_creator.py
@@ -22,11 +22,16 @@ from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.test_m
 	create_pmo,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.serial_number_creator.serial_number_creator import (
+	_active_sres_for,
+	_allocate_pcs_across_rows,
+	_allocate_qty_across_warehouses,
 	_physical_batch_qty,
 	_pick_source_warehouse,
+	_reserved_warehouse_caps,
 	_sre_reserves_batch,
 	_warehouse_has_batch_stock,
 	calulate_id_wise_sum_up,
+	split_source_rows_by_reservation,
 	validate_qty,
 )
 
@@ -616,3 +621,519 @@ class TestDeriveOwnershipTag(IntegrationTestCase):
 	def test_blank_rows_do_not_block_outright(self):
 		row_data = [{"inventory_type": "Regular Stock"}, {"inventory_type": None}]
 		self.assertEqual(_derive_ownership_tag(row_data), "Outright")
+
+
+# ── Warehouse-split source rows ────────────────────────────────────────────────
+#
+# Live case behind the whole group: SNC 7e4huirltd, batch None2F074-MGL22919Y0-01VO7
+# of M-G-22KT-91.9-Y. The job reserved 3.557 in "Waxing WO - KGJPL" and 0.02 in
+# "Model Making WO - KGJPL" — 3.577 total, exactly the source row qty — but the single
+# source row demanded all 3.577 from one warehouse and submit threw. The same batch also
+# sits in four other warehouses (Casting MSL WH 1: 6.35, Model Making RM: 5.0, Assembly
+# MSL WH 14: 4.98, Waxing RM: 1.763) reserved for OTHER jobs, which must never be drawn on.
+
+_LIVE_BATCH = "None2F074-MGL22919Y0-01VO7"
+_LIVE_ITEM = "M-G-22KT-91.9-Y"
+_WAXING = "Waxing WO - KGJPL"
+_MODEL_MAKING = "Model Making WO - KGJPL"
+
+
+class TestAllocateQtyAcrossWarehouses(IntegrationTestCase):
+	"""Greedy split of a row qty over the warehouses this job has reserved."""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_live_case_splits_across_two_warehouses(self):
+		caps = [(_WAXING, 3.557, ["a"]), (_MODEL_MAKING, 0.02, ["b"])]
+		allocs = _allocate_qty_across_warehouses(3.577, caps)
+		self.assertEqual(allocs, [(_WAXING, 3.557), (_MODEL_MAKING, 0.02)])
+		self.assertEqual(sum(q for _wh, q in allocs), 3.577)
+
+	def test_single_warehouse_covering_returns_one_row(self):
+		caps = [("Diamond Setting WO - KGJPL", 0.29, ["c"])]
+		self.assertEqual(
+			_allocate_qty_across_warehouses(0.29, caps),
+			[("Diamond Setting WO - KGJPL", 0.29)],
+		)
+
+	def test_partial_coverage_returns_none(self):
+		# Reserved 3.5 but 3.577 needed: refuse to split rather than strand the
+		# remainder on a warehouse with no reservation for this job.
+		caps = [(_WAXING, 3.48, ["a"]), (_MODEL_MAKING, 0.02, ["b"])]
+		self.assertIsNone(_allocate_qty_across_warehouses(3.577, caps))
+
+	def test_no_caps_or_zero_qty_returns_none(self):
+		self.assertIsNone(_allocate_qty_across_warehouses(3.577, []))
+		self.assertIsNone(_allocate_qty_across_warehouses(0, [(_WAXING, 5.0, ["a"])]))
+
+	def test_surplus_capacity_is_truncated(self):
+		# 5.0 reserved, only 0.02 needed -> take 0.02 and stop; the second warehouse is
+		# never reached, so its reservation is left alone.
+		caps = [(_WAXING, 5.0, ["a"]), (_MODEL_MAKING, 1.0, ["b"])]
+		self.assertEqual(_allocate_qty_across_warehouses(0.02, caps), [(_WAXING, 0.02)])
+
+	def test_sum_is_exact_for_sub_milligram_qty(self):
+		# calulate_id_wise_sum_up compares per-item totals; the split must not drift.
+		caps = [(_WAXING, 3.557, ["a"]), (_MODEL_MAKING, 0.05, ["b"])]
+		allocs = _allocate_qty_across_warehouses(3.5771, caps)
+		self.assertEqual(sum(q for _wh, q in allocs), 3.5771)
+
+	def test_zero_capacity_warehouse_never_emitted(self):
+		caps = [(_WAXING, 3.577, ["a"]), (_MODEL_MAKING, 0.00005, ["b"])]
+		self.assertEqual(
+			_allocate_qty_across_warehouses(3.577, caps), [(_WAXING, 3.577)]
+		)
+
+
+class TestAllocatePcsAcrossRows(IntegrationTestCase):
+	"""Pcs must survive the split: fg_details SUMs pcs for D/G items and takes max()
+	for metal, so the distribution has to preserve whichever the item uses.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_metal_keeps_whole_count_on_largest_row(self):
+		parts = _allocate_pcs_across_rows(
+			_LIVE_ITEM, 2, [(_WAXING, 3.557), (_MODEL_MAKING, 0.02)]
+		)
+		self.assertEqual(parts, [2.0, 0.0])
+		self.assertEqual(sum(parts), 2)  # SUM preserved
+		self.assertEqual(max(parts), 2)  # MAX preserved
+
+	def test_diamond_splits_pcs_and_preserves_total(self):
+		parts = _allocate_pcs_across_rows(
+			"D-NT-RO-6B-+1.5-2", 8, [("WH-A", 0.2), ("WH-B", 0.09)]
+		)
+		self.assertEqual(sum(parts), 8)
+		self.assertTrue(all(p >= 1 for p in parts))
+
+	def test_diamond_with_fewer_stones_than_rows_keeps_count_whole(self):
+		parts = _allocate_pcs_across_rows(
+			"D-NT-RO-6B-+1.5-2", 1, [("WH-A", 0.2), ("WH-B", 0.09)]
+		)
+		self.assertEqual(parts, [1.0, 0.0])
+
+	def test_fractional_count_is_not_split_into_fractional_stones(self):
+		parts = _allocate_pcs_across_rows(
+			"D-NT-RO-6B-+1.5-2", 2.5, [("WH-A", 0.2), ("WH-B", 0.09)]
+		)
+		self.assertEqual(parts, [2.5, 0.0])
+
+	def test_zero_pcs_and_single_row(self):
+		self.assertEqual(
+			_allocate_pcs_across_rows(_LIVE_ITEM, 0, [("WH-A", 1), ("WH-B", 1)]),
+			[0.0, 0.0],
+		)
+		self.assertEqual(_allocate_pcs_across_rows(_LIVE_ITEM, 2, [("WH-A", 1)]), [2.0])
+
+	def test_never_returns_none_for_a_row(self):
+		# Stock Entry Detail.pcs is a Data field with default "1" — a None would
+		# silently become 1 and inflate the count.
+		for parts in (
+			_allocate_pcs_across_rows(_LIVE_ITEM, 2, [("A", 1), ("B", 1)]),
+			_allocate_pcs_across_rows("D-X", 3, [("A", 1), ("B", 1)]),
+			_allocate_pcs_across_rows(_LIVE_ITEM, None, [("A", 1), ("B", 1)]),
+		):
+			self.assertTrue(all(p is not None for p in parts))
+
+
+class TestActiveSresFor(IntegrationTestCase):
+	"""Which reservations count as live, and how much of one belongs to a batch."""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	@staticmethod
+	def _mock_get_all(sres, children):
+		def _inner(doctype, **kwargs):
+			if doctype == "Stock Reservation Entry":
+				return sres
+			return children
+
+		return _inner
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_batch_scoped_remaining_from_children(self, mock_get_all):
+		# Header reserves 5.0 across two batches; only 3.557 of it is this batch's.
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 5.0,
+					"delivered_qty": 0.0,
+				}
+			],
+			[
+				{
+					"parent": "sre1",
+					"batch_no": _LIVE_BATCH,
+					"qty": 3.557,
+					"delivered_qty": 0.0,
+				},
+				{
+					"parent": "sre1",
+					"batch_no": "OTHER-BATCH",
+					"qty": 1.443,
+					"delivered_qty": 0.0,
+				},
+			],
+		)
+		out = _active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"])
+		self.assertEqual([rem for _sre, rem in out], [3.557])
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_sre_on_another_batch_is_skipped(self, mock_get_all):
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 5.0,
+					"delivered_qty": 0.0,
+				}
+			],
+			[
+				{
+					"parent": "sre1",
+					"batch_no": "OTHER-BATCH",
+					"qty": 5.0,
+					"delivered_qty": 0.0,
+				}
+			],
+		)
+		self.assertEqual(_active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]), [])
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_fully_delivered_child_is_skipped(self, mock_get_all):
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 3.557,
+					"delivered_qty": 0.0,
+				}
+			],
+			[
+				{
+					"parent": "sre1",
+					"batch_no": _LIVE_BATCH,
+					"qty": 3.557,
+					"delivered_qty": 3.557,
+				}
+			],
+		)
+		self.assertEqual(_active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]), [])
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_qty_based_sre_uses_header_remaining(self, mock_get_all):
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 4.0,
+					"delivered_qty": 1.0,
+				}
+			],
+			[],
+		)
+		out = _active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"])
+		self.assertEqual([rem for _sre, rem in out], [3.0])
+
+	@patch(f"{_SNC_MODULE}.frappe.get_all")
+	def test_excluded_sre_is_dropped(self, mock_get_all):
+		mock_get_all.side_effect = self._mock_get_all(
+			[
+				{
+					"name": "sre1",
+					"warehouse": _WAXING,
+					"reserved_qty": 3.0,
+					"delivered_qty": 0.0,
+				}
+			],
+			[],
+		)
+		self.assertEqual(
+			_active_sres_for(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"], exclude={"sre1"}), []
+		)
+
+	def test_no_mwos_returns_empty(self):
+		self.assertEqual(_active_sres_for(_LIVE_ITEM, _LIVE_BATCH, []), [])
+
+
+class TestReservedWarehouseCaps(IntegrationTestCase):
+	"""Capacity is ``min(reserved-remaining, physical)`` per warehouse, and ONLY for
+	warehouses this job actually holds a reservation in.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty")
+	@patch(f"{_SNC_MODULE}._active_sres_for")
+	def test_live_case_two_warehouses(self, mock_sres, mock_phys):
+		mock_sres.return_value = [
+			({"name": "a", "warehouse": _WAXING}, 3.557),
+			({"name": "b", "warehouse": _MODEL_MAKING}, 0.02),
+		]
+		physical = {_WAXING: 3.557, _MODEL_MAKING: 0.02}
+		mock_phys.side_effect = lambda item, batch, wh: physical[wh]
+		self.assertEqual(
+			_reserved_warehouse_caps(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]),
+			[(_WAXING, 3.557, ["a"]), (_MODEL_MAKING, 0.02, ["b"])],
+		)
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty")
+	@patch(f"{_SNC_MODULE}._active_sres_for")
+	def test_warehouse_holding_the_batch_without_a_reservation_is_excluded(
+		self, mock_sres, mock_phys
+	):
+		# Casting MSL WH 1 physically holds 6.35 of the batch but belongs to another
+		# job. It has no SRE for this PMO, so it can never become a candidate.
+		mock_sres.return_value = [({"name": "a", "warehouse": _WAXING}, 3.557)]
+		mock_phys.return_value = 3.557
+		caps = _reserved_warehouse_caps(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"])
+		self.assertEqual([wh for wh, _cap, _sres in caps], [_WAXING])
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty", return_value=1.0)
+	@patch(f"{_SNC_MODULE}._active_sres_for")
+	def test_physical_stock_caps_an_over_reservation(self, mock_sres, _mock_phys):
+		# Reserved 5.0 but only 1.0 physically left there: never promise the 5.0.
+		mock_sres.return_value = [({"name": "a", "warehouse": _WAXING}, 5.0)]
+		self.assertEqual(
+			_reserved_warehouse_caps(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]),
+			[(_WAXING, 1.0, ["a"])],
+		)
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty", return_value=0.0)
+	@patch(f"{_SNC_MODULE}._active_sres_for")
+	def test_stale_reservation_with_no_physical_stock_is_dropped(
+		self, mock_sres, _mock_phys
+	):
+		mock_sres.return_value = [({"name": "a", "warehouse": _WAXING}, 3.557)]
+		self.assertEqual(
+			_reserved_warehouse_caps(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]), []
+		)
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty", return_value=10.0)
+	@patch(f"{_SNC_MODULE}._active_sres_for")
+	def test_two_reservations_in_one_warehouse_merge(self, mock_sres, _mock_phys):
+		mock_sres.return_value = [
+			({"name": "a", "warehouse": _WAXING}, 2.0),
+			({"name": "b", "warehouse": _WAXING}, 1.5),
+		]
+		self.assertEqual(
+			_reserved_warehouse_caps(_LIVE_ITEM, _LIVE_BATCH, ["MWO-1"]),
+			[(_WAXING, 3.5, ["a", "b"])],
+		)
+
+
+class TestPickSourceWarehouseUsedLedger(IntegrationTestCase):
+	"""The ``used`` ledger stops two rows of a split group both claiming the warehouse
+	that only has enough for one of them.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty", return_value=3.557)
+	def test_no_ledger_behaves_as_before(self, _mock):
+		self.assertEqual(
+			_pick_source_warehouse(_LIVE_ITEM, _LIVE_BATCH, 0.02, [_WAXING]), _WAXING
+		)
+
+	@patch(f"{_SNC_MODULE}._physical_batch_qty")
+	def test_exhausted_warehouse_is_skipped(self, mock_phys):
+		physical = {_WAXING: 3.557, _MODEL_MAKING: 0.02}
+		mock_phys.side_effect = lambda item, batch, wh: physical[wh]
+		# The 3.557 row already took all of Waxing; the 0.02 sibling must fall through.
+		wh = _pick_source_warehouse(
+			_LIVE_ITEM,
+			_LIVE_BATCH,
+			0.02,
+			[_WAXING, _MODEL_MAKING],
+			used={_WAXING: 3.557},
+		)
+		self.assertEqual(wh, _MODEL_MAKING)
+
+
+class TestSplitSourceRowsByReservation(IntegrationTestCase):
+	"""``source_table`` is keyed by (item, batch, warehouse); ``fg_details`` stays
+	item-wise. The split preserves the per-item qty total, so calulate_id_wise_sum_up
+	keeps balancing.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def _snc(self, rows):
+		doc = frappe.new_doc("Serial Number Creator")
+		doc.manufacturing_work_order = "MWO-TEST-001"
+		for row in rows:
+			doc.append("source_table", row)
+		return doc
+
+	def _live_doc(self):
+		return self._snc(
+			[
+				{
+					"row_material": "D-NT-RO-6B-+1.5-2",
+					"qty": 0.29,
+					"pcs": 8,
+					"uom": "Carat",
+					"batch_no": "None2F073-DNTROX6A05B00-W04B5",
+					"s_warehouse": "Diamond Setting WO - KGJPL",
+				},
+				{
+					"row_material": _LIVE_ITEM,
+					"qty": 3.577,
+					"pcs": 2,
+					"uom": "Gram",
+					"batch_no": _LIVE_BATCH,
+					"s_warehouse": _WAXING,
+				},
+			]
+		)
+
+	@staticmethod
+	def _caps_for_live_case(item_code, batch_no, _mwos):
+		if item_code == _LIVE_ITEM:
+			return [(_WAXING, 3.557, ["a"]), (_MODEL_MAKING, 0.02, ["b"])]
+		return [("Diamond Setting WO - KGJPL", 0.29, ["c"])]
+
+	@patch(f"{_SNC_MODULE}._pmo_mwo_names", return_value=("PMO-1", ["MWO-TEST-001"]))
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps")
+	def test_splits_metal_row_and_leaves_diamond_alone(self, mock_caps, _mock_mwos):
+		mock_caps.side_effect = self._caps_for_live_case
+		doc = self._live_doc()
+		split_source_rows_by_reservation(doc)
+
+		self.assertEqual(len(doc.source_table), 3)
+		metal = [r for r in doc.source_table if r.row_material == _LIVE_ITEM]
+		self.assertEqual(
+			[(r.s_warehouse, r.qty) for r in metal],
+			[(_WAXING, 3.557), (_MODEL_MAKING, 0.02)],
+		)
+		# Per-item totals unchanged -> calulate_id_wise_sum_up still balances.
+		self.assertEqual(sum(r.qty for r in metal), 3.577)
+		# Metal pcs stays whole on the larger row (fg_details takes max()).
+		self.assertEqual([r.pcs for r in metal], [2.0, 0.0])
+		# Non-warehouse detail is carried onto the new row.
+		self.assertEqual([r.uom for r in metal], ["Gram", "Gram"])
+		# The diamond row, which one warehouse fully covers, is untouched.
+		diamond = [r for r in doc.source_table if r.row_material != _LIVE_ITEM]
+		self.assertEqual(len(diamond), 1)
+		self.assertEqual(diamond[0].qty, 0.29)
+		self.assertEqual([r.idx for r in doc.source_table], [1, 2, 3])
+
+	@patch(f"{_SNC_MODULE}._pmo_mwo_names", return_value=("PMO-1", ["MWO-TEST-001"]))
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps")
+	def test_second_pass_is_a_no_op(self, mock_caps, _mock_mwos):
+		mock_caps.side_effect = self._caps_for_live_case
+		doc = self._live_doc()
+		split_source_rows_by_reservation(doc)
+		before = [
+			(r.row_material, r.s_warehouse, r.qty, r.pcs) for r in doc.source_table
+		]
+		split_source_rows_by_reservation(doc)
+		after = [
+			(r.row_material, r.s_warehouse, r.qty, r.pcs) for r in doc.source_table
+		]
+		self.assertEqual(before, after)
+
+	@patch(f"{_SNC_MODULE}._pmo_mwo_names", return_value=("PMO-1", ["MWO-TEST-001"]))
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps", return_value=[])
+	def test_no_reservation_leaves_rows_untouched(self, _mock_caps, _mock_mwos):
+		doc = self._live_doc()
+		split_source_rows_by_reservation(doc)
+		self.assertEqual(len(doc.source_table), 2)
+		self.assertEqual(doc.source_table[1].s_warehouse, _WAXING)
+
+	@patch(f"{_SNC_MODULE}._pmo_mwo_names", return_value=("PMO-1", ["MWO-TEST-001"]))
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps")
+	def test_shortfall_leaves_rows_untouched(self, mock_caps, _mock_mwos):
+		# Only 3.5 reserved for a 3.577 row -> no split; submit fails fast with the
+		# reserved-vs-physical message instead of silently under-consuming.
+		mock_caps.return_value = [(_WAXING, 3.48, ["a"]), (_MODEL_MAKING, 0.02, ["b"])]
+		doc = self._snc(
+			[
+				{
+					"row_material": _LIVE_ITEM,
+					"qty": 3.577,
+					"pcs": 2,
+					"batch_no": _LIVE_BATCH,
+					"s_warehouse": _WAXING,
+				}
+			]
+		)
+		split_source_rows_by_reservation(doc)
+		self.assertEqual(len(doc.source_table), 1)
+		self.assertEqual(doc.source_table[0].qty, 3.577)
+
+	@patch(f"{_SNC_MODULE}._pmo_mwo_names", return_value=("PMO-1", ["MWO-TEST-001"]))
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps")
+	def test_collapses_back_when_reservations_merge(self, mock_caps, _mock_mwos):
+		# A draft split earlier; the reservations have since consolidated onto one
+		# warehouse, so the group must merge back to a single row.
+		mock_caps.return_value = [(_WAXING, 5.0, ["a"])]
+		doc = self._snc(
+			[
+				{
+					"row_material": _LIVE_ITEM,
+					"qty": 3.557,
+					"pcs": 2,
+					"batch_no": _LIVE_BATCH,
+					"s_warehouse": _WAXING,
+				},
+				{
+					"row_material": _LIVE_ITEM,
+					"qty": 0.02,
+					"pcs": 0,
+					"batch_no": _LIVE_BATCH,
+					"s_warehouse": _MODEL_MAKING,
+				},
+			]
+		)
+		split_source_rows_by_reservation(doc)
+		self.assertEqual(len(doc.source_table), 1)
+		self.assertEqual(doc.source_table[0].s_warehouse, _WAXING)
+		self.assertEqual(doc.source_table[0].qty, 3.577)
+
+	@patch(f"{_SNC_MODULE}._pmo_mwo_names", return_value=("PMO-1", ["MWO-TEST-001"]))
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps")
+	def test_corrects_a_stale_single_warehouse(self, mock_caps, _mock_mwos):
+		mock_caps.return_value = [(_MODEL_MAKING, 3.577, ["a"])]
+		doc = self._snc(
+			[
+				{
+					"row_material": _LIVE_ITEM,
+					"qty": 3.577,
+					"pcs": 2,
+					"batch_no": _LIVE_BATCH,
+					"s_warehouse": _WAXING,
+				}
+			]
+		)
+		split_source_rows_by_reservation(doc)
+		self.assertEqual(len(doc.source_table), 1)
+		self.assertEqual(doc.source_table[0].s_warehouse, _MODEL_MAKING)
+
+	@patch(f"{_SNC_MODULE}._reserved_warehouse_caps")
+	def test_skipped_without_a_work_order(self, mock_caps):
+		doc = frappe.new_doc("Serial Number Creator")
+		doc.append(
+			"source_table",
+			{"row_material": _LIVE_ITEM, "qty": 3.577, "batch_no": _LIVE_BATCH},
+		)
+		split_source_rows_by_reservation(doc)
+		mock_caps.assert_not_called()


### PR DESCRIPTION

- Implement tests for allocating quantities across warehouses, ensuring correct distribution based on reservations.
- Add tests for splitting pieces across rows, preserving counts for different item types.
- Introduce tests for identifying active stock reservation entries, ensuring only relevant reservations are considered.
- Validate warehouse capacity calculations based on reserved quantities and physical stock availability.
- Ensure proper handling of edge cases, including zero quantities and non-existent reservations.