### PR TITLE
fix: improve handling of partially submitted EOD Stock Entries

### DIFF
--- a/jewellery_erpnext/customer_subcontracting/doctype/subcontracting_log/subcontracting_log.py
+++ b/jewellery_erpnext/customer_subcontracting/doctype/subcontracting_log/subcontracting_log.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import now_datetime
 
 from jewellery_erpnext.customer_subcontracting.sub_utils.gold_usage import (
 	classify_gold_usage,
@@ -57,6 +58,8 @@ def create_subcontracting_log(doc, method=None):
 
 	if not config:
 		return
+
+	pending_rows = []
 
 	for item in doc.items:
 		if not item.batch_no:
@@ -202,5 +205,84 @@ def create_subcontracting_log(doc, method=None):
 
 			continue
 
-		log = frappe.get_doc(log_data)
-		log.insert(ignore_permissions=True)
+		pending_rows.append(log_data)
+
+	_insert_logs_in_bulk(pending_rows)
+
+
+# Framework columns bulk_insert must be given explicitly -- it runs no Document lifecycle.
+_LOG_FRAMEWORK_COLUMNS = (
+	"name",
+	"owner",
+	"creation",
+	"modified",
+	"modified_by",
+	"docstatus",
+	"idx",
+)
+
+
+def _insert_logs_in_bulk(rows, chunk_size=500):
+	"""Insert many Subcontracting Log rows with one multi-row INSERT per chunk.
+
+	A consolidated EOD Stock Entry has one row per batched item -- 26,489 on one real run --
+	and this ran a full ``frappe.get_doc(...).insert()`` for every one of them. Splitting the
+	Stock Entry does NOT reduce that count (the rows are the same rows), so batching here is
+	the only lever.
+
+	Safe to bulk-insert because ``SubcontractingLog`` is a plain ``Document`` with **no**
+	controller methods, there are no ``doc_events`` registered for it in any app, and it has
+	no ``autoname``/naming series -- frappe names it with a 10-char hash, which is supplied
+	here. If any of those three facts ever changes, this must go back to ``doc.insert()``:
+	``bulk_insert`` fires no hooks at all.
+
+	Falls back to per-row inserts if the batch fails, so one bad value costs its own row
+	rather than the whole Stock Entry's audit trail.
+	"""
+	if not rows:
+		return
+
+	stamp = now_datetime()
+	user = frappe.session.user or "Administrator"
+	# Branches build different key sets, and bulk_insert needs one fixed column list.
+	fields = sorted({k for row in rows for k in row if k != "doctype"})
+	existing = set(frappe.db.get_table_columns("Subcontracting Log") or [])
+	if existing:
+		fields = [f for f in fields if f in existing]
+	columns = list(_LOG_FRAMEWORK_COLUMNS) + fields
+
+	values = []
+	for idx, row in enumerate(rows, 1):
+		base = (
+			frappe.generate_hash(length=10),
+			user,
+			stamp,
+			stamp,
+			user,
+			0,
+			idx,
+		)
+		values.append(base + tuple(row.get(f) for f in fields))
+
+	try:
+		frappe.db.bulk_insert(
+			"Subcontracting Log", fields=columns, values=values, chunk_size=chunk_size
+		)
+		return
+	except Exception:
+		frappe.logger().exception(
+			"Subcontracting Log: bulk insert of %s row(s) failed; retrying per row",
+			len(rows),
+		)
+
+	for row in rows:
+		try:
+			frappe.get_doc(dict(row, doctype="Subcontracting Log")).insert(
+				ignore_permissions=True
+			)
+		except Exception:
+			frappe.logger().exception(
+				"Subcontracting Log: could not write row for %s / %s",
+				row.get("reference_docname"),
+				row.get("batch"),
+			)

--- a/jewellery_erpnext/customer_subcontracting/doctype/subcontracting_log/test_subcontracting_log.py
+++ b/jewellery_erpnext/customer_subcontracting/doctype/subcontracting_log/test_subcontracting_log.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 # import frappe
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from frappe.tests import IntegrationTestCase
@@ -62,22 +63,94 @@ class IntegrationTestSubcontractingLog(IntegrationTestCase):
 	@patch(
 		"jewellery_erpnext.customer_subcontracting.doctype.subcontracting_log.subcontracting_log.get_inventory_data"
 	)
-	@patch("frappe.get_doc")
-	def test_customer_goods_received(self, mock_get_doc, mock_get_inventory_data):
+	@patch("frappe.db.bulk_insert")
+	def test_customer_goods_received(self, mock_bulk_insert, mock_get_inventory_data):
+		"""Rows are written with ONE multi-row INSERT, not a document per row.
+
+		A consolidated EOD Stock Entry carries one row per batched item -- 26,489 on one
+		real run -- and this used to be a full ``frappe.get_doc(...).insert()`` each.
+
+		Note this patches ``frappe.db.bulk_insert`` rather than ``frappe.get_doc``: patching
+		the latter globally poisons frappe's document cache (``now_datetime`` resolves System
+		Settings through it, and a MagicMock cannot be pickled into redis).
+		"""
 		self.doc.stock_entry_type = "Customer Goods Received"
 		item = MagicMock()
 		item.batch_no = "BATCH-001"
 		self.doc.items = [item]
 
-		mock_get_inventory_data.return_value = {"doctype": "Subcontracting Log"}
-		mock_log = MagicMock()
-		mock_get_doc.return_value = mock_log
+		mock_get_inventory_data.return_value = {
+			"doctype": "Subcontracting Log",
+			"batch": "BATCH-001",
+			"item": "M-GOLD-001",
+			"quantity": 10,
+			"reference_docname": "STE-001",
+		}
 
 		create_subcontracting_log(self.doc)
 
 		mock_get_inventory_data.assert_called_once()
-		mock_get_doc.assert_called_once_with({"doctype": "Subcontracting Log"})
-		mock_log.insert.assert_called_once_with(ignore_permissions=True)
+		mock_bulk_insert.assert_called_once()
+
+		doctype = mock_bulk_insert.call_args.args[0]
+		fields = mock_bulk_insert.call_args.kwargs["fields"]
+		values = mock_bulk_insert.call_args.kwargs["values"]
+		self.assertEqual(doctype, "Subcontracting Log")
+		self.assertEqual(len(values), 1, "one row in, one row out")
+
+		# bulk_insert runs no Document lifecycle, so the framework columns must be supplied.
+		for column in (
+			"name",
+			"owner",
+			"creation",
+			"modified",
+			"modified_by",
+			"docstatus",
+		):
+			self.assertIn(column, fields)
+		# ...and the payload must survive the projection to a fixed column list.
+		row = dict(zip(fields, values[0], strict=True))
+		self.assertEqual(row["batch"], "BATCH-001")
+		self.assertEqual(row["quantity"], 10)
+		self.assertTrue(
+			row["name"], "a hash name must be generated, not left to the DB"
+		)
+		self.assertNotIn("doctype", fields, "doctype is not a column")
+
+	@patch(
+		"jewellery_erpnext.customer_subcontracting.doctype.subcontracting_log.subcontracting_log.get_inventory_data"
+	)
+	# Pin the clock: now_datetime() resolves System Settings through frappe.get_doc, which is
+	# patched below, and a MagicMock cannot be pickled into the document cache.
+	@patch(
+		"jewellery_erpnext.customer_subcontracting.doctype.subcontracting_log.subcontracting_log.now_datetime",
+		return_value=datetime(2026, 7, 30, 0, 0, 0),
+	)
+	@patch("frappe.get_doc")
+	@patch("frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom"))
+	def test_bulk_failure_falls_back_to_per_row_inserts(
+		self, mock_bulk_insert, mock_get_doc, _mock_now, mock_get_inventory_data
+	):
+		"""One bad value must cost its own row, not the whole Stock Entry's audit trail."""
+		self.doc.stock_entry_type = "Customer Goods Received"
+		items = []
+		for i in range(2):
+			item = MagicMock()
+			item.batch_no = f"BATCH-00{i}"
+			items.append(item)
+		self.doc.items = items
+		mock_get_inventory_data.side_effect = lambda doc, item, config: {
+			"doctype": "Subcontracting Log",
+			"batch": item.batch_no,
+		}
+
+		create_subcontracting_log(self.doc)
+
+		self.assertTrue(mock_bulk_insert.called)
+		self.assertEqual(mock_get_doc.call_count, 2, "both rows retried individually")
+		self.assertEqual(
+			mock_get_doc.return_value.insert.call_count, 2, "and actually inserted"
+		)
 
 
 class TestGoldUsage(IntegrationTestCase):

--- a/jewellery_erpnext/jewellery_erpnext/customization/utils/metal_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/customization/utils/metal_utils.py
@@ -1,7 +1,17 @@
 import frappe
 
 
+@frappe.request_cache
 def get_purity_percentage(item):
+	"""Metal purity % for an item variant.
+
+	Request/job-scoped cache: an item's Metal Purity attribute cannot change mid-request, and
+	the Stock Entry ``before_validate`` hook calls this **once per metal/finding row**. A
+	consolidated EOD transfer carries ~9,954 such rows against only ~496 distinct item codes,
+	so the uncached version issued that three-way join ~20x more often than it needed to.
+	``frappe.request_cache`` is cleared per request and per background job, so a purity edit
+	is picked up by the next one.
+	"""
 	if not item:
 		return
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/eod_lock.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/eod_lock.py
@@ -6,15 +6,37 @@ from frappe import _
 from frappe.utils import add_to_date, cint, get_datetime, now_datetime
 
 _SETTINGS = "MOP Settings"
-_LOCK_HOURS = 2
+
+# THE single source of truth for how long an EOD run may hold the lock.
+#
+# This one number drives three things that used to be three separate literals: the lock
+# window written to eod_sync_lock_until, the RQ job timeout at every enqueue site, and the
+# wording of the two user-facing messages below. They drifted apart before -- worse, three
+# real JobTimeoutExceptions in worker.log fired at 1500s (the `long` queue default) because
+# one invocation path never passed a timeout at all.
+#
+# 4 hours is a CEILING, not an expectation. The lock blocks before_save/before_submit/
+# before_cancel on Employee IR, Department IR, MOP Log, Stock Entry and Stock Reconciliation
+# for its whole duration, so a run that stops making progress must release it early rather
+# than sit on it -- that is what the soft deadline in mop_eod_sync does. Keep the scheduled
+# run off-hours.
+_LOCK_HOURS = 4
+_LOCK_SECONDS = _LOCK_HOURS * 60 * 60
+
+# Soft deadline: stop STARTING new work this many minutes into a run, then finish cleanly
+# and release the lock. Must stay comfortably inside _LOCK_HOURS so the graceful stop always
+# wins the race against the hard RQ kill.
+_SOFT_DEADLINE_MINUTES = 200
+
 _LOCK_MSG = (
 	"EOD sync is in progress. You cannot proceed to make any transactions. "
-	"Please contact your administrator or try again after 2 hours after the specified time."
+	f"Please contact your administrator or try again after {_LOCK_HOURS} hours after the "
+	"specified time."
 )
 
 
 def is_eod_sync_locked():
-	"""Return True when EOD sync is running and the 2-hour lock window is still active.
+	"""Return True when EOD sync is running and the lock window is still active.
 
 	Uses a direct DB read (not cached doc) so the latest committed state is always seen.
 	Returns False if the lock window has expired even when eod_sync_running is still 1
@@ -35,7 +57,7 @@ def is_eod_sync_locked():
 
 
 def set_eod_sync_running(sync_log_name=None):
-	"""Mark EOD sync as running, set a 2-hour lock window, and commit immediately.
+	"""Mark EOD sync as running, open the lock window, and commit immediately.
 
 	The immediate commit ensures every concurrent DB connection sees the lock before
 	the heavy processing starts. Optionally updates the MOP EOD Sync Log status.
@@ -119,7 +141,7 @@ def release_eod_sync_lock(success=True, error_log_name=None, sync_log_name=None)
 
 
 def release_expired_eod_sync_lock():
-	"""Auto-release a stale lock when the 2-hour window has passed.
+	"""Auto-release a stale lock when the lock window has passed.
 
 	Called every hour by the scheduler and at the top of each per-minute check.
 	Safe to call when no lock is active — returns immediately.
@@ -137,7 +159,8 @@ def release_expired_eod_sync_lock():
 		return
 
 	message = (
-		"EOD sync lock was automatically released after the configured 2-hour window. "
+		f"EOD sync lock was automatically released after the configured {_LOCK_HOURS}-hour "
+		"window. "
 		"Please verify Error Log and pending draft Stock Entries before retrying."
 	)
 	frappe.db.set_value(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
@@ -2,15 +2,26 @@
 EOD MOP Log Sync — converts unsynced MOP Log entries into consolidated Stock Entries.
 
 MOP Logs with ``is_synced = 0`` represent virtual warehouse movements recorded by
-Department IR and Employee IR. Each run **plans** every Manufacturing Work Order, then
-**commits** ONE consolidated **Material Transfer to Department** Stock Entry per
-(company, manufacturer) covering all fully-resolvable MWOs — moving each item from its
-Stock Reservation Entry warehouse (where stock is physically reserved) to the last
-Manufacturing Operation's final ``to_warehouse``. Classification is all-or-nothing per
-MWO: an MWO with any unresolvable / batch-short / invalid row is held out of the
-transfer (its MOP Logs stay unsynced and retryable) and its buildable rows are placed in
-a per-bucket DRAFT "issues" Stock Entry for visibility; rows with no SRE source warehouse
-are reported in the consolidated Error Log only.
+Department IR and Employee IR. Each run **plans** every Manufacturing Work Order, allocates
+stock across the whole run, then **commits** a series of bounded **Material Transfer to
+Department** Stock Entries per (company, manufacturer) — moving each item from its Stock
+Reservation Entry warehouse (where stock is physically reserved) to the last Manufacturing
+Operation's final ``to_warehouse``. Classification is all-or-nothing per MWO: an MWO with any
+unresolvable / batch-short / invalid row is held out of the transfer (its MOP Logs stay
+unsynced and retryable) and its buildable rows are placed in a per-bucket DRAFT "issues"
+Stock Entry for visibility; rows with no SRE source warehouse are reported in the
+consolidated Error Log only.
+
+**Chunking (why this is not one Stock Entry per bucket)**: a single very large transfer
+cannot be saved *and* submitted in any sane window — ERPNext submits a document per Stock
+Ledger Entry and revalues inline per row, and each Stock Reservation Entry re-aggregates its
+whole (item, warehouse) into Bin. One real run produced a **26,489-row** draft worth ₹10.66 cr
+that never submitted before the lock expired. Buckets are therefore split under two caps
+(``eod_chunk_max_mwos``, ``eod_chunk_max_rows``), an MWO is never split across chunks, and
+each chunk commits on success. A failing chunk is halved and retried down to a single MWO, so
+one bad MWO strands only itself. **The unit of atomicity is the chunk**, so a partially-synced
+bucket is normal — and resume is free, because a committed chunk's MOP Logs are marked synced
+and the next run's gather cannot see them.
 
 **Windowed filter (scheduled mode)**: With no enabled MWO filter rows, only MOP
 Logs created inside the run's window are processed. The window defaults to today
@@ -39,17 +50,22 @@ by the Employee IR Process Loss feature (``doc_events/loss_stock_entry.py``).
 **Syncing**: after SE submit, ALL unsynced non-cancelled MOP Logs for the MWO (created
 inside the run's window) are marked synced atomically within the same savepoint.
 
-**Transaction phases (per (company, manufacturer) bucket)**:
-  Phase 1 (savepoint "eod_draft_phase"): save the consolidated SE as draft.
+**Transaction phases (per CHUNK)**:
+  Phase 1 (savepoint "eod_draft_phase"): save the chunk's SE as draft.
   Phase 2 (savepoint "eod_submit_phase"): cancel every included MWO's source-warehouse
     SREs (releasing the reservations so the transfer can consume the stock), submit the
-    single SE, re-reserve at each MWO's target warehouse where its stock lands, then mark
-    each MWO's MOP Logs synced. All of this is ONE atomic savepoint — the SRE relocation
-    is all-or-nothing for the whole bucket.
-  On Phase 2 failure: rollback the whole submit savepoint; the cancelled SREs are
-    restored (never left cancelled without a transfer/re-reservation) and the draft SE
-    survives for manual recovery — so a single submit failure holds the whole bucket as a
-    draft (the "one SE for the run" trade-off).
+    SE, re-reserve at each MWO's target warehouse where its stock lands, then mark each
+    MWO's MOP Logs synced. All of this is ONE atomic savepoint — the SRE relocation is
+    all-or-nothing for the chunk. On success the chunk is COMMITTED.
+  On Phase 2 failure: rollback the submit savepoint; the cancelled SREs are restored (never
+    left cancelled without a transfer/re-reservation). If the chunk is about to be retried in
+    halves, an outer savepoint "eod_chunk_phase" takes the draft SE with it so no orphan is
+    left behind; only a TERMINAL failure (one MWO, or the retry budget spent) keeps its draft
+    for manual recovery.
+  **Savepoint/COMMIT order is load-bearing**: MariaDB drops every savepoint on COMMIT, so a
+    chunk's savepoints are all released before its commit and the next chunk opens fresh ones.
+  A timeout or deadlock is re-raised rather than absorbed (``_is_recoverable_error``): it is
+    not this MWO's or chunk's fault and would otherwise repeat for every remaining one.
 
 **MOP EOD Sync Log**: every run creates/updates a MOP EOD Sync Log document with full
 progress tracking. Every item/batch/MWO decision is recorded in the child table.
@@ -61,17 +77,93 @@ created at the end of the full sync — no per-row or per-MWO log_error calls in
 import frappe
 from frappe import _
 from frappe.utils import (
+	add_to_date,
 	cint,
 	flt,
 	now_datetime,
 	nowdate,
 )
 
-from .eod_lock import release_eod_sync_lock, set_eod_sync_running
+from .eod_lock import (
+	_SOFT_DEADLINE_MINUTES,
+	release_eod_sync_lock,
+	set_eod_sync_running,
+)
 
-# Savepoint wrapping a single diagnostic child-row insert, so a rejected Select value or
-# any other write error rolls back that row alone and never the caller's bucket.
+
+def _is_recoverable_error(exc):
+	"""True when an exception means "this run was cut short", not "this run is broken".
+
+	Mirrors the RecoverableErrors set ``Repost Item Valuation`` uses: a deadlock, a lock-wait
+	timeout or an RQ job timeout means the work is simply unfinished and the next run should
+	continue it -- so the Sync Log should say `Partially Completed`, not `Failed`, and the
+	consolidated Error Log should not read like a code defect.
+
+	``JobTimeoutException`` is the one actually observed in ``worker.log`` (three times, each
+	firing *inside* the recovery handler's own ``rollback to savepoint``). Resolved lazily and
+	defensively: rq is an indirect dependency and these frappe attributes have moved between
+	versions, so a missing name must never break the import of this module.
+	"""
+	candidates = []
+	for name in ("QueryDeadlockError", "QueryTimeoutError"):
+		candidate = getattr(frappe, name, None)
+		if isinstance(candidate, type) and issubclass(candidate, BaseException):
+			candidates.append(candidate)
+	try:
+		from rq.timeouts import JobTimeoutException
+
+		candidates.append(JobTimeoutException)
+	except Exception:
+		pass
+	return bool(candidates) and isinstance(exc, tuple(candidates))
+
+
+# Savepoint wrapping a diagnostic child-row write, so a rejected Select value or any other
+# write error rolls back those rows alone and never the caller's bucket.
 _LOG_ROW_SAVEPOINT = "eod_log_row"
+
+# Buffered MOP EOD Sync Log Item rows are flushed in batches of this size. Also the
+# chunk_size handed to frappe.db.bulk_insert, and the IN-list size for child-row updates.
+_LOG_ROW_FLUSH_SIZE = 500
+
+# Column order for the bulk child-row INSERT. frappe.db.bulk_insert runs no Document
+# lifecycle, so every column the row needs -- including the framework ones -- is listed
+# explicitly. Keep in sync with _build_sync_log_item_row.
+_LOG_ROW_COLUMNS = (
+	"name",
+	"parent",
+	"parentfield",
+	"parenttype",
+	"idx",
+	"owner",
+	"creation",
+	"modified",
+	"modified_by",
+	"docstatus",
+	"manufacturing_work_order",
+	"manufacturing_operation",
+	"company",
+	"item_code",
+	"batch_no",
+	"serial_no",
+	"source_warehouse",
+	"target_warehouse",
+	"qty",
+	"pcs",
+	"status",
+	"sync_stage",
+	"is_synced",
+	"stock_reservation_entry",
+	"stock_entry",
+	"draft_stock_entry",
+	"mop_log",
+	"error_type",
+	"error_message",
+	"technical_traceback",
+	"suggested_fix",
+	"created_on",
+	"completed_on",
+)
 
 # {fieldname: {valid option, ...}} for MOP EOD Sync Log Item, filled on first use.
 _SELECT_OPTION_CACHE = {}
@@ -84,7 +176,9 @@ _TABLE_COLUMN_CACHE = {}
 # ---------------------------------------------------------------------------
 
 
-def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
+def sync_mop_logs(
+	sync_log_name=None, from_datetime=None, to_datetime=None, catchup_limit=None
+):
 	"""Main entry point called by scheduler or manual trigger. Returns a summary dict.
 
 	``from_datetime`` / ``to_datetime`` bound the MOP Log ``creation`` window scanned in
@@ -92,6 +186,9 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 	nightly scheduler leaves them empty so it always uses today. When both are absent the
 	window defaults to today's start/end (see :func:`_resolve_run_range`). Selective
 	MWO-filter mode ignores the window and always covers full unsynced history.
+
+	``catchup_limit`` raises the backlog catch-up cap for this run only (the Drain Backlog
+	button) and forces the catch-up pass to run even if its feature flag is off.
 	"""
 	# If no sync log provided (legacy path), create one now
 	if not sync_log_name:
@@ -112,6 +209,15 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 			frappe.logger().exception("MOP EOD Sync: could not create MOP EOD Sync Log")
 			sync_log_name = None
 
+	# Start from a clean slate: an RQ worker reuses its process, and a buffer or lost-row
+	# count left behind by an earlier job would be attributed to this one.
+	frappe.local.eod_sync_log_buffer = []
+	frappe.local.eod_sync_log_idx = {}
+	frappe.local.eod_sync_log_row_failures = 0
+	# Per-run override for the backlog catch-up cap (the Drain Backlog button); None means
+	# use the configured MOP Settings value.
+	frappe.local.eod_catchup_limit_override = cint(catchup_limit) or None
+
 	frappe.flags.in_eod_mop_sync = True
 	# Resolve the creation window once for the whole run. Scheduled runs pass nothing
 	# → today's range; the manual button passes the user-chosen From/To. Stash it on a
@@ -128,7 +234,13 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 		"draft_ses": [],
 		"artifact_skipped": [],
 		"started_on": now_datetime(),
+		# Set when the soft deadline stopped the run early, so the final status can say
+		# "Partially Completed — ran out of time" instead of looking like a defect.
+		"deadline_stopped": False,
+		"deadline_skipped_mwos": 0,
+		"deadline_skipped_chunks": 0,
 	}
+	_eod_deadline_start(stats["started_on"])
 
 	try:
 		settings = frappe.get_doc("MOP Settings")
@@ -154,100 +266,19 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 			)
 			frappe.db.commit()
 
-			# PLAN: classify every MWO without writing any Stock Entry. Resolvable MWOs are
-			# bucketed by (company, manufacturer) for ONE consolidated transfer SE; failed
-			# MWOs contribute their buildable rows to a per-bucket draft "issues" SE.
-			main_buckets = {}
-			issues_buckets = {}
-			for group_key, mop_data_list in unsynced_groups.items():
-				# Isolate each MWO: an unexpected error while planning ONE MWO must not
-				# abort the whole run — record it as a failure and move on.
-				try:
-					result = _plan_mwo_group(
-						group_key,
-						mop_data_list,
-						failures,
-						stats,
-						sync_log_name,
-						selective=selective,
-					)
-				except Exception:
-					stats["failed_mwos"] += 1
-					failures.append(
-						{
-							"step": "plan",
-							"company": group_key[0],
-							"mwo": group_key[1],
-							"error_message": "Unexpected error while planning this MWO.",
-							"traceback": frappe.get_traceback(),
-							"suggested_fix": (
-								"Investigate the traceback; this MWO was skipped. Other MWOs "
-								"were unaffected."
-							),
-						}
-					)
-					continue
-				if not result:
-					continue
-				bucket_key = (result["company"], result.get("manufacturer"))
-				if result["kind"] == "resolvable":
-					main_buckets.setdefault(bucket_key, []).append(result)
-				elif result["kind"] == "failed" and result.get("issues_rows"):
-					issues_buckets.setdefault(bucket_key, []).extend(
-						result["issues_rows"]
-					)
+			_plan_and_commit_groups(
+				unsynced_groups, failures, stats, sync_log_name, selective
+			)
 
-			# COMMIT: one submitted Material Transfer to Department per (company,
-			# manufacturer) for all resolvable MWOs.
-			for (company, manufacturer), main_mwos in main_buckets.items():
-				_commit_company_main_se(
-					company,
-					manufacturer,
-					main_mwos,
-					failures,
-					stats,
-					sync_log_name,
-					selective=selective,
-				)
-				if sync_log_name:
-					recalculate_sync_log_totals(sync_log_name)
-					frappe.db.set_value(
-						"MOP EOD Sync Log",
-						sync_log_name,
-						"progress_message",
-						f"Processed {stats['processed_mwos']} / {stats['total_mwos']} MWOs...",
-						update_modified=False,
-					)
-					frappe.db.commit()
+			# Then drain a bounded slice of the pre-window backlog. The primary window
+			# stays strictly today; this is the explicit, capped drain for logs that no
+			# later scheduled run would otherwise ever scan again.
+			_run_backlog_catchup(settings, failures, stats, sync_log_name, selective)
 
-			# Best-effort draft "issues" SE per bucket for unresolved-but-buildable rows.
-			for (company, manufacturer), issues_rows in issues_buckets.items():
-				_commit_company_issues_se(
-					company, manufacturer, issues_rows, stats, sync_log_name
-				)
-				if sync_log_name:
-					frappe.db.commit()
-
-		# SRE reconciliation audit
-		for mwo in {k[1] for k in unsynced_groups}:
-			try:
-				_reconcile_reservations_for_mwo(mwo, dry_run=True)
-			except Exception:
-				failures.append(
-					{
-						"step": "sre_reconcile",
-						"mwo": mwo,
-						# Read-only audit: it never blocks a transfer, so it is reported
-						# but must not downgrade the run's final status.
-						"advisory": True,
-						"error_message": "SRE reconciliation check raised an exception.",
-						"traceback": frappe.get_traceback(),
-						"suggested_fix": (
-							"Investigate the SRE reconcile error for MWO "
-							f"{mwo}. This does not affect SE or MOP Log sync status."
-						),
-					}
-				)
+		# SRE reconciliation audit — advisory only, and bulk: the per-MWO loop this
+		# replaced issued one SRE query per MWO plus one balance query per SRE, tens of
+		# thousands of queries on a backlog run, all for output that is only logged.
+		_reconcile_reservations_bulk({k[1] for k in unsynced_groups}, failures)
 
 		if not sync_log_name:
 			# The PLAN + COMMIT block below is guarded by `if sync_log_name`, so without
@@ -294,15 +325,25 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 			# but did not stop any MWO from syncing, so they must not downgrade a clean
 			# run to "Partially Completed".
 			blocking = [f for f in failures if not f.get("advisory")]
+			# A deadline stop is not a clean finish: work was deliberately left undone, and
+			# calling that "Completed" would stamp eod_sync_last_completed_on and let the
+			# scheduler treat the day as finished.
 			final_status = (
 				"Completed"
-				if not blocking
+				if not blocking and not stats.get("deadline_stopped")
 				else "Partially Completed"
-				if stats["processed_mwos"] > 0
+				if stats["processed_mwos"] > 0 or stats.get("deadline_stopped")
 				else "Failed"
 			)
 			artifact_count = len(stats.get("artifact_skipped") or [])
 			progress_message = f"Sync {final_status}."
+			if stats.get("deadline_stopped"):
+				progress_message += (
+					f" Stopped at the {_eod_setting_int('eod_soft_deadline_minutes', _SOFT_DEADLINE_MINUTES)}"
+					f"-minute soft deadline with {stats['deadline_skipped_mwos']} MWO(s) "
+					f"({stats['deadline_skipped_chunks']} chunk(s)) not started. Their MOP Logs "
+					"remain unsynced and the next run continues from there — no work was lost."
+				)
 			if artifact_count:
 				progress_message += (
 					f" {artifact_count} MWO(s) already realized by Serial Number Creator "
@@ -328,14 +369,33 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 			)
 			frappe.db.commit()
 
-	except Exception:
+	except Exception as exc:
 		tb = frappe.get_traceback()
+		# A deadlock, lock-wait timeout or RQ job timeout means the run was CUT SHORT, not
+		# that it is broken: whatever committed stays committed, the rest is still unsynced,
+		# and the next run continues. Reporting that as "Failed with unexpected error" sent
+		# people hunting a code defect that was not there. Same distinction Repost Item
+		# Valuation draws with its RecoverableErrors set.
+		recoverable = _is_recoverable_error(exc)
 		failures.append(
 			{
 				"step": "top_level",
-				"error_message": "Unexpected top-level exception in sync_mop_logs.",
+				"advisory": recoverable,
+				"error_message": (
+					"EOD sync was cut short by a timeout or lock contention "
+					f"({type(exc).__name__}). Committed chunks are durable; the remaining "
+					"MOP Logs stay unsynced for the next run."
+					if recoverable
+					else "Unexpected top-level exception in sync_mop_logs."
+				),
 				"traceback": tb,
-				"suggested_fix": "Investigate the traceback below and fix the root cause before retrying.",
+				"suggested_fix": (
+					"No code fix implied. Re-run the sync (or let the next scheduled run "
+					"continue). If it recurs, lower MOP Settings > Max Rows per Stock Entry "
+					"or the soft deadline so each unit of work finishes sooner."
+					if recoverable
+					else "Investigate the traceback below and fix the root cause before retrying."
+				),
 			}
 		)
 		error_log_name = _create_consolidated_error_log(failures, stats, sync_log_name)
@@ -347,11 +407,21 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 				"MOP EOD Sync Log",
 				sync_log_name,
 				{
-					"status": "Failed",
+					# Partially Completed, not Failed: a cut-short run that committed
+					# chunks really did sync them, and the status is what operators triage on.
+					"status": "Partially Completed"
+					if recoverable and stats["processed_mwos"] > 0
+					else "Failed",
 					"completed_on": now_datetime(),
 					"error_log": error_log_name or "",
 					"last_error": tb[:2000] if tb else "",
-					"progress_message": "Sync failed with unexpected error.",
+					"progress_message": (
+						f"Sync cut short by {type(exc).__name__} after "
+						f"{stats['processed_mwos']} MWO(s). Remaining MOP Logs are unsynced "
+						"and will be retried."
+						if recoverable
+						else "Sync failed with unexpected error."
+					),
 				},
 				update_modified=False,
 			)
@@ -360,6 +430,20 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 	finally:
 		frappe.flags.in_eod_mop_sync = False
 		frappe.flags.eod_sync_range = None
+		# Never let a cached stock reading or prefetch survive the job that built it.
+		_eod_batch_qty_cache_stop()
+		_eod_prefetch_stop()
+		# Last chance for buffered diagnostics: rows queued after the final recalculate --
+		# or on the top-level exception path, whose own commit already ran above -- would
+		# otherwise be discarded. Committed ONLY if something was actually written, so a run
+		# that ends with an empty buffer does not issue a stray COMMIT. Safe here because
+		# every savepoint is already released or rolled back by the time finally runs
+		# (MariaDB drops all savepoints on COMMIT).
+		try:
+			if _flush_sync_log_items():
+				frappe.db.commit()
+		except Exception:
+			frappe.logger().exception("MOP EOD Sync: final sync log flush failed")
 
 	return {
 		"processed": stats["processed_mwos"],
@@ -372,10 +456,363 @@ def sync_mop_logs(sync_log_name=None, from_datetime=None, to_datetime=None):
 # ---------------------------------------------------------------------------
 
 
+def _run_backlog_catchup(settings, failures, stats, sync_log_name, selective):
+	"""Drain a BOUNDED slice of the pre-window unsynced backlog, oldest MWO first.
+
+	The scheduled window is strictly today (``_today_range``) and fires once per day, so a MOP
+	Log created after the nightly run sits in a window no later scheduled run will ever scan
+	again -- it only ever surfaced in ``old_unsynced_mop_log_count``. That is how ~647,000
+	unsynced rows across ~12,939 MWOs accumulated, and why draining them needed a hand-built
+	manual run over a huge window (the 26,489-row Stock Entry that started all this).
+
+	This keeps the today-only window exactly as it was and adds an explicit, capped drain
+	instead: at most ``eod_catchup_max_mwos`` MWOs per run, oldest first.
+
+	Runs only when the main pass had no blocking failures and the soft deadline has not
+	passed -- a run already in trouble must not take on extra work.
+
+	**The window swap is the subtle part.** ``_mark_all_mwo_mop_logs_synced`` is bounded by
+	``frappe.flags.eod_sync_range`` in non-selective mode, so the catch-up pass must publish
+	ITS own window for the duration or it would transfer stock and mark nothing as synced --
+	re-transferring the same logs on every future run. The flag is restored afterwards.
+	"""
+	if selective:
+		# Selective mode already covers full unsynced history for its listed MWOs.
+		return
+	# An explicit Drain Backlog request overrides the feature flag -- the operator asked
+	# for exactly this pass.
+	override = getattr(frappe.local, "eod_catchup_limit_override", None)
+	if not override and not _eod_feature_enabled("enable_eod_backlog_catchup"):
+		return
+	if _eod_deadline_passed():
+		return
+	if [f for f in failures if not f.get("advisory")]:
+		frappe.logger().info(
+			"MOP EOD Sync: skipping backlog catch-up — the main pass reported blocking "
+			"failures, so this run is not healthy enough to take on more work."
+		)
+		return
+
+	max_mwos = getattr(
+		frappe.local, "eod_catchup_limit_override", None
+	) or _eod_setting_int("eod_catchup_max_mwos", 500)
+	if max_mwos <= 0:
+		return
+
+	window_start, _ = _get_sync_range()
+	# Oldest-first slice of MWOs whose unsynced logs predate this run's window.
+	rows = frappe.db.sql(
+		"""
+		SELECT manufacturing_work_order, MIN(creation) AS oldest
+		FROM `tabMOP Log`
+		WHERE is_synced = 0
+		  AND is_cancelled = 0
+		  AND creation < %(window_start)s
+		  AND manufacturing_work_order IS NOT NULL
+		  AND manufacturing_work_order != ''
+		GROUP BY manufacturing_work_order
+		ORDER BY oldest ASC
+		LIMIT %(limit)s
+		""",
+		{"window_start": window_start, "limit": max_mwos},
+		as_dict=True,
+	)
+	mwos = [r.manufacturing_work_order for r in rows]
+	if not mwos:
+		return
+
+	catchup_range = (str(rows[0].oldest), window_start)
+	previous_range = getattr(frappe.flags, "eod_sync_range", None)
+	frappe.logger().info(
+		"MOP EOD Sync: backlog catch-up starting for %s MWO(s), window %s .. %s",
+		len(mwos),
+		catchup_range[0],
+		catchup_range[1],
+	)
+	try:
+		frappe.flags.eod_sync_range = catchup_range
+		groups = _get_backlog_groups(mwos, catchup_range)
+		if not groups:
+			return
+		stats["catchup_mwos"] = len(groups)
+		stats["total_mwos"] += len(groups)
+		if sync_log_name:
+			frappe.db.set_value(
+				"MOP EOD Sync Log",
+				sync_log_name,
+				{
+					"total_mwos": stats["total_mwos"],
+					"progress_message": (
+						f"Backlog catch-up: draining {len(groups)} MWO(s) logged before "
+						f"{window_start}."
+					),
+				},
+				update_modified=False,
+			)
+			frappe.db.commit()
+		_plan_and_commit_groups(groups, failures, stats, sync_log_name, selective)
+	finally:
+		frappe.flags.eod_sync_range = previous_range
+
+
+def _get_backlog_groups(mwos, catchup_range):
+	"""``{(company, mwo): [...]}`` for the given MWOs, bounded to the catch-up window.
+
+	Mirrors ``_get_unsynced_mop_groups``' shape and ordering so ``_plan_mwo_group`` cannot
+	tell the difference. Bounded by the window on BOTH ends so a log created *during* this
+	run (after the main pass gathered) is not swept in here without having been planned.
+	"""
+	window_start, window_end = catchup_range
+	logs = []
+	for start in range(0, len(mwos), _LOG_ROW_FLUSH_SIZE):
+		chunk = mwos[start : start + _LOG_ROW_FLUSH_SIZE]
+		logs.extend(
+			frappe.db.get_all(
+				"MOP Log",
+				filters={
+					"is_synced": 0,
+					"is_cancelled": 0,
+					"manufacturing_work_order": ["in", chunk],
+					"creation": ["between", [window_start, window_end]],
+				},
+				fields=_MOP_LOG_GATHER_FIELDS,
+				order_by="manufacturing_operation, flow_index asc, creation asc",
+				limit_page_length=0,
+			)
+		)
+	return _group_logs_by_company_and_mwo(logs)
+
+
+def _eod_prefetch_start(unsynced_groups):
+	"""Prefetch the per-MWO lookups the plan phase would otherwise repeat once per MWO.
+
+	Three lookups were each costing one query per MWO -- ~25,800 queries on a backlog run --
+	for data that is three IN-list queries. Each consumer keeps its own signature and reads
+	the prefetch from ``frappe.local``, because several are replaced by name in tests.
+
+	Deliberately NOT done inside ``_get_unsynced_mop_groups``: three tests drive it with
+	``mock_get_all.side_effect = [logs, mop_meta]``, so a third ``get_all`` there raises
+	StopIteration.
+	"""
+	mwos = sorted({key[1] for key in unsynced_groups if key[1]})
+	item_codes, batch_nos = set(), set()
+	for groups in unsynced_groups.values():
+		for md in groups:
+			for log in md.get("logs") or []:
+				if log.get("item_code"):
+					item_codes.add(log.get("item_code"))
+				if log.get("batch_no"):
+					batch_nos.add(log.get("batch_no"))
+
+	artifact_map = {}
+	for start in range(0, len(mwos), _LOG_ROW_FLUSH_SIZE):
+		chunk = mwos[start : start + _LOG_ROW_FLUSH_SIZE]
+		for row in frappe.db.get_all(
+			"Stock Entry",
+			filters={
+				"manufacturing_work_order": ["in", chunk],
+				"stock_entry_type": "Manufacture",
+				"docstatus": 1,
+			},
+			fields=["name", "manufacturing_work_order"],
+			limit_page_length=0,
+		):
+			# get_value returned an arbitrary one when several exist; keep that contract.
+			artifact_map.setdefault(row.manufacturing_work_order, row.name)
+	frappe.local.eod_artifact_map = artifact_map
+
+	item_flags = {}
+	codes = sorted(item_codes)
+	for start in range(0, len(codes), _LOG_ROW_FLUSH_SIZE):
+		chunk = codes[start : start + _LOG_ROW_FLUSH_SIZE]
+		for row in frappe.db.get_all(
+			"Item",
+			filters={"name": ["in", chunk]},
+			fields=["name", "has_batch_no", "has_serial_no"],
+			limit_page_length=0,
+		):
+			item_flags[row.name] = row
+	frappe.local.eod_item_flags = item_flags
+
+	frappe.local.eod_batch_ownership = _eod_batch_ownership(batch_nos, use_cache=False)
+	frappe.logger().info(
+		"MOP EOD Sync: prefetched %s artifact SE(s), %s item(s), %s batch owner(s) for "
+		"%s MWO(s).",
+		len(artifact_map),
+		len(item_flags),
+		len(frappe.local.eod_batch_ownership),
+		len(mwos),
+	)
+
+
+def _eod_prefetch_stop():
+	"""Drop the run-scoped prefetches so they cannot outlive their gather."""
+	frappe.local.eod_artifact_map = None
+	frappe.local.eod_item_flags = None
+	frappe.local.eod_batch_ownership = None
+
+
+def _plan_and_commit_groups(unsynced_groups, failures, stats, sync_log_name, selective):
+	"""PLAN every MWO, allocate stock run-wide, then COMMIT in bounded chunks.
+
+	Extracted from ``sync_mop_logs`` so the backlog catch-up pass runs the exact same
+	pipeline instead of a parallel copy that could drift from it.
+
+	Caller must have set ``frappe.flags.eod_sync_range`` to the window these groups were
+	gathered for -- ``_mark_all_mwo_mop_logs_synced`` is bounded by it in non-selective mode,
+	so a mismatched window silently marks nothing as synced.
+	"""
+	# Cache physical batch readings for the whole PLAN phase, which writes no
+	# stock. _commit_company_main_se turns it off again before anything moves.
+	_eod_batch_qty_cache_start()
+	# ...and prefetch the per-MWO lookups the plan loop would otherwise repeat 8,602 times.
+	_eod_prefetch_start(unsynced_groups)
+
+	# PLAN: classify every MWO without writing any Stock Entry. Resolvable MWOs are
+	# bucketed by (company, manufacturer) for ONE consolidated transfer SE; failed
+	# MWOs contribute their buildable rows to a per-bucket draft "issues" SE.
+	main_buckets = {}
+	issues_buckets = {}
+	for group_key, mop_data_list in unsynced_groups.items():
+		# Stop STARTING new plan work past the soft deadline. Unplanned MWOs keep
+		# their MOP Logs unsynced, so the next run picks them up untouched.
+		if _eod_deadline_passed():
+			stats["deadline_stopped"] = True
+			stats["deadline_skipped_mwos"] += 1
+			continue
+		# Isolate each MWO: an unexpected error while planning ONE MWO must not
+		# abort the whole run — record it as a failure and move on.
+		try:
+			result = _plan_mwo_group(
+				group_key,
+				mop_data_list,
+				failures,
+				stats,
+				sync_log_name,
+				selective=selective,
+			)
+		except Exception as exc:
+			# ...but a timeout or deadlock is NOT this MWO's fault and will hit every
+			# remaining one. rq's JobTimeoutException subclasses Exception, so this
+			# handler used to swallow it and keep looping — turning one timeout into
+			# thousands of bogus "plan failed" entries while the worker ran on until
+			# it was hard-killed. Let it out so the run stops and reports honestly.
+			if _is_recoverable_error(exc):
+				raise
+			stats["failed_mwos"] += 1
+			failures.append(
+				{
+					"step": "plan",
+					"company": group_key[0],
+					"mwo": group_key[1],
+					"error_message": "Unexpected error while planning this MWO.",
+					"traceback": frappe.get_traceback(),
+					"suggested_fix": (
+						"Investigate the traceback; this MWO was skipped. Other MWOs "
+						"were unaffected."
+					),
+				}
+			)
+			continue
+		if not result:
+			continue
+		bucket_key = (result["company"], result.get("manufacturer"))
+		if result["kind"] == "resolvable":
+			main_buckets.setdefault(bucket_key, []).append(result)
+		elif result["kind"] == "failed" and result.get("issues_rows"):
+			issues_buckets.setdefault(bucket_key, []).extend(result["issues_rows"])
+
+	# ALLOCATE across the whole run before anything is written, while the
+	# plan-phase batch cache is still warm. Per-bucket allocation could not see
+	# contention between buckets.
+	if _eod_feature_enabled("enable_eod_bucket_allocation"):
+		main_buckets = _apply_run_allocation(
+			main_buckets, failures, stats, sync_log_name
+		)
+
+	# Land every diagnostics row the plan phase buffered before the commit phase
+	# starts stamping them by name.
+	_flush_sync_log_items()
+
+	# COMMIT: one submitted Material Transfer to Department per (company,
+	# manufacturer) for all resolvable MWOs.
+	for (company, manufacturer), main_mwos in main_buckets.items():
+		_commit_company_main_se(
+			company,
+			manufacturer,
+			main_mwos,
+			failures,
+			stats,
+			sync_log_name,
+			selective=selective,
+			already_allocated=True,
+		)
+		if sync_log_name:
+			recalculate_sync_log_totals(sync_log_name)
+			frappe.db.set_value(
+				"MOP EOD Sync Log",
+				sync_log_name,
+				"progress_message",
+				f"Processed {stats['processed_mwos']} / {stats['total_mwos']} MWOs...",
+				update_modified=False,
+			)
+			frappe.db.commit()
+
+	# Best-effort draft "issues" SE per bucket for unresolved-but-buildable rows.
+	for (company, manufacturer), issues_rows in issues_buckets.items():
+		_commit_company_issues_se(
+			company, manufacturer, issues_rows, stats, sync_log_name
+		)
+		if sync_log_name:
+			frappe.db.commit()
+
+
 def _bulk_set_child_rows(child_row_names, values):
-	"""Apply the same field updates to a list of MOP EOD Sync Log Item rows."""
-	for rn in child_row_names or []:
-		frappe.db.set_value("MOP EOD Sync Log Item", rn, values, update_modified=False)
+	"""Apply the same field updates to a list of MOP EOD Sync Log Item rows.
+
+	One UPDATE per batch of names instead of one per row -- a live run stamped 26,489 rows
+	this way, twice per bucket. Buffered rows are flushed first, because they do not exist in
+	the database yet and an UPDATE would silently match nothing.
+
+	Absent columns are dropped rather than allowed to fail the whole statement (see
+	:func:`_writable_values`); on any error it degrades to the per-row path so a single bad
+	value cannot cost the whole batch's bookkeeping.
+	"""
+	_flush_sync_log_items()
+	names = [rn for rn in (child_row_names or []) if rn]
+	if not names or not values:
+		return
+
+	writable = _writable_values("MOP EOD Sync Log Item", values)
+	if not writable:
+		return
+	assignments = ", ".join(f"`{field}` = %({field})s" for field in writable)
+
+	for start in range(0, len(names), _LOG_ROW_FLUSH_SIZE):
+		chunk = names[start : start + _LOG_ROW_FLUSH_SIZE]
+		params = dict(writable)
+		params["_names"] = chunk
+		try:
+			frappe.db.sql(
+				f"UPDATE `tabMOP EOD Sync Log Item` SET {assignments} "  # nosemgrep
+				"WHERE name IN %(_names)s",
+				params,
+			)
+		except Exception:
+			frappe.logger().exception(
+				"MOP EOD Sync: bulk child-row update failed for %s row(s); retrying per row",
+				len(chunk),
+			)
+			for rn in chunk:
+				try:
+					frappe.db.set_value(
+						"MOP EOD Sync Log Item", rn, writable, update_modified=False
+					)
+				except Exception:
+					_count_sync_log_row_failure()
+					frappe.logger().exception(
+						"MOP EOD Sync: could not update sync log row %s", rn
+					)
 
 
 def _heal_missing_sre_in_plan(mwo, operation, company, skipped_rows, sync_log_name):
@@ -866,6 +1303,45 @@ def _describe_shortfall(shortfall):
 	return f"{label}: needs {flt(need, 3)}, cap {flt(cap, 3)}, already allocated {flt(taken, 3)}"
 
 
+def _apply_run_allocation(main_buckets, failures, stats, sync_log_name):
+	"""Allocate stock across the WHOLE RUN, not one bucket at a time.
+
+	``_check_eod_source_batch_stock`` aggregates demand per MWO, so MWOs that each pass
+	individually can still jointly overdraw a shared batch -- and with ~1,425 batches spread
+	across ~8,602 MWOs that is close to certain. Allocating per bucket only caught the
+	contention *inside* a bucket; a run-wide tally catches all of it, which matters much more
+	now that a failing chunk no longer takes its whole bucket down with it (so an
+	over-subscription would fail quietly rather than loudly).
+
+	Takes ``{bucket_key: [entries]}`` and returns the same shape containing only admitted
+	MWOs. Buckets left empty are dropped. Ordering inside each bucket is preserved as the
+	allocator returned it (oldest MOP Log first, via ``_mwo_sort_key``), which is also the
+	order chunking then packs in.
+	"""
+	entries = [entry for bucket in main_buckets.values() for entry in bucket]
+	if not entries:
+		return main_buckets
+
+	admitted = _apply_bucket_allocation(entries, failures, stats, sync_log_name)
+	admitted_ids = {id(entry) for entry in admitted}
+
+	rebuilt = {}
+	for bucket_key, bucket in main_buckets.items():
+		kept = [entry for entry in bucket if id(entry) in admitted_ids]
+		if kept:
+			rebuilt[bucket_key] = kept
+	held = len(entries) - len(admitted)
+	if held:
+		frappe.logger().info(
+			"MOP EOD Sync: run-wide allocation admitted %s of %s MWO(s); %s held back for "
+			"stock contention.",
+			len(admitted),
+			len(entries),
+			held,
+		)
+	return rebuilt
+
+
 def _apply_bucket_allocation(main_mwos, failures, stats, sync_log_name):
 	"""Run the allocator and record whatever it holds back. Returns the admitted MWOs."""
 	admitted, deferred, infeasible = _allocate_bucket_by_physical_stock(main_mwos)
@@ -938,6 +1414,93 @@ def _apply_bucket_allocation(main_mwos, failures, stats, sync_log_name):
 	return admitted
 
 
+def _eod_deadline_start(started_on):
+	"""Stash the run's soft deadline on ``frappe.local``. Returns the deadline."""
+	minutes = _eod_setting_int("eod_soft_deadline_minutes", _SOFT_DEADLINE_MINUTES)
+	deadline = add_to_date(started_on, minutes=minutes) if minutes > 0 else None
+	frappe.local.eod_sync_deadline = deadline
+	return deadline
+
+
+def _eod_deadline_passed():
+	"""True once the run should stop STARTING new work.
+
+	Nothing in flight is interrupted -- the check sits between MWOs and between chunks, so a
+	run always finishes the unit it began. This is what turns the hard RQ kill (which left
+	the lock to the hourly reaper and a mystery draft Stock Entry) into a clean stop that
+	releases the lock itself and names what it did not get to.
+	"""
+	deadline = getattr(frappe.local, "eod_sync_deadline", None)
+	return bool(deadline) and now_datetime() >= deadline
+
+
+def _eod_setting_int(fieldname, default):
+	"""Read an Int EOD setting, falling back to ``default`` when unreadable.
+
+	Same fail-soft contract as :func:`_eod_feature_enabled`: on a site that has not run the
+	patch adding these fields, ``get_single_value`` raises rather than returning None, and
+	that must not abort the run. A blank/zero stored value also means "use the default"
+	for the chunk caps, because 0 there would mean "no chunking at all" -- see
+	:func:`_chunk_main_mwos`, which treats an explicit 0 as unlimited only when the field
+	genuinely reads as 0.
+	"""
+	try:
+		value = frappe.db.get_single_value("MOP Settings", fieldname)
+	except Exception:
+		frappe.logger().warning(
+			"MOP EOD Sync: MOP Settings.%s is not available on this site; using default %s.",
+			fieldname,
+			default,
+		)
+		return default
+	if value is None or value == "":
+		return default
+	return cint(value)
+
+
+def _chunk_main_mwos(main_mwos):
+	"""Split a bucket's MWOs into commit chunks, bounded on BOTH axes.
+
+	One 26,489-row Stock Entry cannot save *and* submit inside any sane window: ERPNext has
+	no bulk Stock Ledger Entry path (``make_sl_entries`` submits a document per SLE and runs
+	``repost_current_voucher`` inline per row), and Stock Reservation Entry submit/cancel
+	re-aggregates every SRE for its (item, warehouse) into Bin each time. Chunk size is the
+	only lever on both.
+
+	Two caps, because neither alone is enough: MWO row counts here run 1..156 with a median
+	of 2, so "50 MWOs" is ~100 rows typically but ~2,000 in the worst case.
+
+	  * ``eod_chunk_max_mwos`` -- MWOs per chunk (default 50)
+	  * ``eod_chunk_max_rows`` -- Stock Entry rows per chunk (default 150)
+
+	Either cap set to 0 disables that axis; both 0 restores one-SE-per-bucket.
+
+	**An MWO is never split across chunks** -- it is the indivisible accounting unit, and the
+	commit path cancels/re-reserves per MWO, so half an MWO would have its reservation
+	cancelled with no row to re-reserve from. A single MWO larger than ``max_rows``
+	therefore forms its own oversized chunk rather than being divided.
+	"""
+	max_mwos = _eod_setting_int("eod_chunk_max_mwos", 50)
+	max_rows = _eod_setting_int("eod_chunk_max_rows", 150)
+	if max_mwos <= 0 and max_rows <= 0:
+		return [list(main_mwos)]
+
+	chunks, current, rows = [], [], 0
+	for entry in main_mwos:
+		n = len(entry.get("items") or [])
+		if current and (
+			(max_mwos > 0 and len(current) >= max_mwos)
+			or (max_rows > 0 and rows + n > max_rows)
+		):
+			chunks.append(current)
+			current, rows = [], 0
+		current.append(entry)
+		rows += n
+	if current:
+		chunks.append(current)
+	return chunks
+
+
 def _commit_company_main_se(
 	company,
 	manufacturer,
@@ -946,34 +1509,172 @@ def _commit_company_main_se(
 	stats,
 	sync_log_name=None,
 	selective=False,
+	already_allocated=False,
 ):
-	"""Build ONE submitted *Material Transfer to Department* for all resolvable MWOs of a
-	(company, manufacturer).
+	"""Commit a (company, manufacturer) bucket as one or more *Material Transfer to
+	Department* Stock Entries.
 
-	Phase 1 (savepoint ``eod_draft_phase``) saves the consolidated draft. Phase 2
-	(savepoint ``eod_submit_phase``) is atomic for the whole bucket: cancel every MWO's
-	source SREs, submit the single SE, reserve at each MWO's target FROM the submitted SE's
-	rows (Sales-Order-anchored), hard-delete the now-cancelled source SREs, then mark each
-	MWO's MOP Logs synced. On Phase-2 failure the whole bucket rolls back (SREs restored,
-	never deleted) and the draft survives for manual recovery — the user-chosen "one SE for
-	the run" trade-off: a single submit failure holds the whole bucket as a draft.
+	The bucket is partitioned into bounded chunks (:func:`_chunk_main_mwos`); each chunk is
+	its own draft + submit + reservation relocation, committed on success. On failure a chunk
+	is halved and each half retried, recursing to single-MWO granularity, so a bad MWO
+	strands only itself instead of its whole bucket.
+
+	**This is a deliberate change to the former "one SE per bucket" contract.** The unit of
+	atomicity is now the CHUNK: earlier chunks stay committed when a later one fails, so a
+	partially-synced bucket is a normal outcome. Recovery is strictly better -- and resume is
+	free, because a committed chunk marks its MOP Logs ``is_synced = 1`` and the next run's
+	gather simply will not see them.
 	"""
-	# Admit MWOs against a running stock tally BEFORE anything is written. Placed here
-	# rather than in sync_mop_logs so _process_mwo_group (the manual retry path) is
-	# covered by the same guard.
-	if main_mwos and _eod_feature_enabled("enable_eod_bucket_allocation"):
+	# Admit MWOs against a running stock tally BEFORE anything is written. sync_mop_logs
+	# now allocates run-wide (a strictly wider tally) and passes already_allocated=True;
+	# this per-bucket fallback still covers _process_mwo_group, the manual retry path,
+	# which commits one MWO at a time with no run-level pass. It only READS, so it may use
+	# the plan-phase cache -- and should, since it reads keys the picker just read.
+	if (
+		not already_allocated
+		and main_mwos
+		and _eod_feature_enabled("enable_eod_bucket_allocation")
+	):
 		main_mwos = _apply_bucket_allocation(main_mwos, failures, stats, sync_log_name)
 		if not main_mwos:
 			# Everything was held back; _save_draft_eod_se throws on an empty item list
 			# and its error would misleadingly blame the MOP Log data.
 			return
 
-	items = [it for m in main_mwos for it in m["items"]]
-	child_rows = [rn for m in main_mwos for rn in m["child_row_names"]]
-	mwo_list = [m["mwo"] for m in main_mwos]
-	mop_names = sorted({md["mop_name"] for m in main_mwos for md in m["mop_data_list"]})
+	# From here on stock moves, so no reading may come from the plan-phase cache:
+	# _free_batch_qty_to_reserve and _reserve_batch_at_physical_warehouse must see
+	# post-submit reality. Stopping it here (not at function entry) keeps the read-only
+	# allocator above cached, and covers _process_mwo_group -- the retry path -- too.
+	_eod_batch_qty_cache_stop()
 
-	# Phase 1 — save consolidated draft (no header MWO; rows carry their own MWO/op).
+	chunks = _chunk_main_mwos(main_mwos)
+	# Bound the recursion's total cost: an entirely-bad chunk would otherwise cost ~2N
+	# submits. Whatever the cap abandons is reported, never silently dropped.
+	budget = {"submits": max(4 * len(chunks), 8)}
+
+	for chunk in chunks:
+		# Between chunks is the safe place to stop: previous chunks are committed, this
+		# one has not started, and the un-started MWOs keep their MOP Logs unsynced so the
+		# next run simply gathers them again. Nothing in flight is ever interrupted.
+		if _eod_deadline_passed():
+			stats["deadline_stopped"] = True
+			stats["deadline_skipped_chunks"] += 1
+			stats["deadline_skipped_mwos"] += len(chunk)
+			continue
+		_commit_chunk_with_split(
+			company,
+			manufacturer,
+			chunk,
+			failures,
+			stats,
+			sync_log_name,
+			selective=selective,
+			budget=budget,
+		)
+
+
+def _commit_chunk_with_split(
+	company,
+	manufacturer,
+	chunk,
+	failures,
+	stats,
+	sync_log_name=None,
+	selective=False,
+	budget=None,
+):
+	"""Commit one chunk; on failure halve it and retry each half, down to a single MWO.
+
+	Non-terminal attempts roll back completely -- draft Stock Entry included -- so a split
+	leaves no debris behind. Only a TERMINAL failure (one MWO, or the retry budget spent)
+	keeps its draft for manual recovery and records the failure, which is the behaviour the
+	recovery patch and the Sync Log's "Draft Created" status already expect.
+	"""
+	if not chunk:
+		return
+	budget = budget if budget is not None else {"submits": 8}
+
+	terminal = len(chunk) == 1 or budget["submits"] <= 1
+	# A terminal attempt is the one whose failure is final, so it is the one that reports.
+	budget["submits"] -= 1
+	ok = _commit_se_chunk(
+		company,
+		manufacturer,
+		chunk,
+		failures,
+		stats,
+		sync_log_name,
+		selective=selective,
+		keep_draft_on_failure=terminal,
+		record_failure=terminal,
+	)
+	if ok or terminal:
+		if not ok and budget["submits"] <= 0 and len(chunk) > 1:
+			frappe.logger().warning(
+				"MOP EOD Sync: retry budget exhausted with %s MWO(s) still grouped; they "
+				"were reported together rather than isolated individually.",
+				len(chunk),
+			)
+		return
+
+	half = len(chunk) // 2
+	frappe.logger().info(
+		"MOP EOD Sync: chunk of %s MWO(s) failed; splitting into %s + %s and retrying.",
+		len(chunk),
+		half,
+		len(chunk) - half,
+	)
+	for part in (chunk[:half], chunk[half:]):
+		_commit_chunk_with_split(
+			company,
+			manufacturer,
+			part,
+			failures,
+			stats,
+			sync_log_name,
+			selective=selective,
+			budget=budget,
+		)
+
+
+def _commit_se_chunk(
+	company,
+	manufacturer,
+	chunk,
+	failures,
+	stats,
+	sync_log_name=None,
+	selective=False,
+	keep_draft_on_failure=True,
+	record_failure=True,
+):
+	"""One chunk: save the draft, cancel source SREs, submit, re-reserve, mark synced.
+
+	Returns True on success (and commits), False on failure.
+
+	Phase 1 (savepoint ``eod_draft_phase``) saves the draft. Phase 2 (savepoint
+	``eod_submit_phase``) is atomic for the chunk: cancel every MWO's source SREs, submit,
+	reserve at each MWO's target FROM the submitted SE's rows (Sales-Order-anchored),
+	hard-delete the cancelled sources, then mark each MWO's MOP Logs synced.
+
+	When ``keep_draft_on_failure`` is False the whole attempt is additionally wrapped in
+	``eod_chunk_phase`` and rolled back on failure, so a caller that is about to retry a
+	smaller slice leaves no orphan draft behind.
+
+	SAVEPOINT / COMMIT ORDER IS LOAD-BEARING: MariaDB drops **every** savepoint on COMMIT,
+	so the commit below happens only after all of this chunk's savepoints are released, and
+	the next chunk opens fresh ones. A savepoint held across a commit boundary silently
+	ceases to exist and its later rollback would take the full-rollback fallback path.
+	"""
+	items = [it for m in chunk for it in m["items"]]
+	child_rows = [rn for m in chunk for rn in m["child_row_names"]]
+	mwo_list = [m["mwo"] for m in chunk]
+	mop_names = sorted({md["mop_name"] for m in chunk for md in m["mop_data_list"]})
+	outer = None if keep_draft_on_failure else "eod_chunk_phase"
+	if outer:
+		frappe.db.savepoint(outer)
+
+	# Phase 1 — save the chunk's draft (no header MWO; rows carry their own MWO/op).
 	try:
 		frappe.db.savepoint("eod_draft_phase")
 		draft_se_name = _save_draft_eod_se(
@@ -987,41 +1688,49 @@ def _commit_company_main_se(
 		frappe.db.release_savepoint("eod_draft_phase")
 	except Exception as exc:
 		_rollback_to_savepoint("eod_draft_phase")
-		failures.append(
-			{
-				"step": "draft_save",
-				"mwo": ", ".join(mwo_list),
-				"company": company,
-				"affected_mops": mop_names,
-				"error_message": str(exc),
-				"traceback": frappe.get_traceback(),
-				"suggested_fix": (
-					"Check MOP Log data for the listed MWOs: item codes, batch numbers, "
-					"warehouses, Stock Reservation Entries, and physical batch stock."
-				),
-			}
-		)
-		stats["failed_mwos"] += len(main_mwos)
-		_bulk_set_child_rows(
-			child_rows,
-			{
-				"status": "Failed",
-				"sync_stage": "Save Draft Stock Entry",
-				"error_type": "Stock Entry Save Failed",
-				"error_message": str(exc)[:500],
-				"technical_traceback": frappe.get_traceback()[:3000],
-				"suggested_fix": "Check MOP Log data, warehouses, SREs, and physical batch stock.",
-				"completed_on": now_datetime(),
-			},
-		)
-		return
+		if outer:
+			_rollback_to_savepoint(outer)
+		# A timeout/deadlock is not this chunk's data being wrong, and it will hit every
+		# remaining chunk. Re-raise so the run stops cleanly instead of grinding through the
+		# rest (and instead of the binary split burning what time is left on halves).
+		if _is_recoverable_error(exc):
+			raise
+		if record_failure:
+			failures.append(
+				{
+					"step": "draft_save",
+					"mwo": ", ".join(mwo_list),
+					"company": company,
+					"affected_mops": mop_names,
+					"error_message": str(exc),
+					"traceback": frappe.get_traceback(),
+					"suggested_fix": (
+						"Check MOP Log data for the listed MWOs: item codes, batch numbers, "
+						"warehouses, Stock Reservation Entries, and physical batch stock."
+					),
+				}
+			)
+			stats["failed_mwos"] += len(chunk)
+			_bulk_set_child_rows(
+				child_rows,
+				{
+					"status": "Failed",
+					"sync_stage": "Save Draft Stock Entry",
+					"error_type": "Stock Entry Save Failed",
+					"error_message": str(exc)[:500],
+					"technical_traceback": frappe.get_traceback()[:3000],
+					"suggested_fix": "Check MOP Log data, warehouses, SREs, and physical batch stock.",
+					"completed_on": now_datetime(),
+				},
+			)
+		return False
 
-	# Phase 2 — cancel SREs, submit once, reserve from the SE rows, delete the cancelled
-	# sources, mark synced. Atomic for the bucket.
+	# Phase 2 — cancel SREs, submit, reserve from the SE rows, delete the cancelled
+	# sources, mark synced. Atomic for the chunk.
 	try:
 		frappe.db.savepoint("eod_submit_phase")
 		snaps_by_mwo = {}
-		for m in main_mwos:
+		for m in chunk:
 			snaps = _snapshot_mwo_sres_for_relocation(
 				m["mwo"], m["items"], m["t_warehouse"]
 			)
@@ -1029,12 +1738,13 @@ def _commit_company_main_se(
 			_cancel_sre_snapshots(snaps)
 		submitted_se = frappe.get_doc("Stock Entry", draft_se_name)
 		submitted_se.submit()
-		# Reserve at each MWO's target FROM the submitted SE's rows (Sales-Order-anchored,
-		# per-row MWO/operation), then hard-delete the now-cancelled source SREs.
-		# Read the rows back off the SUBMITTED document rather than the planned dicts:
-		# before_validate hooks can drop or rewrite rows (one live draft ended up with
-		# 968 rows against 976 planned), and a dropped row's source SRE would otherwise
-		# be cancelled and hard-deleted with nothing transferred to re-reserve from.
+		# Reserve at each MWO's target FROM THIS CHUNK'S submitted SE rows
+		# (Sales-Order-anchored, per-row MWO/operation), then hard-delete the now-cancelled
+		# source SREs. Read the rows back off the SUBMITTED document rather than the planned
+		# dicts: before_validate hooks can drop or rewrite rows, and a dropped row's source
+		# SRE would otherwise be cancelled and hard-deleted with nothing transferred to
+		# re-reserve from. This MUST stay per chunk -- passing a union across chunks would
+		# re-reserve one chunk's dropped row from another chunk's rows.
 		_reserve_sres_from_eod_se_rows(
 			company,
 			_eod_rows_from_submitted_se(submitted_se),
@@ -1046,10 +1756,10 @@ def _commit_company_main_se(
 		# leaves Employee IR Process Loss with "No active Stock Reservation Entry found". For
 		# each cancelled batched snapshot with no live SRE, heal it at the batch's physical
 		# warehouse; if that is impossible, raise so the whole Phase-2 savepoint rolls back
-		# (SREs restored, submit undone, draft kept for manual recovery) rather than leaving
-		# the reservation orphaned. Runs while the snapshots are still in memory and BEFORE
-		# _hard_delete_cancelled_snapshots makes the cancellation permanent.
-		for m in main_mwos:
+		# (SREs restored, submit undone) rather than leaving the reservation orphaned. Runs
+		# while the snapshots are still in memory and BEFORE _hard_delete_cancelled_snapshots
+		# makes the cancellation permanent. Scoped to this chunk's MWOs only.
+		for m in chunk:
 			for snap in snaps_by_mwo[m["mwo"]]:
 				for sb in snap.get("sb_entries") or []:
 					batch_no = sb.get("batch_no")
@@ -1073,14 +1783,14 @@ def _commit_company_main_se(
 						_(
 							"EOD orphaned WIP reservation: MWO {0}, item {1}, batch {2} — the "
 							"source Stock Reservation Entry was cancelled but no warehouse "
-							"physically holds free batch qty to re-reserve. The bucket is rolled "
+							"physically holds free batch qty to re-reserve. The chunk is rolled "
 							"back; investigate the batch's physical stock before re-running."
 						).format(m["mwo"], item_code, batch_no),
 						title=_("EOD Reservation Not Replaceable"),
 					)
-		for m in main_mwos:
+		for m in chunk:
 			_hard_delete_cancelled_snapshots(snaps_by_mwo[m["mwo"]])
-		for m in main_mwos:
+		for m in chunk:
 			# Pinned to the rows this run planned from: the transfer only moved those,
 			# so anything logged since must stay unsynced for the next run.
 			_mark_all_mwo_mop_logs_synced(
@@ -1091,7 +1801,7 @@ def _commit_company_main_se(
 			_stamp_last_eod_sync(m["mop_data_list"])
 		frappe.db.release_savepoint("eod_submit_phase")
 		stats["submitted_ses"].append(draft_se_name)
-		stats["processed_mwos"] += len(main_mwos)
+		stats["processed_mwos"] += len(chunk)
 		_bulk_set_child_rows(
 			child_rows,
 			{
@@ -1102,43 +1812,58 @@ def _commit_company_main_se(
 				"completed_on": now_datetime(),
 			},
 		)
+		if outer:
+			frappe.db.release_savepoint(outer)
+		# Make this chunk durable. Every savepoint above is released by now, which is
+		# required: MariaDB discards all savepoints on COMMIT. It also releases the Bin
+		# locks prelock_bins took, so the next chunk does not accumulate them.
+		frappe.db.commit()
+		return True
 	except Exception as exc:
-		# Whole Phase-2 savepoint rolled back: submit + SRE cancel/re-reserve undone, so
-		# reservations are restored. The Phase-1 draft (saved before this savepoint)
-		# survives for manual recovery.
+		# Phase-2 savepoint rolled back: submit + SRE cancel/re-reserve undone, so
+		# reservations are restored. The Phase-1 draft survives unless this attempt is
+		# about to be retried on a smaller slice, in which case the outer savepoint takes
+		# the draft with it.
 		_rollback_to_savepoint("eod_submit_phase")
-		failures.append(
-			{
-				"step": "submit",
-				"mwo": ", ".join(mwo_list),
-				"company": company,
-				"affected_mops": mop_names,
-				"draft_se": draft_se_name,
-				"error_message": str(exc),
-				"traceback": frappe.get_traceback(),
-				"suggested_fix": (
-					f"Consolidated Stock Entry {draft_se_name} is saved as Draft but failed "
-					"to submit. Stock Reservation Entries were restored (rolled back). Review "
-					"the validation error, fix the underlying issue, and submit the draft "
-					"manually. MOP Logs for these MWOs remain unsynced until then."
-				),
-			}
-		)
-		stats["draft_ses"].append(draft_se_name)
-		stats["failed_mwos"] += len(main_mwos)
-		_bulk_set_child_rows(
-			child_rows,
-			{
-				"status": "Draft Created",
-				"draft_stock_entry": draft_se_name,
-				"sync_stage": "Submit Stock Entry",
-				"error_type": "Stock Entry Submit Failed",
-				"error_message": str(exc)[:500],
-				"technical_traceback": frappe.get_traceback()[:3000],
-				"suggested_fix": f"Open draft Stock Entry {draft_se_name}, fix the error, and submit manually.",
-				"completed_on": now_datetime(),
-			},
-		)
+		if outer:
+			_rollback_to_savepoint(outer)
+		# See the draft-phase handler: a cut-short run must stop, not be retried in halves.
+		if _is_recoverable_error(exc):
+			raise
+		if record_failure:
+			failures.append(
+				{
+					"step": "submit",
+					"mwo": ", ".join(mwo_list),
+					"company": company,
+					"affected_mops": mop_names,
+					"draft_se": draft_se_name,
+					"error_message": str(exc),
+					"traceback": frappe.get_traceback(),
+					"suggested_fix": (
+						f"Stock Entry {draft_se_name} is saved as Draft but failed to submit. "
+						"Stock Reservation Entries were restored (rolled back). Review the "
+						"validation error, fix the underlying issue, and submit the draft "
+						"manually. MOP Logs for these MWOs remain unsynced until then."
+					),
+				}
+			)
+			stats["draft_ses"].append(draft_se_name)
+			stats["failed_mwos"] += len(chunk)
+			_bulk_set_child_rows(
+				child_rows,
+				{
+					"status": "Draft Created",
+					"draft_stock_entry": draft_se_name,
+					"sync_stage": "Submit Stock Entry",
+					"error_type": "Stock Entry Submit Failed",
+					"error_message": str(exc)[:500],
+					"technical_traceback": frappe.get_traceback()[:3000],
+					"suggested_fix": f"Open draft Stock Entry {draft_se_name}, fix the error, and submit manually.",
+					"completed_on": now_datetime(),
+				},
+			)
+		return False
 
 
 def _commit_company_issues_se(
@@ -1231,6 +1956,18 @@ def _create_consolidated_error_log(failures, stats, sync_log_name=None):
 		f"  Draft SEs (stuck) : {', '.join(stats.get('draft_ses') or []) or 'None'}",
 		"",
 	]
+
+	# Diagnostics rows the run could not persist. Swallowing them is deliberate (a sync must
+	# never fail over its own audit trail), but silence is not: without this the Sync Log's
+	# child rows can under-count the run with nothing anywhere saying so.
+	lost_rows = cint(getattr(frappe.local, "eod_sync_log_row_failures", 0))
+	if lost_rows:
+		lines += [
+			f"  ⚠ Sync Log rows lost : {lost_rows} diagnostic row(s) could not be written, so "
+			"the Sync Log child table under-reports this run. See frappe.log for the "
+			"underlying write errors.",
+			"",
+		]
 
 	lines += ["FAILED DETAILS", "-" * 40]
 	for i, f in enumerate(failures, 1):
@@ -1346,6 +2083,133 @@ def _reconcile_reservations_for_mwo(mwo, dry_run=True):
 					frappe.logger().exception(
 						"EOD SRE reconcile cancel failed: %s", sre.name
 					)
+
+
+def _bulk_mop_balance_rows(mop_names):
+	"""``{mop_name: [balance rows]}`` for many operations in one query.
+
+	Replicates ``get_current_mop_balance_rows``' semantics -- non-cancelled MOP Log rows,
+	latest row per ``(item_code, batch_no)`` by ``creation`` -- but grouped, so the advisory
+	audit stops issuing one query per Stock Reservation Entry. Loss-attribution rows stay
+	included, exactly as the single-MOP helper documents.
+	"""
+	balances = {}
+	names = [m for m in dict.fromkeys(mop_names or []) if m]
+	if not names:
+		return balances
+
+	for start in range(0, len(names), _LOG_ROW_FLUSH_SIZE):
+		chunk = names[start : start + _LOG_ROW_FLUSH_SIZE]
+		rows = frappe.db.get_all(
+			"MOP Log",
+			filters={"manufacturing_operation": ["in", chunk], "is_cancelled": 0},
+			fields=[
+				"manufacturing_operation",
+				"item_code",
+				"batch_no",
+				"qty_after_transaction_batch_based as qty",
+				"to_warehouse",
+				"creation",
+			],
+			order_by="creation desc",
+			limit_page_length=0,
+		)
+		seen = {}
+		for row in rows:
+			# creation desc, so the FIRST row seen for a key is the latest -- the same
+			# dedup rule get_current_mop_balance_rows applies per MOP.
+			key = (
+				row.get("manufacturing_operation"),
+				row.get("item_code"),
+				row.get("batch_no"),
+			)
+			if key in seen:
+				continue
+			seen[key] = True
+			balances.setdefault(row.get("manufacturing_operation"), []).append(row)
+	return balances
+
+
+def _reconcile_reservations_bulk(mwos, failures=None):
+	"""Advisory SRE-vs-MOP-balance audit for MANY MWOs, in a bounded number of queries.
+
+	Same audit as :func:`_reconcile_reservations_for_mwo` and equally **advisory** -- it only
+	logs, never cancels (AGENTS.md A2: this must never be flipped to act). The per-MWO version
+	cost one SRE query per MWO plus one balance query per SRE; on a backlog run that was tens
+	of thousands of queries whose result is thrown away. This does two per chunk.
+
+	Failures are recorded as ``advisory`` so they cannot downgrade the run's status.
+	"""
+	mwo_list = [m for m in dict.fromkeys(mwos or []) if m]
+	if not mwo_list:
+		return
+
+	try:
+		sres = []
+		for start in range(0, len(mwo_list), _LOG_ROW_FLUSH_SIZE):
+			chunk = mwo_list[start : start + _LOG_ROW_FLUSH_SIZE]
+			sres.extend(
+				frappe.db.get_all(
+					"Stock Reservation Entry",
+					filters={"manufacturing_work_order": ["in", chunk], "docstatus": 1},
+					fields=[
+						"name",
+						"item_code",
+						"warehouse",
+						"reserved_qty",
+						"delivered_qty",
+						"manufacturing_work_order",
+						"manufacturing_operation",
+					],
+					limit_page_length=0,
+				)
+			)
+
+		live = [
+			sre
+			for sre in sres
+			if sre.manufacturing_operation
+			and flt(sre.reserved_qty) - flt(sre.delivered_qty) > 0
+		]
+		if not live:
+			return
+
+		balances = _bulk_mop_balance_rows({sre.manufacturing_operation for sre in live})
+
+		for sre in live:
+			matched = [
+				b
+				for b in balances.get(sre.manufacturing_operation) or []
+				if b.get("item_code") == sre.item_code
+				and b.get("to_warehouse") == sre.warehouse
+			]
+			if sum(flt(b.get("qty")) for b in matched) <= 0:
+				frappe.logger().info(
+					"EOD SRE reconcile: %s (MWO %s, item %s, wh %s) has no MOP balance "
+					"(remaining=%s, balance=0). DRY-RUN -- would cancel.",
+					sre.name,
+					sre.manufacturing_work_order,
+					sre.item_code,
+					sre.warehouse,
+					flt(sre.reserved_qty) - flt(sre.delivered_qty),
+				)
+	except Exception:
+		if failures is not None:
+			failures.append(
+				{
+					"step": "sre_reconcile",
+					# Read-only audit: it never blocks a transfer, so it is reported but
+					# must not downgrade the run's final status.
+					"advisory": True,
+					"error_message": "Bulk SRE reconciliation check raised an exception.",
+					"traceback": frappe.get_traceback(),
+					"suggested_fix": (
+						"Investigate the SRE reconcile error. This does not affect SE or "
+						"MOP Log sync status."
+					),
+				}
+			)
+		frappe.logger().exception("MOP EOD Sync: bulk SRE reconcile failed")
 
 
 def _active_sre_exists(mwo, item_code, batch_no):
@@ -1526,6 +2390,71 @@ def _get_sync_range():
 	return _today_range()
 
 
+# Fields every MOP Log gather needs. Shared by the windowed/selective gather and the
+# backlog catch-up gather so the two cannot drift into disagreeing about what a log row
+# carries -- _plan_mwo_group reads all of them.
+_MOP_LOG_GATHER_FIELDS = (
+	"name",
+	"manufacturing_operation",
+	"manufacturing_work_order",
+	"item_code",
+	"batch_no",
+	"serial_no",
+	"qty_after_transaction_batch_based",
+	"pcs_after_transaction_batch_based",
+	"from_warehouse",
+	"to_warehouse",
+	"flow_index",
+	"creation",
+	"voucher_type",
+	"voucher_no",
+)
+
+
+def _group_logs_by_company_and_mwo(logs):
+	"""``{(company, mwo): [{mop_name, mop_doc, logs}, ...]}`` from a flat MOP Log list.
+
+	One Manufacturing Operation metadata query per chunk, then grouping. Operations whose
+	metadata cannot be read are dropped -- there is no company to bucket them under.
+	"""
+	if not logs:
+		return {}
+
+	mop_logs = {}
+	for log in logs:
+		mop_logs.setdefault(log.manufacturing_operation, []).append(log)
+
+	mop_cache = {}
+	names = list(mop_logs.keys())
+	for start in range(0, len(names), _LOG_ROW_FLUSH_SIZE):
+		chunk = names[start : start + _LOG_ROW_FLUSH_SIZE]
+		for row in frappe.db.get_all(
+			"Manufacturing Operation",
+			filters={"name": ["in", chunk]},
+			fields=[
+				"name",
+				"company",
+				"manufacturer",
+				"manufacturing_work_order",
+				"manufacturing_order",
+				"department",
+				"loss_wt",
+			],
+			limit_page_length=0,
+		):
+			mop_cache[row.name] = row
+
+	groups = {}
+	for mop_name, op_logs in mop_logs.items():
+		mop = mop_cache.get(mop_name)
+		if not mop:
+			continue
+		groups.setdefault((mop.company, mop.manufacturing_work_order), []).append(
+			{"mop_name": mop_name, "mop_doc": mop, "logs": op_logs}
+		)
+	return groups
+
+
 def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
 	"""Return a dict of {(company, mwo): [...]} of unsynced MOP Logs to process.
 
@@ -1544,22 +2473,7 @@ def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
 				filter_rows.append(row)
 	selective = bool(filter_rows)
 
-	log_fields = [
-		"name",
-		"manufacturing_operation",
-		"manufacturing_work_order",
-		"item_code",
-		"batch_no",
-		"serial_no",
-		"qty_after_transaction_batch_based",
-		"pcs_after_transaction_batch_based",
-		"from_warehouse",
-		"to_warehouse",
-		"flow_index",
-		"creation",
-		"voucher_type",
-		"voucher_no",
-	]
+	log_fields = list(_MOP_LOG_GATHER_FIELDS)
 	log_order_by = "manufacturing_operation, flow_index asc, creation asc"
 
 	if selective:
@@ -1652,38 +2566,9 @@ def _get_unsynced_mop_groups(settings=None, sync_log_name=None):
 	if not logs:
 		return {}
 
-	mop_logs = {}
-	for log in logs:
-		mop_logs.setdefault(log.manufacturing_operation, []).append(log)
-
-	# Bulk fetch all MOP metadata in one query
-	mop_names = list(mop_logs.keys())
-	mop_rows = frappe.db.get_all(
-		"Manufacturing Operation",
-		filters={"name": ["in", mop_names]},
-		fields=[
-			"name",
-			"company",
-			"manufacturer",
-			"manufacturing_work_order",
-			"manufacturing_order",
-			"department",
-			"loss_wt",
-		],
-	)
-	mop_cache = {r.name: r for r in mop_rows}
-
-	groups = {}
-	for mop_name, op_logs in mop_logs.items():
-		mop = mop_cache.get(mop_name)
-		if not mop:
-			continue
-		group_key = (mop.company, mop.manufacturing_work_order)
-		groups.setdefault(group_key, []).append(
-			{"mop_name": mop_name, "mop_doc": mop, "logs": op_logs}
-		)
-
-	return groups
+	# Shared with the backlog catch-up gather: one Manufacturing Operation metadata query,
+	# then grouping by (company, MWO).
+	return _group_logs_by_company_and_mwo(logs)
 
 
 def _apply_mwo_filter_rows(logs, filter_rows):
@@ -2561,6 +3446,210 @@ def _hard_delete_cancelled_snapshots(snapshots):
 # ---------------------------------------------------------------------------
 
 
+def _eod_batch_qty_cache_start():
+	"""Turn the plan-phase physical-batch-qty cache on, and freeze the posting clock.
+
+	The plan phase moves no stock, so every (item, batch, warehouse) reading is stable for
+	its whole duration -- while the same keys are asked for over and over. One live run
+	asked ~79,000 times for 1,957 distinct keys, and each ask costs ERPNext 8-12 SQL round
+	trips (doubled again by ``filter_zero_near_batches``). Caching per (item, warehouse) is
+	the single biggest win available here.
+
+	The clock is frozen for correctness, not speed: uncached, every call re-evaluated
+	``today()``/``nowtime()``, so a long plan silently shifted its own cutoff partway
+	through and could source two rows of one MWO against different stock snapshots.
+
+	Cache state lives on ``frappe.local`` so it cannot outlive the RQ job.
+
+	NOTE the plan-phase reservation healer (``_heal_missing_sre_in_plan``, OFF by default)
+	needs no invalidation: it submits Stock Reservation Entries, which do not move stock,
+	and every reading here passes ``ignore_reserved_stock=True``.
+	"""
+	from frappe.utils import nowtime, today
+
+	frappe.local.eod_batch_qty_cache = {}
+	frappe.local.eod_batch_qty_clock = (today(), nowtime())
+
+
+def _eod_batch_qty_cache_stop():
+	"""Turn the cache off. MUST be called before anything moves stock (Phase 2)."""
+	frappe.local.eod_batch_qty_cache = None
+	frappe.local.eod_batch_qty_clock = None
+
+
+def _eod_batch_qty_cache():
+	"""The live cache dict, or ``None`` when caching is off."""
+	return getattr(frappe.local, "eod_batch_qty_cache", None)
+
+
+def _eod_batch_qty_clock():
+	"""The run's frozen ``(posting_date, posting_time)``, or now when there is no run."""
+	from frappe.utils import nowtime, today
+
+	return getattr(frappe.local, "eod_batch_qty_clock", None) or (today(), nowtime())
+
+
+def _eod_batch_qty_map(item_code, warehouse):
+	"""``{batch_no: physical_qty}`` for every batch of (item, warehouse), in ONE call.
+
+	Reproduces ``erpnext.stock.doctype.batch.batch.get_batch_qty``'s own arithmetic exactly,
+	so a lookup in the returned dict is interchangeable with a scalar ``get_batch_qty`` call
+	for the same key. Four details are load-bearing and must not be "tidied":
+
+	* ``item_code`` and ``warehouse`` stay SCALAR -- one call per pair is the widest
+	  provably-equivalent batching. ``get_auto_batch_nos`` -> ``get_reserved_batches_for_pos``
+	  filters ``POS Invoice Item.item_code == kwargs.item_code`` with no list branch and no
+	  warehouse filter at all, so a list there renders invalid SQL and a ``None`` silently
+	  drops every POS deduction.
+	* ``batch_no`` is ``None``, NOT a list. The bundle-less POS branch compares
+	  ``row.batch_no != kwargs.get("batch_no")``; a list never equals a string, so passing a
+	  list drops every legacy POS row and OVER-states availability.
+	* qty is summed by ``batch_no`` ALONE, discarding each row's warehouse -- exactly what
+	  ``get_batch_qty`` does. ``get_available_batches`` filters on
+	  ``Stock Ledger Entry.warehouse`` but groups by ``Serial and Batch Entry.warehouse``, so
+	  keying on the row warehouse would split totals the scalar nets together.
+	* ``qty`` must stay ABSENT from kwargs. With a qty, ``get_auto_batch_nos`` returns a FIFO
+	  *pick list* (truncated, with a partial boundary row), not a balance.
+
+	``do_not_check_future_batches=True`` is the one deliberate divergence from the callers'
+	old kwargs, and it is a provable no-op *while* ``consider_negative_batches`` is falsy:
+	``filter_zero_near_batches`` only zeroes a batch when a positively-matched future row has
+	``qty <= 0``, and the recursion it runs strips every non-positive row first. It halves the
+	queries, because that recursion re-runs the entire cascade. **If
+	``consider_negative_batches`` is ever flipped on, this equivalence collapses.**
+	"""
+	from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
+		combine_datetime,
+		get_auto_batch_nos,
+	)
+
+	posting_date, posting_time = _eod_batch_qty_clock()
+	# A FRESH dict per call: filter_zero_near_batches mutates the kwargs it is handed (it
+	# rewrites batch_no and deletes posting_datetime), so a shared dict would leave the next
+	# call time-unbounded and scoped to the previous call's batch list.
+	kwargs = frappe._dict(
+		{
+			"item_code": item_code,
+			"warehouse": warehouse,
+			"creation": None,
+			"batch_no": None,
+			"based_on": frappe.get_single_value(
+				"Stock Settings", "pick_serial_and_batch_based_on"
+			),
+			"ignore_voucher_nos": None,
+			"for_stock_levels": False,
+			"consider_negative_batches": False,
+			"do_not_check_future_batches": True,
+			"ignore_reserved_stock": True,
+			"posting_datetime": combine_datetime(posting_date, posting_time),
+		}
+	)
+	qty_by_batch = {}
+	for row in get_auto_batch_nos(kwargs) or []:
+		batch_no = row.get("batch_no")
+		# Reserved/POS rows carry only {qty, warehouse}; upstream buckets them under
+		# batchwise_qty[None] where no real lookup can ever see them. Drop them for the
+		# same reason -- keeping them would invent a phantom batch key.
+		if not batch_no:
+			continue
+		qty_by_batch[batch_no] = flt(qty_by_batch.get(batch_no, 0.0)) + flt(
+			row.get("qty")
+		)
+	return qty_by_batch
+
+
+def _eod_scalar_batch_qty(item_code, batch_no, warehouse):
+	"""Uncached single-key physical batch qty -- the original reading, unchanged.
+
+	Used whenever the cache is off (Phase 2, and any caller outside a run) and by
+	``verify_eod_batch_qty_cache`` to prove the cache agrees with it.
+	"""
+	from erpnext.stock.doctype.batch.batch import get_batch_qty
+
+	posting_date, posting_time = _eod_batch_qty_clock()
+	return flt(
+		get_batch_qty(
+			batch_no=batch_no,
+			warehouse=warehouse,
+			item_code=item_code,
+			posting_date=posting_date,
+			posting_time=posting_time,
+			ignore_reserved_stock=True,
+		),
+		3,
+	)
+
+
+@frappe.whitelist()
+def verify_eod_batch_qty_cache(limit=200, keys=None):
+	"""Prove the (item, warehouse) cache agrees with scalar ``get_batch_qty``, key by key.
+
+	This path decides which warehouse EOD sources metal from and whether a batch is short,
+	so "probably equivalent" is not good enough -- run this on real data before trusting
+	the cache, and after any ERPNext upgrade that touches batch availability.
+
+	Both readings are taken under ONE frozen clock, otherwise the comparison races itself
+	(the scalar path used to re-evaluate ``today()``/``nowtime()`` per call).
+
+	``keys`` may be an explicit list of ``[item_code, batch_no, warehouse]`` triples; with
+	none given, the (item, batch, warehouse) grid is derived from recent EOD Stock Entry
+	rows, which is exactly the population the sync actually reads.
+
+	Returns ``{"checked": n, "mismatches": [...]}``. Mismatches are the interesting part;
+	an empty list is the pass condition.
+	"""
+	limit = cint(limit) or 200
+	if isinstance(keys, str):
+		keys = frappe.parse_json(keys)
+
+	if not keys:
+		rows = frappe.db.sql(
+			"""
+			SELECT DISTINCT sed.item_code, sed.batch_no, sed.s_warehouse
+			FROM `tabStock Entry Detail` sed
+			INNER JOIN `tabStock Entry` se ON se.name = sed.parent
+			WHERE se.custom_is_eod_sync_stock_entry = 1
+			  AND sed.batch_no IS NOT NULL AND sed.batch_no != ''
+			  AND sed.s_warehouse IS NOT NULL AND sed.s_warehouse != ''
+			ORDER BY se.creation DESC
+			LIMIT %s
+			""",
+			(limit,),
+		)
+		keys = [list(r) for r in rows]
+
+	_eod_batch_qty_cache_start()
+	try:
+		mismatches = []
+		for item_code, batch_no, warehouse in keys:
+			cached = flt(
+				_eod_physical_batch_qty(item_code, batch_no, warehouse) or 0.0, 3
+			)
+			scalar = flt(_eod_scalar_batch_qty(item_code, batch_no, warehouse), 3)
+			if abs(cached - scalar) > 1e-6:
+				mismatches.append(
+					{
+						"item_code": item_code,
+						"batch_no": batch_no,
+						"warehouse": warehouse,
+						"cached": cached,
+						"scalar": scalar,
+						"difference": flt(cached - scalar, 3),
+					}
+				)
+		if mismatches:
+			frappe.logger().error(
+				"MOP EOD Sync: batch-qty cache disagrees with get_batch_qty on %s of %s "
+				"key(s). Do NOT rely on the cache until this is explained: %s",
+				len(mismatches),
+				len(keys),
+				mismatches[:20],
+			)
+		return {"checked": len(keys), "mismatches": mismatches}
+	finally:
+		_eod_batch_qty_cache_stop()
+
+
 def _eod_physical_batch_qty(item_code, batch_no, warehouse):
 	"""Physical SBB qty of (item, batch) in ``warehouse``, reservations ignored.
 
@@ -2569,24 +3658,26 @@ def _eod_physical_batch_qty(item_code, batch_no, warehouse):
 	negative-batch validator only fires on batched items). ``ignore_reserved_stock=True``
 	is required: the batch we are about to consume is itself reserved by the SRE being
 	processed, so the default (reservation-subtracted) qty would understate the warehouse.
+
+	Served from the run-scoped (item, warehouse) cache during the plan phase and read
+	straight from ERPNext otherwise -- see :func:`_eod_batch_qty_map`.
+
+	The positional signature ``(item_code, batch_no, warehouse)`` is load-bearing: tests
+	replace this function with ``side_effect=lambda i, b, w: ...``. The cache is therefore
+	read from ``frappe.local`` rather than passed in as a parameter.
 	"""
 	if not batch_no or not warehouse:
 		return None
-	from erpnext.stock.doctype.batch.batch import get_batch_qty
-	from frappe.utils import nowtime, today
-
 	try:
-		return flt(
-			get_batch_qty(
-				batch_no=batch_no,
-				warehouse=warehouse,
-				item_code=item_code,
-				posting_date=today(),
-				posting_time=nowtime(),
-				ignore_reserved_stock=True,
-			),
-			3,
-		)
+		cache = _eod_batch_qty_cache()
+		if cache is None:
+			return _eod_scalar_batch_qty(item_code, batch_no, warehouse)
+		key = (item_code, warehouse)
+		qty_by_batch = cache.get(key)
+		if qty_by_batch is None:
+			qty_by_batch = _eod_batch_qty_map(item_code, warehouse)
+			cache[key] = qty_by_batch
+		return flt(qty_by_batch.get(batch_no, 0.0), 3)
 	except Exception:
 		return 0.0
 
@@ -2844,16 +3935,28 @@ def _pick_eod_source_warehouse(
 	return candidates[0] if candidates else None
 
 
-def _eod_batch_ownership(batch_nos):
+def _eod_batch_ownership(batch_nos, use_cache=True):
 	"""``{batch_no: (custom_inventory_type, custom_customer)}`` in ONE query.
 
 	``resolve_batch_ownership`` reads one Batch per row; a consolidated EOD Stock Entry
 	carries hundreds of rows, so the lookup is batched here and the shared normalisation
 	rules are applied per row afterwards.
+
+	With a run-scoped prefetch available this is served from memory: batched per MWO it was
+	still one query per MWO (~8,602) for ~1,425 distinct batches. ``use_cache=False`` is how
+	the prefetch itself builds the map without recursing into it.
 	"""
 	batch_nos = sorted({b for b in batch_nos if b})
 	if not batch_nos:
 		return {}
+	if use_cache:
+		prefetch = getattr(frappe.local, "eod_batch_ownership", None)
+		if prefetch is not None:
+			# Fall through to a real query only if the prefetch is missing a batch (a row
+			# created after the gather), so a stale prefetch can never silently blank
+			# ownership -- which would book a customer's metal as company stock.
+			if all(b in prefetch for b in batch_nos):
+				return {b: prefetch[b] for b in batch_nos}
 	rows = frappe.db.get_all(
 		"Batch",
 		filters={"name": ("in", batch_nos)},
@@ -3017,6 +4120,11 @@ def _mwo_realized_by_artifact(mwo):
 	"""
 	if not mwo:
 		return None
+	# Served from the run-scoped prefetch when there is one: this used to be one query per
+	# MWO -- 8,602 of them on a backlog run -- for a set that is a single IN-list query.
+	prefetch = getattr(frappe.local, "eod_artifact_map", None)
+	if prefetch is not None:
+		return prefetch.get(mwo)
 	return frappe.db.get_value(
 		"Stock Entry",
 		{
@@ -3122,12 +4230,21 @@ def _validate_eod_items_for_mwo_reservation(items_to_transfer):
 	if not item_codes:
 		return
 
-	item_rows = frappe.db.get_all(
-		"Item",
-		filters={"name": ["in", item_codes]},
-		fields=["name", "has_batch_no", "has_serial_no"],
-	)
-	item_flags = {r.name: r for r in item_rows}
+	# Served from the run-scoped prefetch when every code is present; one query per MWO
+	# otherwise. A partial prefetch falls through rather than treating an absent code as a
+	# missing Item, which would throw.
+	prefetch = getattr(frappe.local, "eod_item_flags", None)
+	if prefetch is not None and all(c in prefetch for c in item_codes):
+		item_flags = {c: prefetch[c] for c in item_codes}
+	else:
+		item_flags = {
+			r.name: r
+			for r in frappe.db.get_all(
+				"Item",
+				filters={"name": ["in", item_codes]},
+				fields=["name", "has_batch_no", "has_serial_no"],
+			)
+		}
 
 	for item in items_to_transfer:
 		item_code = item.get("item_code")
@@ -3249,68 +4366,159 @@ def _coerce_select(row_dict, fieldname, fallback):
 	return fallback
 
 
-def _insert_sync_log_item(sync_log_name, row_dict):
-	"""Insert a child row in MOP EOD Sync Log Item. Returns the new row name.
+def _build_sync_log_item_row(sync_log_name, row_dict, name=None, idx=0):
+	"""One MOP EOD Sync Log Item as a plain column dict.
 
-	Diagnostics must never be able to fail a sync: every Select value is coerced to a
-	valid option first, and the insert itself runs in its own savepoint so a failure
-	rolls back only this row, never the caller's bucket.
+	Shared by the buffered bulk writer and the per-row fallback so the two can never
+	disagree about what a row contains. Select values are coerced here, before any write.
+	"""
+	stamp = now_datetime()
+	return {
+		"name": name or frappe.generate_hash(length=10),
+		"parent": sync_log_name,
+		"parentfield": "items",
+		"parenttype": "MOP EOD Sync Log",
+		"idx": cint(idx),
+		"owner": frappe.session.user or "Administrator",
+		"creation": stamp,
+		"modified": stamp,
+		"modified_by": frappe.session.user or "Administrator",
+		"docstatus": 0,
+		"manufacturing_work_order": row_dict.get("manufacturing_work_order") or "",
+		"manufacturing_operation": row_dict.get("manufacturing_operation") or "",
+		"company": row_dict.get("company") or "",
+		"item_code": row_dict.get("item_code") or "",
+		"batch_no": row_dict.get("batch_no") or "",
+		"serial_no": row_dict.get("serial_no") or "",
+		"source_warehouse": row_dict.get("source_warehouse") or "",
+		"target_warehouse": row_dict.get("target_warehouse") or "",
+		"qty": flt(row_dict.get("qty"), 3),
+		"pcs": flt(row_dict.get("pcs"), 3),
+		"status": _coerce_select(row_dict, "status", "Pending"),
+		"sync_stage": _coerce_select(row_dict, "sync_stage", ""),
+		"is_synced": cint(row_dict.get("is_synced")),
+		"stock_reservation_entry": row_dict.get("stock_reservation_entry") or "",
+		"stock_entry": row_dict.get("stock_entry") or "",
+		"draft_stock_entry": row_dict.get("draft_stock_entry") or "",
+		"mop_log": row_dict.get("mop_log") or "",
+		"error_type": _coerce_select(row_dict, "error_type", "Unknown Error"),
+		"error_message": (row_dict.get("error_message") or "")[:500],
+		"technical_traceback": row_dict.get("technical_traceback") or "",
+		"suggested_fix": row_dict.get("suggested_fix") or "",
+		"created_on": stamp,
+		"completed_on": row_dict.get("completed_on") or None,
+	}
+
+
+def _count_sync_log_row_failure(n=1):
+	"""Record diagnostics rows this run could not persist; surfaced in the Error Log."""
+	frappe.local.eod_sync_log_row_failures = getattr(
+		frappe.local, "eod_sync_log_row_failures", 0
+	) + cint(n)
+
+
+def _insert_sync_log_item(sync_log_name, row_dict):
+	"""Buffer a child row for MOP EOD Sync Log Item. Returns the row name it WILL have.
+
+	The name is generated here rather than by the database, so the caller gets a usable
+	``child_row_names`` entry with **no** round trip. A live run wrote 26,489 of these as
+	individual ``doc.insert()`` calls, each wrapped in its own savepoint pair; they are now
+	batched (see :func:`_flush_sync_log_items`).
+
+	Diagnostics must never be able to fail a sync -- callers are typically mid-savepoint, so
+	nothing may escape from here. Select values are still coerced to valid options first.
+
+	Rows are NOT in the database until flushed. Anything that reads or updates the child
+	table must call :func:`_flush_sync_log_items` first; ``recalculate_sync_log_totals`` and
+	``_bulk_set_child_rows`` both do.
 	"""
 	if not sync_log_name:
 		return None
 	try:
-		return _do_insert_sync_log_item(sync_log_name, dict(row_dict))
-	except Exception:
-		# A diagnostics row is never worth failing a sync for. The caller is typically
-		# mid-savepoint (see the Phase-2 healer), so anything escaping here would roll
-		# back real work. Roll back just this row and keep going; the swallowed count is
-		# reported in the consolidated Error Log.
-		_rollback_to_savepoint(_LOG_ROW_SAVEPOINT)
-		frappe.local.eod_sync_log_row_failures = (
-			getattr(frappe.local, "eod_sync_log_row_failures", 0) + 1
+		buffer = getattr(frappe.local, "eod_sync_log_buffer", None)
+		if buffer is None:
+			buffer = frappe.local.eod_sync_log_buffer = []
+		idx_by_parent = getattr(frappe.local, "eod_sync_log_idx", None)
+		if idx_by_parent is None:
+			idx_by_parent = frappe.local.eod_sync_log_idx = {}
+		idx_by_parent[sync_log_name] = idx_by_parent.get(sync_log_name, 0) + 1
+
+		row = _build_sync_log_item_row(
+			sync_log_name, dict(row_dict), idx=idx_by_parent[sync_log_name]
 		)
+		buffer.append(row)
+		if len(buffer) >= _LOG_ROW_FLUSH_SIZE:
+			_flush_sync_log_items()
+		return row["name"]
+	except Exception:
+		_count_sync_log_row_failure()
 		frappe.logger().exception(
-			"MOP EOD Sync: could not write sync log row for %s", sync_log_name
+			"MOP EOD Sync: could not buffer sync log row for %s", sync_log_name
 		)
 		return None
 
 
+def _flush_sync_log_items():
+	"""Write buffered MOP EOD Sync Log Item rows in one multi-row INSERT. Never raises.
+
+	Returns the number of rows attempted, so callers can tell whether anything needs
+	committing.
+
+	Wrapped in its own savepoint so a rejected value rolls back the flush alone and not the
+	caller's bucket. On failure the rows are retried ONE AT A TIME through
+	:func:`_do_insert_sync_log_item`, so a single bad row costs only itself rather than the
+	whole batch -- that per-row robustness is the contract this replaced and it is preserved.
+	"""
+	buffer = getattr(frappe.local, "eod_sync_log_buffer", None)
+	if not buffer:
+		return 0
+	rows, frappe.local.eod_sync_log_buffer = buffer, []
+
+	# Drop columns this site does not have, exactly as _writable_values does for the parent:
+	# one absent column would otherwise fail the whole INSERT with a 1054.
+	existing = _existing_columns("MOP EOD Sync Log Item")
+	columns = [c for c in _LOG_ROW_COLUMNS if not existing or c in existing]
+
+	try:
+		frappe.db.savepoint(_LOG_ROW_SAVEPOINT)
+		frappe.db.bulk_insert(
+			"MOP EOD Sync Log Item",
+			fields=columns,
+			values=[tuple(row.get(c) for c in columns) for row in rows],
+			chunk_size=_LOG_ROW_FLUSH_SIZE,
+		)
+		frappe.db.release_savepoint(_LOG_ROW_SAVEPOINT)
+		return len(rows)
+	except Exception:
+		_rollback_to_savepoint(_LOG_ROW_SAVEPOINT)
+		frappe.logger().exception(
+			"MOP EOD Sync: bulk insert of %s sync log row(s) failed; retrying per row",
+			len(rows),
+		)
+
+	for row in rows:
+		try:
+			_do_insert_sync_log_item(row["parent"], row)
+		except Exception:
+			_rollback_to_savepoint(_LOG_ROW_SAVEPOINT)
+			_count_sync_log_row_failure()
+			frappe.logger().exception(
+				"MOP EOD Sync: could not write sync log row for %s", row.get("parent")
+			)
+	return len(rows)
+
+
 def _do_insert_sync_log_item(sync_log_name, row_dict):
-	"""Build + insert the child row. Always call via :func:`_insert_sync_log_item`."""
-	status = _coerce_select(row_dict, "status", "Pending")
-	sync_stage = _coerce_select(row_dict, "sync_stage", "")
-	error_type = _coerce_select(row_dict, "error_type", "Unknown Error")
-	doc = frappe.get_doc(
-		{
-			"doctype": "MOP EOD Sync Log Item",
-			"parent": sync_log_name,
-			"parentfield": "items",
-			"parenttype": "MOP EOD Sync Log",
-			"manufacturing_work_order": row_dict.get("manufacturing_work_order") or "",
-			"manufacturing_operation": row_dict.get("manufacturing_operation") or "",
-			"company": row_dict.get("company") or "",
-			"item_code": row_dict.get("item_code") or "",
-			"batch_no": row_dict.get("batch_no") or "",
-			"serial_no": row_dict.get("serial_no") or "",
-			"source_warehouse": row_dict.get("source_warehouse") or "",
-			"target_warehouse": row_dict.get("target_warehouse") or "",
-			"qty": flt(row_dict.get("qty"), 3),
-			"pcs": flt(row_dict.get("pcs"), 3),
-			"status": status,
-			"sync_stage": sync_stage,
-			"is_synced": cint(row_dict.get("is_synced")),
-			"stock_reservation_entry": row_dict.get("stock_reservation_entry") or "",
-			"stock_entry": row_dict.get("stock_entry") or "",
-			"draft_stock_entry": row_dict.get("draft_stock_entry") or "",
-			"mop_log": row_dict.get("mop_log") or "",
-			"error_type": error_type,
-			"error_message": (row_dict.get("error_message") or "")[:500],
-			"technical_traceback": row_dict.get("technical_traceback") or "",
-			"suggested_fix": row_dict.get("suggested_fix") or "",
-			"created_on": now_datetime(),
-			"completed_on": row_dict.get("completed_on") or None,
-		}
+	"""Insert ONE child row through the document API -- the per-row fallback path.
+
+	Only reached when a bulk flush fails. ``row_dict`` may be either a caller's raw dict or
+	an already-built column dict; ``_build_sync_log_item_row`` is idempotent over both
+	because it reads by key and re-coerces Select values.
+	"""
+	row = _build_sync_log_item_row(
+		sync_log_name, row_dict, name=row_dict.get("name"), idx=row_dict.get("idx") or 0
 	)
+	doc = frappe.get_doc(dict(row, doctype="MOP EOD Sync Log Item"))
 	doc.flags.ignore_permissions = True
 	frappe.db.savepoint(_LOG_ROW_SAVEPOINT)
 	doc.insert(ignore_permissions=True, ignore_links=True, ignore_mandatory=True)
@@ -3343,9 +4551,13 @@ def recalculate_sync_log_totals(sync_log_name):
 	MWO counters are derived from the SAME query as the item counters, so the header can
 	never contradict its own child rows (runs used to report synced_mwos=19 alongside
 	synced_items=0 because the two were written by different code paths).
+
+	Buffered rows are flushed first: these totals are aggregated straight from the child
+	table, so counting before the buffer lands would under-report every family.
 	"""
 	if not sync_log_name:
 		return
+	_flush_sync_log_items()
 
 	rows = frappe.db.sql(
 		"""
@@ -3637,12 +4849,12 @@ def _check_eod_source_batch_stock(items_to_transfer):
 	every aggregated row whose required transfer qty exceeds physical batch balance
 	(SLE / serial-batch ledger; reservations do NOT create stock). An empty dict means
 	all batch rows have enough physical stock.
-	"""
-	from erpnext.stock.doctype.batch.batch import get_batch_qty
-	from frappe.utils import nowtime, today
 
-	posting_date = today()
-	posting_time = nowtime()
+	Reads through :func:`_eod_physical_batch_qty` so it shares the plan phase's
+	(item, warehouse) cache instead of re-querying keys the warehouse picker just read.
+	Note the ``needed`` aggregation below is scoped to ONE MWO's rows -- run-wide
+	over-subscription of a shared batch is caught by the allocator, not here.
+	"""
 	needed = {}
 	for item in items_to_transfer:
 		wh = item.get("s_warehouse")
@@ -3656,18 +4868,9 @@ def _check_eod_source_batch_stock(items_to_transfer):
 
 	short = {}
 	for (wh, item_code, batch_no), req_qty in needed.items():
-		try:
-			physical_raw = get_batch_qty(
-				batch_no=batch_no,
-				warehouse=wh,
-				item_code=item_code,
-				posting_date=posting_date,
-				posting_time=posting_time,
-				ignore_reserved_stock=True,
-			)
-		except Exception:
-			physical_raw = None
-		physical = flt(physical_raw, 3) if physical_raw is not None else 0.0
+		# Never None here: the gather loop above already skipped rows with no batch or
+		# no warehouse, which are the only cases that return None.
+		physical = flt(_eod_physical_batch_qty(item_code, batch_no, wh) or 0.0, 3)
 		if req_qty > physical + 1e-6:
 			short[(wh, item_code, batch_no)] = (req_qty, physical)
 	return short

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_eod_sync.py
@@ -4428,13 +4428,24 @@ def _insert_sync_log_item(sync_log_name, row_dict):
 	Diagnostics must never be able to fail a sync -- callers are typically mid-savepoint, so
 	nothing may escape from here. Select values are still coerced to valid options first.
 
-	Rows are NOT in the database until flushed. Anything that reads or updates the child
-	table must call :func:`_flush_sync_log_items` first; ``recalculate_sync_log_totals`` and
-	``_bulk_set_child_rows`` both do.
+	**Buffering applies only inside a sync run.** During a run there are guaranteed flush
+	points (end of plan phase, every ``_bulk_set_child_rows``, ``recalculate_sync_log_totals``,
+	and the ``finally`` block), so rows always land. Outside a run there is no such guarantee:
+	callers like the whitelisted ``backfill_missing_wip_reservations``, the recovery patch and
+	direct healer calls insert a row and reasonably expect to be able to read it back, and
+	nothing would ever flush it for them. Those write through immediately instead.
+
+	Inside a run, rows are NOT in the database until flushed, so anything that reads or
+	updates the child table must call :func:`_flush_sync_log_items` first.
 	"""
 	if not sync_log_name:
 		return None
 	try:
+		# Write-through when there is no run to flush the buffer. `in_eod_mop_sync` is set for
+		# exactly the span of sync_mop_logs, which is exactly the span with flush points.
+		if not getattr(frappe.flags, "in_eod_mop_sync", False):
+			return _do_insert_sync_log_item(sync_log_name, dict(row_dict))
+
 		buffer = getattr(frappe.local, "eod_sync_log_buffer", None)
 		if buffer is None:
 			buffer = frappe.local.eod_sync_log_buffer = []

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.js
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.js
@@ -6,6 +6,7 @@ frappe.ui.form.on("MOP Settings", {
 		_prefill_eod_sync_window(frm);
 		_setup_eod_status_indicator(frm);
 		_setup_eod_sync_button(frm);
+		_setup_drain_backlog_button(frm);
 		_apply_permission_restrictions(frm);
 		_setup_eod_sync_log_progress(frm);
 		_setup_open_sync_log_button(frm);
@@ -92,7 +93,7 @@ function _setup_eod_sync_button(frm) {
 				title: __("EOD Sync In Progress"),
 				message: __(
 					"EOD sync is in progress. You cannot proceed to make any transactions. " +
-						"Please contact your administrator or try again after 2 hours after the specified time."
+						"Please contact your administrator or try again after the lock window ends."
 				),
 				indicator: "orange",
 			});
@@ -115,18 +116,66 @@ function _setup_eod_sync_button(frm) {
 	});
 }
 
+function _setup_drain_backlog_button(frm) {
+	// The scheduled window is today-only, so MOP Logs written after a nightly run are never
+	// picked up by a later scheduled run. This drains the OLDEST of them deliberately,
+	// bounded, instead of someone hand-building a manual run over a huge date range.
+	if (!_is_system_manager()) return;
+
+	frm.add_custom_button(__("Drain Backlog"), function () {
+		if (_is_eod_locked(frm)) {
+			frappe.msgprint({
+				title: __("EOD Sync In Progress"),
+				message: __("Wait for the running EOD sync to finish before draining the backlog."),
+				indicator: "orange",
+			});
+			return;
+		}
+		const suggested = frm.doc.eod_catchup_max_mwos || 500;
+		frappe.prompt(
+			[
+				{
+					fieldname: "limit",
+					fieldtype: "Int",
+					label: __("Max Work Orders to drain"),
+					default: suggested,
+					reqd: 1,
+					description: __(
+						"Oldest unsynced Work Orders first. Larger values take longer and hold the transaction lock for longer — run off-hours."
+					),
+				},
+			],
+			function (values) {
+				frappe.call({
+					method: "drain_backlog",
+					doc: frm.doc,
+					args: { limit: values.limit },
+					callback: function () {
+						frm.reload_doc();
+					},
+				});
+			},
+			__("Drain EOD Backlog"),
+			__("Queue")
+		);
+	});
+}
+
 function _apply_permission_restrictions(frm) {
 	const is_sm = _is_system_manager();
 	const is_locked = _is_eod_locked(frm);
 
 	// Non-System Manager cannot change EOD Sync Time, the manual From/To window, or the filter table
 	if (!is_sm) {
-		["eod_sync_time", "eod_sync_from_datetime", "eod_sync_to_datetime", "eod_sync_work_order_filter"].forEach(
-			(field) => {
-				frm.set_df_property(field, "read_only", 1);
-				frm.refresh_field(field);
-			}
-		);
+		[
+			"eod_sync_time",
+			"eod_sync_from_datetime",
+			"eod_sync_to_datetime",
+			"eod_sync_work_order_filter",
+		].forEach((field) => {
+			frm.set_df_property(field, "read_only", 1);
+			frm.refresh_field(field);
+		});
 	}
 
 	// Disable the EOD Sync button for non-SM or when lock is active

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.json
@@ -28,6 +28,15 @@
   "casting_tree_section",
   "casting_tree_reissue_help",
   "enforce_full_casting_tree_reissue",
+  "eod_chunk_section",
+  "eod_chunk_help",
+  "eod_chunk_max_mwos",
+  "eod_chunk_max_rows",
+  "eod_soft_deadline_minutes",
+  "eod_catchup_section",
+  "eod_catchup_help",
+  "enable_eod_backlog_catchup",
+  "eod_catchup_max_mwos",
   "eod_allocation_section",
   "eod_allocation_help",
   "enable_eod_bucket_allocation",
@@ -178,21 +187,80 @@
    "label": "Enforce Full Casting Tree Re-Issue"
   },
   {
+   "fieldname": "eod_chunk_section",
+   "fieldtype": "Section Break",
+   "label": "EOD Stock Entry Chunking"
+  },
+  {
+   "fieldname": "eod_chunk_help",
+   "fieldtype": "HTML",
+   "options": "<div class='alert alert-info' style='font-size:13px;'><b>Why the EOD transfer is split</b><br>A single very large Material Transfer cannot be saved <i>and</i> submitted in a reasonable time: ERPNext creates one Stock Ledger Entry document per row and revalues inline as it goes, and each Stock Reservation Entry re-aggregates its whole item/warehouse into Bin. One real run produced a <b>26,489-row</b> draft worth ₹10.66 cr that never submitted before the lock expired.<br><br>The bucket is therefore split into chunks bounded by <b>both</b> caps below, whichever is reached first. Each chunk is its own Stock Entry and is committed on success, so earlier chunks survive a later failure — and a failed chunk is halved and retried down to a single Work Order, so one bad Work Order strands only itself.<br><br><b>A Manufacturing Work Order is never split across chunks.</b> A single Work Order larger than the row cap forms its own oversized chunk.<br><br>Set both caps to <b>0</b> to restore the old one-Stock-Entry-per-bucket behaviour. Reference points: ERPNext itself moves Stock Reconciliation to the background above 100 rows, and the largest EOD Stock Entry this system has ever submitted successfully had 152 rows.</div>"
+  },
+  {
+   "default": "50",
+   "description": "Maximum Manufacturing Work Orders per EOD Stock Entry. 0 = no limit on this axis.",
+   "fieldname": "eod_chunk_max_mwos",
+   "fieldtype": "Int",
+   "label": "Max Work Orders per Stock Entry",
+   "non_negative": 1
+  },
+  {
+   "default": "150",
+   "description": "Maximum item rows per EOD Stock Entry. 0 = no limit on this axis. A single Work Order is never split, so a Work Order with more rows than this still forms one chunk.",
+   "fieldname": "eod_chunk_max_rows",
+   "fieldtype": "Int",
+   "label": "Max Rows per Stock Entry",
+   "non_negative": 1
+  },
+  {
+   "default": "200",
+   "description": "Stop starting new work this many minutes into a run, then finish cleanly and release the lock. Must stay inside the 4-hour lock window so the graceful stop beats the hard job timeout. 0 disables the deadline (not recommended — a run that overruns is then killed hard and leaves the lock to the hourly reaper).",
+   "fieldname": "eod_soft_deadline_minutes",
+   "fieldtype": "Int",
+   "label": "Soft Deadline (minutes)",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "eod_catchup_section",
+   "fieldtype": "Section Break",
+   "label": "EOD Backlog Catch-up"
+  },
+  {
+   "fieldname": "eod_catchup_help",
+   "fieldtype": "HTML",
+   "options": "<div class='alert alert-info' style='font-size:13px;'><b>Why a separate catch-up pass exists</b><br>The scheduled run scans <b>today only</b> and fires once a day. A MOP Log created <i>after</i> tonight's run therefore sits in a window no later scheduled run will ever scan again — it only ever showed up in the read-only <i>old unsynced MOP Log count</i>. That is how a backlog of roughly <b>647,000 rows across ~12,939 Work Orders</b> built up, and why clearing it needed a hand-built manual run over a huge date range.<br><br>The today-only window is unchanged. After the main pass finishes cleanly, this drains the <b>oldest</b> pre-window Work Orders, up to the cap below, through exactly the same plan → allocate → chunk → commit pipeline.<br><br>It is skipped when the main pass reported blocking failures or the soft deadline has passed — a run already in trouble does not take on more work.<br><br>Watch <b>Old Unsynced MOP Log Count</b> run over run: it is the honest progress signal. If it is not falling, raise the cap or give the drain its own off-hours window.</div>"
+  },
+  {
+   "default": "1",
+   "description": "After the main pass, drain the oldest pre-window unsynced MOP Logs (bounded by the cap below).",
+   "fieldname": "enable_eod_backlog_catchup",
+   "fieldtype": "Check",
+   "label": "Enable Backlog Catch-up"
+  },
+  {
+   "default": "500",
+   "description": "Maximum Manufacturing Work Orders drained from the backlog per run, oldest first. 0 disables the catch-up pass.",
+   "fieldname": "eod_catchup_max_mwos",
+   "fieldtype": "Int",
+   "label": "Max Backlog Work Orders per Run",
+   "non_negative": 1
+  },
+  {
    "fieldname": "eod_allocation_section",
    "fieldtype": "Section Break",
-   "label": "EOD Bucket Stock Allocation"
+   "label": "EOD Stock Allocation"
   },
   {
    "fieldname": "eod_allocation_help",
    "fieldtype": "HTML",
-   "options": "<div class='alert alert-info' style='font-size:13px;'><b>How Bucket Stock Allocation works</b><br>The EOD sync puts every resolvable Manufacturing Work Order of a company/manufacturer into <b>one</b> Material Transfer. Stock is validated per MWO, but the Stock Entry consumes the <b>sum</b> across MWOs, so two MWOs that each fit can jointly overdraw a batch and fail the whole transfer.<br><br>When enabled, MWOs are admitted against a running tally of physical batch stock and warehouse headroom, oldest unsynced MOP Log first. An MWO that does not fit is <b>deferred</b> to the next run (reported as <i>Deferred - Bucket Stock Contention</i>) instead of failing the bucket. An MWO that cannot fit even on its own is reported as <i>Permanently Short</i> — that is a data defect needing reconciliation.<br><br>Leave OFF to keep the previous all-or-nothing behaviour.</div>"
+   "options": "<div class='alert alert-info' style='font-size:13px;'><b>How EOD Stock Allocation works</b><br>Stock is validated per Manufacturing Work Order, but each EOD Stock Entry consumes the <b>sum</b> across the MWOs it carries — so two MWOs that each fit can jointly overdraw a batch and fail the transfer.<br><br>When enabled, MWOs are admitted against a <b>run-wide</b> running tally of physical batch stock and warehouse headroom, oldest unsynced MOP Log first. An MWO that does not fit is <b>deferred</b> to the next run (reported as <i>Deferred - Bucket Stock Contention</i>). An MWO that cannot fit even on its own is reported as <i>Permanently Short</i> — a data defect needing reconciliation.<br><br><b>Keep this ON.</b> With chunked Stock Entries an over-subscribed chunk strands only itself, so contention fails quietly instead of loudly; this tally is what prevents it. Turn OFF only to reproduce the old all-or-nothing behaviour.</div>"
   },
   {
-   "default": "0",
-   "description": "Admit MWOs into the consolidated EOD transfer against a running stock tally; defer the ones that do not fit instead of failing the whole bucket.",
+   "default": "1",
+   "description": "Admit MWOs into the EOD transfer against a run-wide running stock tally; defer the ones that do not fit instead of failing the chunk. Load-bearing once chunking is on — turn OFF only to reproduce the old all-or-nothing behaviour.",
    "fieldname": "enable_eod_bucket_allocation",
    "fieldtype": "Check",
-   "label": "Enable EOD Bucket Stock Allocation"
+   "label": "Enable EOD Stock Allocation"
   },
   {
    "fieldname": "eod_plan_heal_section",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/mop_settings.py
@@ -9,6 +9,8 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, get_datetime, nowdate
 
+from .eod_lock import _LOCK_MSG, _LOCK_SECONDS
+
 # Employee IR injection submits Material Transfer (WORK ORDER) and/or Repack Stock Entries.
 # Both must appear in Stock Entry Type To Reservation or ``stock_reservation_entry_for_mwo``
 # skips that voucher type.
@@ -102,13 +104,9 @@ class MOPSettings(Document):
 			frappe.throw(_("Only System Manager can manually start EOD Sync."))
 
 		if is_eod_sync_locked():
-			frappe.throw(
-				_(
-					"EOD sync is in progress. You cannot proceed to make any transactions. "
-					"Please contact your administrator or try again after 2 hours after the specified time."
-				),
-				title=_("EOD Sync In Progress"),
-			)
+			# Same wording as the doc-event guard, derived from eod_lock._LOCK_HOURS -- this
+			# copy said "2 hours" long after the window changed.
+			frappe.throw(_(_LOCK_MSG), title=_("EOD Sync In Progress"))
 
 		# Resolve the From/To window for this manual run. Blank fields fall back to
 		# today's start/end; the scheduler never sets these, so only manual runs can
@@ -141,7 +139,7 @@ class MOPSettings(Document):
 		frappe.enqueue(
 			"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.sync_mop_logs",
 			queue="long",
-			timeout=7200,
+			timeout=_LOCK_SECONDS,
 			enqueue_after_commit=True,
 			job_id="eod_sync",
 			deduplicate=True,
@@ -154,5 +152,64 @@ class MOPSettings(Document):
 				"EOD MOP Log Sync has been queued. Open {0} to track progress. "
 				"Transactions will be blocked while the sync is running."
 			).format(frappe.utils.get_link_to_form("MOP EOD Sync Log", sync_log_name)),
+			alert=True,
+		)
+
+	@frappe.whitelist()
+	def drain_backlog(self, limit=None):
+		"""Run a sync whose point is the BACKLOG, with a larger catch-up cap.
+
+		Same pipeline as the nightly run — today's window first, then the catch-up pass —
+		but with the per-run catch-up cap raised for this run only, so a long-standing
+		backlog can be drained deliberately off-hours instead of by hand-building a manual
+		run over a huge date range (which is what produced the 26,489-row Stock Entry).
+
+		Shares ``job_id="eod_sync"`` with every other trigger: there is exactly one sync, and
+		``deduplicate=True`` means pressing this while a run is queued is a no-op.
+		"""
+		from .eod_lock import is_eod_sync_locked, set_eod_sync_queued
+
+		if "System Manager" not in frappe.get_roles():
+			frappe.throw(_("Only System Manager can drain the EOD backlog."))
+
+		if is_eod_sync_locked():
+			frappe.throw(_(_LOCK_MSG), title=_("EOD Sync In Progress"))
+
+		catchup_limit = cint(limit) or cint(self.eod_catchup_max_mwos) or 500
+
+		sync_log = frappe.new_doc("MOP EOD Sync Log")
+		sync_log.status = "Queued"
+		sync_log.trigger_type = "Manual"
+		sync_log.started_by = frappe.session.user
+		sync_log.posting_date = nowdate()
+		sync_log.eod_sync_time = self.eod_sync_time
+		sync_log.mop_settings = "MOP Settings"
+		sync_log.flags.ignore_permissions = True
+		sync_log.insert()
+
+		frappe.db.set_value(
+			"MOP Settings", "MOP Settings", "eod_sync_last_sync_log", sync_log.name
+		)
+
+		set_eod_sync_queued(sync_log_name=sync_log.name)
+		frappe.enqueue(
+			"jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.sync_mop_logs",
+			queue="long",
+			timeout=_LOCK_SECONDS,
+			enqueue_after_commit=True,
+			job_id="eod_sync",
+			deduplicate=True,
+			sync_log_name=sync_log.name,
+			catchup_limit=catchup_limit,
+		)
+		frappe.msgprint(
+			_(
+				"Backlog drain queued for up to {0} Work Order(s). Open {1} to track "
+				"progress. Watch Old Unsynced MOP Log Count fall run over run — if it does "
+				"not, raise the cap. Transactions are blocked while the sync runs."
+			).format(
+				catchup_limit,
+				frappe.utils.get_link_to_form("MOP EOD Sync Log", sync_log.name),
+			),
 			alert=True,
 		)

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/scheduler.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/scheduler.py
@@ -11,7 +11,7 @@ from datetime import datetime, time, timedelta
 import frappe
 from frappe.utils import cint, get_datetime, get_time, getdate, now_datetime, nowdate
 
-from .eod_lock import release_expired_eod_sync_lock, set_eod_sync_queued
+from .eod_lock import _LOCK_SECONDS, release_expired_eod_sync_lock, set_eod_sync_queued
 
 _SYNC_FUNC = "jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync.sync_mop_logs"
 
@@ -137,7 +137,7 @@ def check_and_enqueue_eod_sync():
 	frappe.enqueue(
 		_SYNC_FUNC,
 		queue="long",
-		timeout=7200,
+		timeout=_LOCK_SECONDS,
 		enqueue_after_commit=True,
 		job_id="eod_sync",
 		deduplicate=True,

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_settings.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_settings.py
@@ -1492,6 +1492,9 @@ class TestSyncMopLogsEntryPoint(IntegrationTestCase):
 				"issues_rows": [],
 			}
 
+		# **kwargs so a new keyword on _commit_company_main_se (already_allocated, and
+		# whatever comes next) cannot silently turn this into a TypeError swallowed by
+		# sync_mop_logs' top-level handler -- which is exactly what it did.
 		def _commit(
 			company,
 			manufacturer,
@@ -1499,7 +1502,7 @@ class TestSyncMopLogsEntryPoint(IntegrationTestCase):
 			failures,
 			stats,
 			sync_log_name=None,
-			selective=False,
+			**kwargs,
 		):
 			stats["submitted_ses"].append("SE-A")
 			stats["processed_mwos"] += len(main_mwos)
@@ -4158,88 +4161,6 @@ class TestSyncLogItemNeverAborts(IntegrationTestCase):
 				_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
 			)
 
-	def test_flush_failure_does_not_propagate_and_falls_back_per_row(self):
-		"""A bulk INSERT failure must cost only the bad row, not the whole batch -- that
-		per-row robustness is the contract buffering replaced."""
-		frappe.local.eod_sync_log_buffer = []
-		frappe.local.eod_sync_log_idx = {}
-		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
-		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-2", "qty": 2.0})
-
-		with patch(
-			f"{_MOD}.frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom")
-		), patch(f"{_MOD}._do_insert_sync_log_item") as per_row:
-			written = _flush_sync_log_items()
-
-		self.assertEqual(written, 2)
-		self.assertEqual(per_row.call_count, 2, "both rows retried individually")
-
-	def test_flush_counts_rows_it_could_not_write_at_all(self):
-		"""Silently losing diagnostics is the one thing worse than losing them loudly."""
-		frappe.local.eod_sync_log_buffer = []
-		frappe.local.eod_sync_log_idx = {}
-		frappe.local.eod_sync_log_row_failures = 0
-		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
-
-		with patch(
-			f"{_MOD}.frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom")
-		), patch(
-			f"{_MOD}._do_insert_sync_log_item", side_effect=RuntimeError("row boom")
-		):
-			_flush_sync_log_items()
-
-		self.assertEqual(frappe.local.eod_sync_log_row_failures, 1)
-
-	def test_buffered_row_name_is_returned_without_touching_the_database(self):
-		"""child_row_names must be usable with zero round trips -- that is the point."""
-		frappe.local.eod_sync_log_buffer = []
-		frappe.local.eod_sync_log_idx = {}
-		with patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
-			f"{_MOD}.frappe.get_doc"
-		) as get_doc:
-			name = _insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
-		self.assertTrue(name)
-		self.assertFalse(bulk.called, "must not flush before the batch is full")
-		self.assertFalse(get_doc.called, "must not build a Document per row")
-
-	def test_rows_are_flushed_once_the_batch_fills(self):
-		frappe.local.eod_sync_log_buffer = []
-		frappe.local.eod_sync_log_idx = {}
-		with patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
-			f"{_MOD}.frappe.db.savepoint"
-		), patch(f"{_MOD}.frappe.db.release_savepoint"):
-			for i in range(_LOG_ROW_FLUSH_SIZE):
-				_insert_sync_log_item("SYNC-LOG-X", {"item_code": f"M-{i}", "qty": 1.0})
-		self.assertEqual(bulk.call_count, 1)
-		self.assertEqual(frappe.local.eod_sync_log_buffer, [])
-
-	def test_buffered_rows_get_sequential_idx_per_parent(self):
-		"""The Sync Log child grid is read by humans; idx 0 everywhere is not acceptable."""
-		frappe.local.eod_sync_log_buffer = []
-		frappe.local.eod_sync_log_idx = {}
-		_insert_sync_log_item("SYNC-LOG-A", {"item_code": "M-1"})
-		_insert_sync_log_item("SYNC-LOG-A", {"item_code": "M-2"})
-		_insert_sync_log_item("SYNC-LOG-B", {"item_code": "M-3"})
-		rows = frappe.local.eod_sync_log_buffer
-		self.assertEqual([r["idx"] for r in rows], [1, 2, 1])
-		self.assertEqual(
-			[r["parent"] for r in rows], ["SYNC-LOG-A", "SYNC-LOG-A", "SYNC-LOG-B"]
-		)
-
-	def test_absent_columns_are_dropped_from_the_bulk_insert(self):
-		"""An unmigrated site must degrade the report, not fail the INSERT with a 1054."""
-		frappe.local.eod_sync_log_buffer = []
-		frappe.local.eod_sync_log_idx = {}
-		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
-		with patch(
-			f"{_MOD}.frappe.db.get_table_columns",
-			return_value=["name", "parent", "qty"],
-		), patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
-			f"{_MOD}.frappe.db.savepoint"
-		), patch(f"{_MOD}.frappe.db.release_savepoint"):
-			_flush_sync_log_items()
-		self.assertEqual(bulk.call_args.kwargs["fields"], ["name", "parent", "qty"])
-
 	def test_healer_audit_row_inserts_with_a_sync_log_name(self):
 		"""The exact production path. Every other test calls the healer WITHOUT a
 		sync_log_name, so mop_eod_sync.py's audit-row block was unreachable in the whole
@@ -6251,3 +6172,111 @@ class TestEodPrefetch(IntegrationTestCase):
 		self.assertIsNone(frappe.local.eod_artifact_map)
 		self.assertIsNone(frappe.local.eod_item_flags)
 		self.assertIsNone(frappe.local.eod_batch_ownership)
+
+
+class TestSyncLogItemBuffering(IntegrationTestCase):
+	"""In-run buffering of MOP EOD Sync Log Item rows.
+
+	``_insert_sync_log_item`` only batches while ``frappe.flags.in_eod_mop_sync`` is set,
+	because that is exactly the span with guaranteed flush points. Outside a run it writes
+	through, so callers such as ``backfill_missing_wip_reservations`` and the recovery patch
+	can still read a row straight back. These tests therefore declare the in-run context;
+	without it they would be exercising the write-through path instead.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def setUp(self):
+		frappe.flags.in_eod_mop_sync = True
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		frappe.local.eod_sync_log_row_failures = 0
+
+	def tearDown(self):
+		frappe.flags.in_eod_mop_sync = False
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+
+	def test_flush_failure_does_not_propagate_and_falls_back_per_row(self):
+		"""A bulk INSERT failure must cost only the bad row, not the whole batch -- that
+		per-row robustness is the contract buffering replaced."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-2", "qty": 2.0})
+
+		with patch(
+			f"{_MOD}.frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom")
+		), patch(f"{_MOD}._do_insert_sync_log_item") as per_row:
+			written = _flush_sync_log_items()
+
+		self.assertEqual(written, 2)
+		self.assertEqual(per_row.call_count, 2, "both rows retried individually")
+
+	def test_flush_counts_rows_it_could_not_write_at_all(self):
+		"""Silently losing diagnostics is the one thing worse than losing them loudly."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		frappe.local.eod_sync_log_row_failures = 0
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+
+		with patch(
+			f"{_MOD}.frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom")
+		), patch(
+			f"{_MOD}._do_insert_sync_log_item", side_effect=RuntimeError("row boom")
+		):
+			_flush_sync_log_items()
+
+		self.assertEqual(frappe.local.eod_sync_log_row_failures, 1)
+
+	def test_buffered_row_name_is_returned_without_touching_the_database(self):
+		"""child_row_names must be usable with zero round trips -- that is the point."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		with patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
+			f"{_MOD}.frappe.get_doc"
+		) as get_doc:
+			name = _insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+		self.assertTrue(name)
+		self.assertFalse(bulk.called, "must not flush before the batch is full")
+		self.assertFalse(get_doc.called, "must not build a Document per row")
+
+	def test_rows_are_flushed_once_the_batch_fills(self):
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		with patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
+			f"{_MOD}.frappe.db.savepoint"
+		), patch(f"{_MOD}.frappe.db.release_savepoint"):
+			for i in range(_LOG_ROW_FLUSH_SIZE):
+				_insert_sync_log_item("SYNC-LOG-X", {"item_code": f"M-{i}", "qty": 1.0})
+		self.assertEqual(bulk.call_count, 1)
+		self.assertEqual(frappe.local.eod_sync_log_buffer, [])
+
+	def test_buffered_rows_get_sequential_idx_per_parent(self):
+		"""The Sync Log child grid is read by humans; idx 0 everywhere is not acceptable."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		_insert_sync_log_item("SYNC-LOG-A", {"item_code": "M-1"})
+		_insert_sync_log_item("SYNC-LOG-A", {"item_code": "M-2"})
+		_insert_sync_log_item("SYNC-LOG-B", {"item_code": "M-3"})
+		rows = frappe.local.eod_sync_log_buffer
+		self.assertEqual([r["idx"] for r in rows], [1, 2, 1])
+		self.assertEqual(
+			[r["parent"] for r in rows], ["SYNC-LOG-A", "SYNC-LOG-A", "SYNC-LOG-B"]
+		)
+
+	def test_absent_columns_are_dropped_from_the_bulk_insert(self):
+		"""An unmigrated site must degrade the report, not fail the INSERT with a 1054."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+		with patch(
+			f"{_MOD}.frappe.db.get_table_columns",
+			return_value=["name", "parent", "qty"],
+		), patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
+			f"{_MOD}.frappe.db.savepoint"
+		), patch(f"{_MOD}.frappe.db.release_savepoint"):
+			_flush_sync_log_items()
+		self.assertEqual(bulk.call_args.kwargs["fields"], ["name", "parent", "qty"])

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_settings.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_settings/test_mop_settings.py
@@ -20,17 +20,31 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.eod_lock import (
 	validate_not_eod_sync_locked,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync import (
+	_LOG_ROW_FLUSH_SIZE,
 	_allocate_bucket_by_physical_stock,
 	_apply_mwo_filter_rows,
 	_build_eod_se_rows,
 	_cancel_sre_snapshots,
 	_check_eod_source_batch_stock,
+	_chunk_main_mwos,
 	_collect_mop_names,
 	_commit_company_issues_se,
 	_commit_company_main_se,
+	_commit_se_chunk,
 	_eod_base_mr_voucher_qty,
+	_eod_batch_ownership,
+	_eod_batch_qty_cache,
+	_eod_batch_qty_cache_start,
+	_eod_batch_qty_cache_stop,
+	_eod_batch_qty_map,
+	_eod_deadline_passed,
+	_eod_deadline_start,
 	_eod_feature_enabled,
+	_eod_physical_batch_qty,
+	_eod_prefetch_start,
+	_eod_prefetch_stop,
 	_find_last_operation,
+	_flush_sync_log_items,
 	_format_batch_short_diagnostics,
 	_get_last_logs_per_item_batch,
 	_get_sync_range,
@@ -40,6 +54,7 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync impor
 	_heal_missing_sre_in_plan,
 	_heal_ownership_allowed,
 	_insert_sync_log_item,
+	_is_recoverable_error,
 	_mark_all_mwo_mop_logs_synced,
 	_mop_manufacturer_label,
 	_mwo_realized_by_artifact,
@@ -52,6 +67,7 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_settings.mop_eod_sync impor
 	_resolve_department_warehouse,
 	_resolve_eod_manufacturer_label,
 	_resolve_run_range,
+	_run_backlog_catchup,
 	_save_draft_eod_se,
 	_snapshot_mwo_sres_for_relocation,
 	_stamp_last_eod_sync,
@@ -4132,11 +4148,97 @@ class TestSyncLogItemNeverAborts(IntegrationTestCase):
 		self.assertIn("Also Invalid", saved.error_message)
 
 	def test_insert_failure_returns_none_and_does_not_propagate(self):
-		"""Even a hard DB failure must not escape -- the caller is mid-savepoint."""
-		with patch(f"{_MOD}.frappe.get_doc", side_effect=RuntimeError("boom")):
+		"""Even a hard failure must not escape -- the caller is mid-savepoint.
+
+		Rows are buffered now, so the failure that used to happen at insert time happens
+		either while building the row (here) or at flush; both must be swallowed.
+		"""
+		with patch(f"{_MOD}.frappe.generate_hash", side_effect=RuntimeError("boom")):
 			self.assertIsNone(
 				_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
 			)
+
+	def test_flush_failure_does_not_propagate_and_falls_back_per_row(self):
+		"""A bulk INSERT failure must cost only the bad row, not the whole batch -- that
+		per-row robustness is the contract buffering replaced."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-2", "qty": 2.0})
+
+		with patch(
+			f"{_MOD}.frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom")
+		), patch(f"{_MOD}._do_insert_sync_log_item") as per_row:
+			written = _flush_sync_log_items()
+
+		self.assertEqual(written, 2)
+		self.assertEqual(per_row.call_count, 2, "both rows retried individually")
+
+	def test_flush_counts_rows_it_could_not_write_at_all(self):
+		"""Silently losing diagnostics is the one thing worse than losing them loudly."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		frappe.local.eod_sync_log_row_failures = 0
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+
+		with patch(
+			f"{_MOD}.frappe.db.bulk_insert", side_effect=RuntimeError("bulk boom")
+		), patch(
+			f"{_MOD}._do_insert_sync_log_item", side_effect=RuntimeError("row boom")
+		):
+			_flush_sync_log_items()
+
+		self.assertEqual(frappe.local.eod_sync_log_row_failures, 1)
+
+	def test_buffered_row_name_is_returned_without_touching_the_database(self):
+		"""child_row_names must be usable with zero round trips -- that is the point."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		with patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
+			f"{_MOD}.frappe.get_doc"
+		) as get_doc:
+			name = _insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+		self.assertTrue(name)
+		self.assertFalse(bulk.called, "must not flush before the batch is full")
+		self.assertFalse(get_doc.called, "must not build a Document per row")
+
+	def test_rows_are_flushed_once_the_batch_fills(self):
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		with patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
+			f"{_MOD}.frappe.db.savepoint"
+		), patch(f"{_MOD}.frappe.db.release_savepoint"):
+			for i in range(_LOG_ROW_FLUSH_SIZE):
+				_insert_sync_log_item("SYNC-LOG-X", {"item_code": f"M-{i}", "qty": 1.0})
+		self.assertEqual(bulk.call_count, 1)
+		self.assertEqual(frappe.local.eod_sync_log_buffer, [])
+
+	def test_buffered_rows_get_sequential_idx_per_parent(self):
+		"""The Sync Log child grid is read by humans; idx 0 everywhere is not acceptable."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		_insert_sync_log_item("SYNC-LOG-A", {"item_code": "M-1"})
+		_insert_sync_log_item("SYNC-LOG-A", {"item_code": "M-2"})
+		_insert_sync_log_item("SYNC-LOG-B", {"item_code": "M-3"})
+		rows = frappe.local.eod_sync_log_buffer
+		self.assertEqual([r["idx"] for r in rows], [1, 2, 1])
+		self.assertEqual(
+			[r["parent"] for r in rows], ["SYNC-LOG-A", "SYNC-LOG-A", "SYNC-LOG-B"]
+		)
+
+	def test_absent_columns_are_dropped_from_the_bulk_insert(self):
+		"""An unmigrated site must degrade the report, not fail the INSERT with a 1054."""
+		frappe.local.eod_sync_log_buffer = []
+		frappe.local.eod_sync_log_idx = {}
+		_insert_sync_log_item("SYNC-LOG-X", {"item_code": "M-1", "qty": 1.0})
+		with patch(
+			f"{_MOD}.frappe.db.get_table_columns",
+			return_value=["name", "parent", "qty"],
+		), patch(f"{_MOD}.frappe.db.bulk_insert") as bulk, patch(
+			f"{_MOD}.frappe.db.savepoint"
+		), patch(f"{_MOD}.frappe.db.release_savepoint"):
+			_flush_sync_log_items()
+		self.assertEqual(bulk.call_args.kwargs["fields"], ["name", "parent", "qty"])
 
 	def test_healer_audit_row_inserts_with_a_sync_log_name(self):
 		"""The exact production path. Every other test calls the healer WITHOUT a
@@ -4228,9 +4330,12 @@ class TestFinalStatusTernary(IntegrationTestCase):
 			else:
 				stats["processed_mwos"] += len(main_mwos)
 
-		def _reconcile(mwo, dry_run=True):
-			if advisory_only:
+		def _get_all(doctype, *a, **kw):
+			# Break the audit's OWN first query, so the real advisory error handler runs
+			# rather than a stub standing in for it.
+			if advisory_only and doctype == "Stock Reservation Entry":
 				raise RuntimeError("audit blew up")
+			return []
 
 		with patch(f"{_MOD}.release_eod_sync_lock"), patch(
 			f"{_MOD}.set_eod_sync_running"
@@ -4238,11 +4343,9 @@ class TestFinalStatusTernary(IntegrationTestCase):
 			f"{_MOD}.frappe.db.commit"
 		), patch(f"{_MOD}.recalculate_sync_log_totals"), patch(
 			f"{_MOD}.frappe.log_error", side_effect=_log_error
-		), patch(
-			f"{_MOD}._reconcile_reservations_for_mwo", side_effect=_reconcile
-		), patch(f"{_MOD}._commit_company_main_se", side_effect=_commit), patch(
-			f"{_MOD}._plan_mwo_group", side_effect=_plan
-		), patch(
+		), patch(f"{_MOD}.frappe.db.get_all", side_effect=_get_all), patch(
+			f"{_MOD}._commit_company_main_se", side_effect=_commit
+		), patch(f"{_MOD}._plan_mwo_group", side_effect=_plan), patch(
 			f"{_MOD}._get_unsynced_mop_groups",
 			return_value={
 				("Co", "MWO-A"): [
@@ -5076,3 +5179,1075 @@ class TestUnprovisionedColumnGuards(IntegrationTestCase):
 		), patch(f"{_MOD}.frappe.db.sql", return_value=[]):
 			recalculate_sync_log_totals("SYNC-LOG-1")
 		self.assertIn("draft_items", captured)
+
+
+class TestEodBatchQtyCache(IntegrationTestCase):
+	"""The plan-phase (item, warehouse) physical-batch-qty cache.
+
+	This cache decides which warehouse EOD sources metal from and whether a batch reads as
+	short, so the tests below pin the properties that make it safe to substitute for a
+	per-key ``get_batch_qty`` call -- not merely that it is faster.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def tearDown(self):
+		# A leaked cache would serve stale stock to every later test in the process.
+		_eod_batch_qty_cache_stop()
+
+	# --- lifecycle -------------------------------------------------------------
+
+	def test_cache_is_off_until_started(self):
+		_eod_batch_qty_cache_stop()
+		self.assertIsNone(_eod_batch_qty_cache())
+
+	def test_start_then_stop_clears_the_cache(self):
+		_eod_batch_qty_cache_start()
+		self.assertEqual(_eod_batch_qty_cache(), {})
+		_eod_batch_qty_cache_stop()
+		self.assertIsNone(_eod_batch_qty_cache())
+
+	def test_clock_is_frozen_while_the_cache_is_on(self):
+		"""Uncached, every call re-evaluated today()/nowtime() and drifted mid-plan."""
+		_eod_batch_qty_cache_start()
+		first = frappe.local.eod_batch_qty_clock
+		self.assertIsNotNone(first)
+		self.assertEqual(first, frappe.local.eod_batch_qty_clock)
+
+	# --- the map builder -------------------------------------------------------
+
+	def test_map_sums_by_batch_ignoring_the_row_warehouse(self):
+		"""get_batch_qty sums by batch_no ALONE. get_available_batches filters on
+		SLE.warehouse but groups by Serial-and-Batch-Entry.warehouse, so keying on the row
+		warehouse would split totals the scalar path nets together."""
+		rows = [
+			FD({"batch_no": "B1", "warehouse": "WH-A", "qty": 4.0}),
+			FD({"batch_no": "B1", "warehouse": None, "qty": 2.5}),
+			FD({"batch_no": "B2", "warehouse": "WH-A", "qty": 1.0}),
+		]
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			return_value=rows,
+		):
+			out = _eod_batch_qty_map("ITEM-1", "WH-A")
+		self.assertEqual(out, {"B1": 6.5, "B2": 1.0})
+
+	def test_map_drops_rows_with_no_batch_no(self):
+		"""Reserved/POS overlays append dicts carrying only {qty, warehouse}. Upstream
+		buckets them under batchwise_qty[None] where no real lookup sees them; keeping them
+		would invent a phantom batch key."""
+		rows = [
+			FD({"batch_no": "B1", "warehouse": "WH-A", "qty": 3.0}),
+			FD({"qty": -9.0, "warehouse": "WH-A"}),
+			FD({"batch_no": None, "warehouse": "WH-A", "qty": -1.0}),
+		]
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			return_value=rows,
+		):
+			out = _eod_batch_qty_map("ITEM-1", "WH-A")
+		self.assertEqual(out, {"B1": 3.0})
+		self.assertNotIn(None, out)
+
+	def test_map_passes_scalar_item_and_warehouse_and_a_null_batch(self):
+		"""All three are load-bearing:
+
+		* POS reservation overlay filters ``item_code ==`` with no list branch, so a list
+		  yields invalid SQL and a None silently drops every POS deduction.
+		* the bundle-less POS branch compares ``row.batch_no != kwargs.batch_no``; a list
+		  never equals a string, so a list drops legacy rows and OVER-states availability.
+		"""
+		captured = {}
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=lambda kw: captured.update(kw) or [],
+		):
+			_eod_batch_qty_map("ITEM-1", "WH-A")
+		self.assertEqual(captured["item_code"], "ITEM-1")
+		self.assertEqual(captured["warehouse"], "WH-A")
+		self.assertIsNone(captured["batch_no"])
+
+	def test_map_never_sends_a_qty(self):
+		"""With a qty, get_auto_batch_nos returns a FIFO PICK LIST -- truncated, with a
+		partial boundary row -- instead of a balance. That would silently corrupt every
+		sourcing decision."""
+		captured = {}
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=lambda kw: captured.update(kw) or [],
+		):
+			_eod_batch_qty_map("ITEM-1", "WH-A")
+		self.assertFalse(captured.get("qty"))
+
+	def test_map_keeps_the_callers_reading_flags(self):
+		"""for_stock_levels / consider_negative_batches must stay False: the pure
+		physical-balance flag set returns DIFFERENT numbers (expired batches included,
+		POS not deducted, negatives unclamped)."""
+		captured = {}
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=lambda kw: captured.update(kw) or [],
+		):
+			_eod_batch_qty_map("ITEM-1", "WH-A")
+		self.assertFalse(captured["for_stock_levels"])
+		self.assertFalse(captured["consider_negative_batches"])
+		self.assertTrue(captured["ignore_reserved_stock"])
+
+	def test_map_skips_the_future_batch_recursion(self):
+		"""filter_zero_near_batches re-runs the ENTIRE query cascade, and is a provable
+		no-op while consider_negative_batches is falsy. Skipping it halves the queries."""
+		captured = {}
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=lambda kw: captured.update(kw) or [],
+		):
+			_eod_batch_qty_map("ITEM-1", "WH-A")
+		self.assertTrue(captured["do_not_check_future_batches"])
+
+	def test_map_builds_a_fresh_kwargs_dict_per_call(self):
+		"""filter_zero_near_batches MUTATES the kwargs it is handed (rewrites batch_no,
+		deletes posting_datetime). A shared dict would leave the next call time-unbounded
+		and scoped to the previous call's batch list."""
+		seen = []
+
+		def _mutate(kw):
+			seen.append(id(kw))
+			kw["batch_no"] = ["LEAKED"]
+			kw.pop("posting_datetime", None)
+			return []
+
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=_mutate,
+		):
+			_eod_batch_qty_map("ITEM-1", "WH-A")
+			captured = {}
+			with patch(
+				"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+				side_effect=lambda kw: captured.update(kw) or [],
+			):
+				_eod_batch_qty_map("ITEM-2", "WH-B")
+
+		self.assertIsNone(
+			captured["batch_no"], "batch_no leaked from the previous call"
+		)
+		self.assertIsNotNone(
+			captured.get("posting_datetime"),
+			"posting_datetime leaked from the previous call",
+		)
+
+	# --- the cached accessor ---------------------------------------------------
+
+	def test_one_query_serves_every_batch_of_a_pair(self):
+		"""The whole point: 26,489 row lookups collapsed onto 1,414 (item, warehouse) calls."""
+		rows = [
+			FD({"batch_no": "B1", "warehouse": "WH-A", "qty": 5.0}),
+			FD({"batch_no": "B2", "warehouse": "WH-A", "qty": 7.0}),
+		]
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			return_value=rows,
+		) as auto:
+			_eod_batch_qty_cache_start()
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B1", "WH-A"), 5.0)
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B2", "WH-A"), 7.0)
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B1", "WH-A"), 5.0)
+		self.assertEqual(auto.call_count, 1)
+
+	def test_a_missing_batch_reads_as_zero_not_an_error(self):
+		"""Upstream uses defaultdict(float); an absent key must be 0.0, never a KeyError."""
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			return_value=[FD({"batch_no": "B1", "warehouse": "WH-A", "qty": 5.0})],
+		):
+			_eod_batch_qty_cache_start()
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "NOPE", "WH-A"), 0.0)
+
+	def test_different_warehouses_are_cached_separately(self):
+		def _rows(kw):
+			qty = 5.0 if kw["warehouse"] == "WH-A" else 11.0
+			return [FD({"batch_no": "B1", "warehouse": kw["warehouse"], "qty": qty})]
+
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=_rows,
+		) as auto:
+			_eod_batch_qty_cache_start()
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B1", "WH-A"), 5.0)
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B1", "WH-B"), 11.0)
+		self.assertEqual(auto.call_count, 2)
+
+	def test_with_the_cache_off_it_reads_through_to_get_batch_qty(self):
+		"""Phase 2 must never be served a pre-submit reading."""
+		_eod_batch_qty_cache_stop()
+		with patch(
+			"erpnext.stock.doctype.batch.batch.get_batch_qty", return_value=3.25
+		) as scalar:
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B1", "WH-A"), 3.25)
+		self.assertTrue(scalar.called)
+
+	def test_non_batch_and_warehouseless_lines_still_return_none(self):
+		"""Contract relied on by _pick_eod_source_warehouse; unchanged by caching."""
+		_eod_batch_qty_cache_start()
+		self.assertIsNone(_eod_physical_batch_qty("ITEM-1", None, "WH-A"))
+		self.assertIsNone(_eod_physical_batch_qty("ITEM-1", "B1", None))
+
+	def test_a_query_failure_still_reads_as_zero(self):
+		"""Preserves the pre-cache swallow-and-return-0.0 contract."""
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			side_effect=Exception("boom"),
+		):
+			_eod_batch_qty_cache_start()
+			self.assertEqual(_eod_physical_batch_qty("ITEM-1", "B1", "WH-A"), 0.0)
+
+	def test_the_positional_signature_tests_depend_on_is_intact(self):
+		"""Several tests replace this function with side_effect=lambda i, b, w: ...
+
+		The cache is therefore read from frappe.local, never passed as a parameter.
+		"""
+		import inspect
+
+		params = list(inspect.signature(_eod_physical_batch_qty).parameters)
+		self.assertEqual(params, ["item_code", "batch_no", "warehouse"])
+
+	# --- the shortfall check shares the cache ----------------------------------
+
+	def test_batch_short_check_reads_through_the_cache(self):
+		"""It used to call get_batch_qty directly, re-reading keys the warehouse picker
+		had just read."""
+		items = [
+			{
+				"item_code": "ITEM-1",
+				"batch_no": "B1",
+				"s_warehouse": "WH-A",
+				"qty": 10.0,
+			},
+			{
+				"item_code": "ITEM-1",
+				"batch_no": "B2",
+				"s_warehouse": "WH-A",
+				"qty": 1.0,
+			},
+		]
+		rows = [
+			FD({"batch_no": "B1", "warehouse": "WH-A", "qty": 4.0}),
+			FD({"batch_no": "B2", "warehouse": "WH-A", "qty": 6.0}),
+		]
+		with patch(
+			"erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_auto_batch_nos",
+			return_value=rows,
+		) as auto:
+			_eod_batch_qty_cache_start()
+			short = _check_eod_source_batch_stock(items)
+		self.assertEqual(
+			auto.call_count, 1, "both rows share one (item, warehouse) key"
+		)
+		self.assertEqual(short, {("WH-A", "ITEM-1", "B1"): (10.0, 4.0)})
+
+
+def _chunk_entry(mwo, rows=1):
+	"""A minimal resolvable-MWO dict shaped like _plan_mwo_group's output."""
+	return {
+		"kind": "resolvable",
+		"company": "Co",
+		"manufacturer": "MF-1",
+		"mwo": mwo,
+		"items": [
+			{
+				"item_code": "M-1",
+				"qty": 1.0,
+				"s_warehouse": "WH-S",
+				"t_warehouse": "WH-T",
+				"batch_no": f"B-{mwo}-{i}",
+				"custom_manufacturing_work_order": mwo,
+				"manufacturing_operation": f"MOP-{mwo}",
+			}
+			for i in range(rows)
+		],
+		"t_warehouse": "WH-T",
+		"mop_data_list": [{"mop_name": f"MOP-{mwo}", "logs": []}],
+		"last_mop_name": f"MOP-{mwo}",
+		"child_row_names": [f"ROW-{mwo}-{i}" for i in range(rows)],
+	}
+
+
+class TestChunkMainMwos(IntegrationTestCase):
+	"""Bucket partitioning. Both caps matter: MWO row counts here run 1..156 (median 2),
+	so an MWO cap alone lets a chunk reach ~2,000 rows."""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def _chunks(self, entries, max_mwos, max_rows):
+		def _setting(field, default):
+			return {"eod_chunk_max_mwos": max_mwos, "eod_chunk_max_rows": max_rows}[
+				field
+			]
+
+		with patch(f"{_MOD}._eod_setting_int", side_effect=_setting):
+			return _chunk_main_mwos(entries)
+
+	def test_splits_on_the_mwo_cap(self):
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(5)]
+		chunks = self._chunks(entries, max_mwos=2, max_rows=0)
+		self.assertEqual([len(c) for c in chunks], [2, 2, 1])
+
+	def test_splits_on_the_row_cap(self):
+		entries = [_chunk_entry(f"MWO-{i}", rows=3) for i in range(4)]
+		chunks = self._chunks(entries, max_mwos=0, max_rows=6)
+		self.assertEqual([len(c) for c in chunks], [2, 2])
+
+	def test_whichever_cap_trips_first_wins(self):
+		entries = [_chunk_entry(f"MWO-{i}", rows=1) for i in range(6)]
+		chunks = self._chunks(entries, max_mwos=2, max_rows=100)
+		self.assertEqual([len(c) for c in chunks], [2, 2, 2])
+
+	def test_an_mwo_is_never_split_even_when_it_exceeds_the_row_cap(self):
+		"""The MWO is the indivisible accounting unit: half an MWO would have its
+		reservation cancelled with no row left to re-reserve from."""
+		entries = [_chunk_entry("BIG", rows=200), _chunk_entry("SMALL", rows=1)]
+		chunks = self._chunks(entries, max_mwos=0, max_rows=150)
+		self.assertEqual(len(chunks), 2)
+		self.assertEqual(len(chunks[0]), 1)
+		self.assertEqual(len(chunks[0][0]["items"]), 200, "oversized MWO kept whole")
+
+	def test_both_caps_zero_restores_one_se_per_bucket(self):
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(9)]
+		chunks = self._chunks(entries, max_mwos=0, max_rows=0)
+		self.assertEqual([len(c) for c in chunks], [9])
+
+	def test_no_empty_chunks_are_emitted(self):
+		entries = [_chunk_entry(f"MWO-{i}", rows=10) for i in range(3)]
+		chunks = self._chunks(entries, max_mwos=1, max_rows=1)
+		self.assertEqual([len(c) for c in chunks], [1, 1, 1])
+		self.assertTrue(all(chunks))
+
+
+class TestChunkCommitAndSplit(IntegrationTestCase):
+	"""Per-chunk commit and the binary-split isolation that replaces whole-bucket rollback."""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def _run(self, entries, fail_mwos=(), max_mwos=2, max_rows=0):
+		"""Drive _commit_company_main_se with a stubbed chunk committer."""
+		attempts = []
+
+		def _chunk(company, manufacturer, chunk, failures, stats, *a, **kw):
+			mwos = [m["mwo"] for m in chunk]
+			attempts.append(
+				{
+					"mwos": mwos,
+					"keep_draft": kw.get("keep_draft_on_failure"),
+					"record": kw.get("record_failure"),
+				}
+			)
+			if any(m in fail_mwos for m in mwos):
+				return False
+			stats["processed_mwos"] += len(chunk)
+			return True
+
+		def _setting(field, default):
+			return {"eod_chunk_max_mwos": max_mwos, "eod_chunk_max_rows": max_rows}[
+				field
+			]
+
+		failures, stats = [], {"processed_mwos": 0, "failed_mwos": 0}
+		with patch(f"{_MOD}._eod_setting_int", side_effect=_setting), patch(
+			f"{_MOD}._eod_feature_enabled", return_value=False
+		), patch(f"{_MOD}._commit_se_chunk", side_effect=_chunk):
+			_commit_company_main_se(
+				"Co",
+				"MF-1",
+				entries,
+				failures,
+				stats,
+				"SYNC-LOG-1",
+				already_allocated=True,
+			)
+		return attempts, failures, stats
+
+	def test_a_clean_bucket_commits_one_chunk_at_a_time(self):
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(4)]
+		attempts, _, stats = self._run(entries)
+		self.assertEqual(
+			[a["mwos"] for a in attempts], [["MWO-0", "MWO-1"], ["MWO-2", "MWO-3"]]
+		)
+		self.assertEqual(stats["processed_mwos"], 4)
+
+	def test_a_failing_chunk_is_halved_and_retried(self):
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(2)]
+		attempts, _, stats = self._run(entries, fail_mwos={"MWO-1"}, max_mwos=2)
+		self.assertEqual(
+			[a["mwos"] for a in attempts],
+			[["MWO-0", "MWO-1"], ["MWO-0"], ["MWO-1"]],
+			"failed pair must be split, not abandoned",
+		)
+		self.assertEqual(stats["processed_mwos"], 1, "the good MWO still syncs")
+
+	def test_only_the_terminal_attempt_keeps_its_draft_and_reports(self):
+		"""Intermediate attempts must leave no orphan draft behind and must not
+		double-report the same failure."""
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(2)]
+		attempts, _, _ = self._run(entries, fail_mwos={"MWO-1"}, max_mwos=2)
+		grouped = next(a for a in attempts if len(a["mwos"]) == 2)
+		singles = [a for a in attempts if len(a["mwos"]) == 1]
+		self.assertFalse(
+			grouped["keep_draft"], "grouped attempt must roll its draft back"
+		)
+		self.assertFalse(grouped["record"], "grouped attempt must not report")
+		self.assertTrue(all(s["keep_draft"] for s in singles))
+		self.assertTrue(all(s["record"] for s in singles))
+
+	def test_a_single_mwo_chunk_is_terminal_immediately(self):
+		entries = [_chunk_entry("MWO-0")]
+		attempts, _, _ = self._run(entries, fail_mwos={"MWO-0"}, max_mwos=2)
+		self.assertEqual(len(attempts), 1, "nothing left to split")
+		self.assertTrue(attempts[0]["keep_draft"])
+		self.assertTrue(attempts[0]["record"])
+
+	def test_recursion_bottoms_out_at_single_mwos(self):
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(4)]
+		attempts, _, _ = self._run(
+			entries, fail_mwos={f"MWO-{i}" for i in range(4)}, max_mwos=4
+		)
+		singles = [a for a in attempts if len(a["mwos"]) == 1]
+		self.assertEqual(
+			sorted(a["mwos"][0] for a in singles), ["MWO-0", "MWO-1", "MWO-2", "MWO-3"]
+		)
+		self.assertTrue(
+			all(len(a["mwos"]) >= 1 for a in attempts), "never splits below one"
+		)
+
+	def test_retry_budget_is_bounded_and_reported(self):
+		"""An entirely-bad bucket must not grind forever, and whatever the cap abandons
+		has to be said out loud rather than silently dropped."""
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(16)]
+		with patch(f"{_MOD}.frappe.logger") as logger:
+			attempts, _, _ = self._run(
+				entries, fail_mwos={f"MWO-{i}" for i in range(16)}, max_mwos=16
+			)
+		self.assertLess(len(attempts), 40, "recursion must be budget-bounded")
+		warned = any(
+			"retry budget exhausted" in str(c)
+			for c in logger.return_value.warning.call_args_list
+		)
+		self.assertTrue(warned or len(attempts) < 32)
+
+
+class TestChunkSavepointCommitOrder(IntegrationTestCase):
+	"""MariaDB drops EVERY savepoint on COMMIT.
+
+	A savepoint opened before a commit and rolled back after it silently does not exist, and
+	_rollback_to_savepoint would then take its full-rollback fallback -- discarding work that
+	looked committed. This is the single most dangerous property of per-chunk commits, so it
+	is asserted directly on the call ORDER.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_every_savepoint_is_released_before_the_chunk_commits(self):
+		calls = []
+
+		def _sp(name):
+			calls.append(("savepoint", name))
+
+		def _release(name):
+			calls.append(("release", name))
+
+		def _commit():
+			calls.append(("commit", None))
+
+		entry = _chunk_entry("MWO-1")
+		with patch(f"{_MOD}.frappe.db.savepoint", side_effect=_sp), patch(
+			f"{_MOD}.frappe.db.release_savepoint", side_effect=_release
+		), patch(f"{_MOD}.frappe.db.commit", side_effect=_commit), patch(
+			f"{_MOD}._save_draft_eod_se", return_value="SE-1"
+		), patch(f"{_MOD}._snapshot_mwo_sres_for_relocation", return_value=[]), patch(
+			f"{_MOD}._reserve_sres_from_eod_se_rows"
+		), patch(f"{_MOD}._eod_rows_from_submitted_se", return_value=[]), patch(
+			f"{_MOD}._mark_all_mwo_mop_logs_synced"
+		), patch(f"{_MOD}._stamp_last_eod_sync"), patch(
+			f"{_MOD}._bulk_set_child_rows"
+		), patch(f"{_MOD}.frappe.get_doc", return_value=MagicMock()):
+			ok = _commit_se_chunk(
+				"Co",
+				"MF-1",
+				[entry],
+				[],
+				{"processed_mwos": 0, "submitted_ses": []},
+				"SYNC-LOG-1",
+			)
+
+		self.assertTrue(ok)
+		commit_at = [i for i, c in enumerate(calls) if c[0] == "commit"]
+		self.assertEqual(len(commit_at), 1, "a chunk commits exactly once")
+		commit_at = commit_at[0]
+		opened = [
+			n
+			for i, (kind, n) in enumerate(calls)
+			if kind == "savepoint" and i < commit_at
+		]
+		released = [
+			n
+			for i, (kind, n) in enumerate(calls)
+			if kind == "release" and i < commit_at
+		]
+		self.assertTrue(opened, "test is vacuous if no savepoint was opened")
+		self.assertEqual(
+			sorted(opened),
+			sorted(released),
+			"every savepoint opened before the COMMIT must be released before it",
+		)
+
+	def test_a_retryable_failure_rolls_the_outer_savepoint_back(self):
+		"""So the abandoned attempt's draft Stock Entry does not survive as debris."""
+		rolled = []
+		entry = _chunk_entry("MWO-1")
+		with patch(f"{_MOD}.frappe.db.savepoint"), patch(
+			f"{_MOD}.frappe.db.release_savepoint"
+		), patch(f"{_MOD}.frappe.db.commit"), patch(
+			f"{_MOD}._rollback_to_savepoint", side_effect=rolled.append
+		), patch(f"{_MOD}._save_draft_eod_se", return_value="SE-1"), patch(
+			f"{_MOD}._snapshot_mwo_sres_for_relocation",
+			side_effect=RuntimeError("boom"),
+		), patch(f"{_MOD}._bulk_set_child_rows"):
+			ok = _commit_se_chunk(
+				"Co",
+				"MF-1",
+				[entry],
+				[],
+				{"processed_mwos": 0, "submitted_ses": []},
+				"SYNC-LOG-1",
+				keep_draft_on_failure=False,
+				record_failure=False,
+			)
+		self.assertFalse(ok)
+		self.assertIn("eod_submit_phase", rolled)
+		self.assertIn("eod_chunk_phase", rolled)
+
+	def test_a_terminal_failure_keeps_the_draft(self):
+		"""Existing recovery behaviour: the draft survives for manual submission."""
+		rolled = []
+		failures, stats = (
+			[],
+			{
+				"processed_mwos": 0,
+				"submitted_ses": [],
+				"draft_ses": [],
+				"failed_mwos": 0,
+			},
+		)
+		entry = _chunk_entry("MWO-1")
+		with patch(f"{_MOD}.frappe.db.savepoint"), patch(
+			f"{_MOD}.frappe.db.release_savepoint"
+		), patch(f"{_MOD}.frappe.db.commit"), patch(
+			f"{_MOD}._rollback_to_savepoint", side_effect=rolled.append
+		), patch(f"{_MOD}._save_draft_eod_se", return_value="SE-1"), patch(
+			f"{_MOD}._snapshot_mwo_sres_for_relocation",
+			side_effect=RuntimeError("boom"),
+		), patch(f"{_MOD}._bulk_set_child_rows"):
+			ok = _commit_se_chunk(
+				"Co",
+				"MF-1",
+				[entry],
+				failures,
+				stats,
+				"SYNC-LOG-1",
+				keep_draft_on_failure=True,
+				record_failure=True,
+			)
+		self.assertFalse(ok)
+		self.assertNotIn(
+			"eod_chunk_phase", rolled, "no outer savepoint when keeping the draft"
+		)
+		self.assertEqual(stats["draft_ses"], ["SE-1"])
+		self.assertEqual(failures[0]["step"], "submit")
+
+
+class TestSoftDeadline(IntegrationTestCase):
+	"""The graceful stop that replaces the hard RQ kill.
+
+	Before this, a run that overran was killed mid-statement: the lock was left for the
+	hourly reaper (which has itself been seen stuck in the queue) and a multi-crore draft
+	Stock Entry was left behind with nothing explaining it.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def tearDown(self):
+		frappe.local.eod_sync_deadline = None
+
+	def test_no_deadline_when_configured_zero(self):
+		with patch(f"{_MOD}._eod_setting_int", return_value=0):
+			self.assertIsNone(_eod_deadline_start(now_datetime()))
+		self.assertFalse(_eod_deadline_passed())
+
+	def test_deadline_not_passed_immediately(self):
+		with patch(f"{_MOD}._eod_setting_int", return_value=200):
+			_eod_deadline_start(now_datetime())
+		self.assertFalse(_eod_deadline_passed())
+
+	def test_deadline_passed_once_the_window_elapsed(self):
+		with patch(f"{_MOD}._eod_setting_int", return_value=1):
+			_eod_deadline_start(add_to_date(now_datetime(), minutes=-5))
+		self.assertTrue(_eod_deadline_passed())
+
+	def test_chunks_stop_starting_past_the_deadline_and_are_counted(self):
+		"""Committed chunks stay committed; un-started MWOs stay unsynced for next run."""
+		entries = [_chunk_entry(f"MWO-{i}") for i in range(6)]
+		committed = []
+
+		def _chunk(company, manufacturer, chunk, failures, stats, *a, **kw):
+			committed.append([m["mwo"] for m in chunk])
+			# Trip the deadline after the first chunk lands.
+			frappe.local.eod_sync_deadline = add_to_date(now_datetime(), minutes=-1)
+			stats["processed_mwos"] += len(chunk)
+			return True
+
+		def _setting(field, default):
+			return {"eod_chunk_max_mwos": 2, "eod_chunk_max_rows": 0}.get(
+				field, default
+			)
+
+		stats = {
+			"processed_mwos": 0,
+			"failed_mwos": 0,
+			"deadline_stopped": False,
+			"deadline_skipped_mwos": 0,
+			"deadline_skipped_chunks": 0,
+		}
+		frappe.local.eod_sync_deadline = None
+		with patch(f"{_MOD}._eod_setting_int", side_effect=_setting), patch(
+			f"{_MOD}._eod_feature_enabled", return_value=False
+		), patch(f"{_MOD}._commit_se_chunk", side_effect=_chunk):
+			_commit_company_main_se(
+				"Co", "MF-1", entries, [], stats, "SYNC-LOG-1", already_allocated=True
+			)
+
+		self.assertEqual(committed, [["MWO-0", "MWO-1"]], "only the first chunk ran")
+		self.assertTrue(stats["deadline_stopped"])
+		self.assertEqual(stats["deadline_skipped_chunks"], 2)
+		self.assertEqual(stats["deadline_skipped_mwos"], 4)
+		self.assertEqual(stats["processed_mwos"], 2, "committed work is still counted")
+
+	def test_a_deadline_stop_is_never_reported_as_completed(self):
+		"""Completed stamps eod_sync_last_completed_on, which makes the scheduler treat the
+		day as done -- exactly the way work gets stranded."""
+		writes = []
+
+		def _set_value(doctype, name, values, *a, **kw):
+			if doctype == "MOP EOD Sync Log" and isinstance(values, dict):
+				writes.append(values)
+
+		def _plan(group_key, mop_data_list, failures, stats, *a, **kw):
+			# Trip the deadline during planning, so nothing is even attempted.
+			frappe.local.eod_sync_deadline = add_to_date(now_datetime(), minutes=-1)
+			return None
+
+		with patch(f"{_MOD}.release_eod_sync_lock"), patch(
+			f"{_MOD}.set_eod_sync_running"
+		), patch(f"{_MOD}.frappe.db.set_value", side_effect=_set_value), patch(
+			f"{_MOD}.frappe.db.commit"
+		), patch(f"{_MOD}.recalculate_sync_log_totals"), patch(
+			f"{_MOD}.frappe.db.get_all", return_value=[]
+		), patch(f"{_MOD}._plan_mwo_group", side_effect=_plan), patch(
+			f"{_MOD}._eod_feature_enabled", return_value=False
+		), patch(
+			f"{_MOD}.frappe.log_error", return_value=FrappeDict({"name": "ERR-1"})
+		), patch(
+			f"{_MOD}._get_unsynced_mop_groups",
+			return_value={
+				("Co", "MWO-A"): [
+					{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": []}
+				],
+				("Co", "MWO-B"): [
+					{"mop_name": "MOP-B", "mop_doc": _mop_doc(), "logs": []}
+				],
+			},
+		), patch(
+			f"{_MOD}.frappe.get_doc",
+			return_value=FrappeDict({"eod_sync_work_order_filter": []}),
+		):
+			sync_mop_logs(sync_log_name="SYNC-LOG-1")
+
+		statuses = [w["status"] for w in writes if "status" in w]
+		self.assertTrue(statuses)
+		self.assertEqual(statuses[-1], "Partially Completed")
+		messages = [w.get("progress_message", "") for w in writes]
+		self.assertTrue(
+			any("soft deadline" in m for m in messages),
+			"the stop must explain itself on the Sync Log",
+		)
+
+
+class TestRecoverableErrors(IntegrationTestCase):
+	"""A timeout means "cut short", not "broken".
+
+	worker.log holds three real JobTimeoutExceptions from this sync, each firing inside the
+	recovery handler's own rollback. Reporting those as an unexpected defect sent people
+	hunting a bug that was not there.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_rq_job_timeout_is_recoverable(self):
+		from rq.timeouts import JobTimeoutException
+
+		self.assertTrue(_is_recoverable_error(JobTimeoutException("timed out")))
+
+	def test_a_plain_bug_is_not_recoverable(self):
+		self.assertFalse(_is_recoverable_error(AttributeError("typo")))
+		self.assertFalse(_is_recoverable_error(RuntimeError("boom")))
+
+	def test_deadlock_is_recoverable_when_frappe_exposes_it(self):
+		exc_cls = getattr(frappe, "QueryDeadlockError", None)
+		if not (isinstance(exc_cls, type) and issubclass(exc_cls, BaseException)):
+			self.skipTest("this frappe build does not expose QueryDeadlockError")
+		self.assertTrue(_is_recoverable_error(exc_cls("deadlock")))
+
+	def test_a_cut_short_run_that_synced_work_is_partially_completed(self):
+		from rq.timeouts import JobTimeoutException
+
+		writes = []
+
+		def _set_value(doctype, name, values, *a, **kw):
+			if doctype == "MOP EOD Sync Log" and isinstance(values, dict):
+				writes.append(values)
+
+		def _plan(group_key, mop_data_list, failures, stats, *a, **kw):
+			stats["processed_mwos"] += 1
+			raise JobTimeoutException("Task exceeded maximum timeout value")
+
+		with patch(f"{_MOD}.release_eod_sync_lock"), patch(
+			f"{_MOD}.set_eod_sync_running"
+		), patch(f"{_MOD}.frappe.db.set_value", side_effect=_set_value), patch(
+			f"{_MOD}.frappe.db.commit"
+		), patch(f"{_MOD}.recalculate_sync_log_totals"), patch(
+			f"{_MOD}.frappe.log_error", return_value=FrappeDict({"name": "ERR-1"})
+		), patch(f"{_MOD}._plan_mwo_group", side_effect=_plan), patch(
+			f"{_MOD}._get_unsynced_mop_groups",
+			return_value={
+				("Co", "MWO-A"): [
+					{"mop_name": "MOP-A", "mop_doc": _mop_doc(), "logs": []}
+				]
+			},
+		), patch(
+			f"{_MOD}.frappe.get_doc",
+			return_value=FrappeDict({"eod_sync_work_order_filter": []}),
+		):
+			sync_mop_logs(sync_log_name="SYNC-LOG-1")
+
+		statuses = [w["status"] for w in writes if "status" in w]
+		self.assertEqual(statuses[-1], "Partially Completed")
+		self.assertTrue(
+			any("cut short" in w.get("progress_message", "") for w in writes),
+			"a timeout must not be described as an unexpected error",
+		)
+
+
+class TestEodReservationGateStaysClosed(IntegrationTestCase):
+	"""``stock_reservation_entry_for_mwo`` must never fire on the EOD transfer.
+
+	Nothing in code keeps it off: the gate is a DATA condition -- "Material Transfer to
+	Department" simply not being listed in MOP Settings' Stock Entry Type To Reservation
+	table (doc_events/stock_entry.py `onsubmit`). Add that row and every EOD submit would
+	throw (the consolidated header deliberately carries no manufacturing_order), and if it
+	somehow got past that it would do ~4 reads plus an SRE insert+submit PER ROW -- tens of
+	thousands of them on a backlog run.
+
+	mop_eod_sync's module docstring depends on this staying absent, so the coupling is
+	asserted here rather than left as a comment.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_eod_se_type_is_not_in_the_reservation_gate(self):
+		listed = frappe.db.get_all(
+			"Stock Entry Type To Reservation",
+			filters={"parent": "MOP Settings"},
+			pluck="stock_entry_type_to_reservation",
+		)
+		self.assertNotIn(
+			"Material Transfer to Department",
+			listed,
+			"EOD sync's own Stock Entry type must stay out of the reservation gate: it "
+			"would throw on the blank header MWO, and would build one SRE per row.",
+		)
+
+
+class TestBacklogCatchup(IntegrationTestCase):
+	"""The bounded drain for MOP Logs the today-only window can never reach again."""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def setUp(self):
+		frappe.local.eod_catchup_limit_override = None
+		frappe.local.eod_sync_deadline = None
+
+	def tearDown(self):
+		frappe.local.eod_catchup_limit_override = None
+		frappe.local.eod_sync_deadline = None
+		frappe.flags.eod_sync_range = None
+
+	def _run(self, **over):
+		"""Call _run_backlog_catchup with everything stubbed; return what it did."""
+		calls = {"planned": None, "range_during": None}
+
+		def _plan_commit(groups, failures, stats, sync_log_name, selective):
+			calls["planned"] = groups
+			calls["range_during"] = frappe.flags.eod_sync_range
+
+		cfg = {
+			"enabled": True,
+			"deadline": False,
+			"failures": [],
+			"selective": False,
+			"rows": [
+				FrappeDict(
+					{
+						"manufacturing_work_order": "MWO-OLD",
+						"oldest": "2026-05-01 09:00:00",
+					}
+				)
+			],
+			"groups": {
+				("Co", "MWO-OLD"): [
+					{"mop_name": "MOP-OLD", "mop_doc": _mop_doc(), "logs": []}
+				]
+			},
+		}
+		cfg.update(over)
+
+		stats = {"total_mwos": 3, "processed_mwos": 0}
+		frappe.flags.eod_sync_range = ("2026-07-30 00:00:00", "2026-07-30 23:59:59")
+		with patch(f"{_MOD}._eod_feature_enabled", return_value=cfg["enabled"]), patch(
+			f"{_MOD}._eod_deadline_passed", return_value=cfg["deadline"]
+		), patch(f"{_MOD}._eod_setting_int", return_value=500), patch(
+			f"{_MOD}.frappe.db.sql", return_value=cfg["rows"]
+		), patch(f"{_MOD}._get_backlog_groups", return_value=cfg["groups"]), patch(
+			f"{_MOD}.frappe.db.set_value"
+		), patch(f"{_MOD}.frappe.db.commit"), patch(
+			f"{_MOD}._plan_and_commit_groups", side_effect=_plan_commit
+		):
+			_run_backlog_catchup(
+				MagicMock(), cfg["failures"], stats, "SYNC-LOG-1", cfg["selective"]
+			)
+		return calls, stats
+
+	def test_it_drains_the_oldest_pre_window_mwos(self):
+		calls, stats = self._run()
+		self.assertIsNotNone(calls["planned"], "catch-up did not run")
+		self.assertEqual(stats["catchup_mwos"], 1)
+		self.assertEqual(stats["total_mwos"], 4, "catch-up MWOs join the run total")
+
+	def test_the_window_is_swapped_to_the_catchup_range_while_it_runs(self):
+		"""_mark_all_mwo_mop_logs_synced is bounded by this flag in non-selective mode, so a
+		mismatched window would transfer the stock and mark NOTHING synced -- re-transferring
+		the same logs on every future run."""
+		calls, _ = self._run()
+		self.assertEqual(
+			calls["range_during"],
+			("2026-05-01 09:00:00", "2026-07-30 00:00:00"),
+			"catch-up must publish its own window, not the main pass's",
+		)
+
+	def test_the_original_window_is_restored_afterwards(self):
+		self._run()
+		self.assertEqual(
+			frappe.flags.eod_sync_range,
+			("2026-07-30 00:00:00", "2026-07-30 23:59:59"),
+		)
+
+	def test_the_window_is_restored_even_if_the_pass_raises(self):
+		def _boom(*a, **kw):
+			raise RuntimeError("boom")
+
+		frappe.flags.eod_sync_range = ("2026-07-30 00:00:00", "2026-07-30 23:59:59")
+		with patch(f"{_MOD}._eod_feature_enabled", return_value=True), patch(
+			f"{_MOD}._eod_deadline_passed", return_value=False
+		), patch(f"{_MOD}._eod_setting_int", return_value=500), patch(
+			f"{_MOD}.frappe.db.sql",
+			return_value=[
+				FrappeDict(
+					{
+						"manufacturing_work_order": "MWO-OLD",
+						"oldest": "2026-05-01 09:00:00",
+					}
+				)
+			],
+		), patch(f"{_MOD}._get_backlog_groups", side_effect=_boom):
+			with self.assertRaises(RuntimeError):
+				_run_backlog_catchup(
+					MagicMock(), [], {"total_mwos": 0}, "SYNC-LOG-1", False
+				)
+		self.assertEqual(
+			frappe.flags.eod_sync_range,
+			("2026-07-30 00:00:00", "2026-07-30 23:59:59"),
+			"a leaked catch-up window would mis-scope the next mark-synced",
+		)
+
+	def test_skipped_when_the_flag_is_off(self):
+		calls, _ = self._run(enabled=False)
+		self.assertIsNone(calls["planned"])
+
+	def test_skipped_past_the_soft_deadline(self):
+		"""A run already out of time must not take on extra work."""
+		calls, _ = self._run(deadline=True)
+		self.assertIsNone(calls["planned"])
+
+	def test_skipped_when_the_main_pass_had_blocking_failures(self):
+		calls, _ = self._run(failures=[{"step": "submit", "error_message": "x"}])
+		self.assertIsNone(calls["planned"])
+
+	def test_advisory_failures_do_not_block_the_catchup(self):
+		calls, _ = self._run(failures=[{"step": "sre_reconcile", "advisory": True}])
+		self.assertIsNotNone(calls["planned"])
+
+	def test_skipped_in_selective_mode(self):
+		"""Selective mode already syncs full unsynced history for its listed MWOs."""
+		calls, _ = self._run(selective=True)
+		self.assertIsNone(calls["planned"])
+
+	def test_nothing_to_drain_is_a_no_op(self):
+		calls, stats = self._run(rows=[])
+		self.assertIsNone(calls["planned"])
+		self.assertNotIn("catchup_mwos", stats)
+
+	def test_an_explicit_drain_request_overrides_the_feature_flag(self):
+		"""The Drain Backlog button asked for exactly this pass."""
+		frappe.local.eod_catchup_limit_override = 250
+		calls, _ = self._run(enabled=False)
+		self.assertIsNotNone(
+			calls["planned"], "explicit request must not be gated by the flag"
+		)
+
+
+class TestEodPrefetch(IntegrationTestCase):
+	"""Run-scoped prefetches for the three lookups that cost one query per MWO."""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def tearDown(self):
+		_eod_prefetch_stop()
+
+	def _groups(self):
+		return {
+			("Co", "MWO-1"): [
+				{
+					"mop_name": "MOP-1",
+					"mop_doc": _mop_doc(),
+					"logs": [FD({"item_code": "M-1", "batch_no": "B1"})],
+				}
+			],
+			("Co", "MWO-2"): [
+				{
+					"mop_name": "MOP-2",
+					"mop_doc": _mop_doc(),
+					"logs": [FD({"item_code": "M-2", "batch_no": "B2"})],
+				}
+			],
+		}
+
+	def test_prefetch_uses_one_query_per_doctype_not_one_per_mwo(self):
+		seen = []
+
+		def _get_all(doctype, *a, **kw):
+			seen.append(doctype)
+			return []
+
+		with patch(f"{_MOD}.frappe.db.get_all", side_effect=_get_all):
+			_eod_prefetch_start(self._groups())
+
+		self.assertEqual(
+			sorted(seen), ["Batch", "Item", "Stock Entry"], "one query per doctype"
+		)
+
+	def test_artifact_lookup_is_served_from_the_prefetch(self):
+		frappe.local.eod_artifact_map = {"MWO-1": "SE-ART-1"}
+		with patch(f"{_MOD}.frappe.db.get_value") as get_value:
+			self.assertEqual(_mwo_realized_by_artifact("MWO-1"), "SE-ART-1")
+			self.assertIsNone(_mwo_realized_by_artifact("MWO-NONE"))
+		self.assertFalse(get_value.called, "must not query per MWO")
+
+	def test_artifact_lookup_falls_back_with_no_prefetch(self):
+		_eod_prefetch_stop()
+		with patch(f"{_MOD}.frappe.db.get_value", return_value="SE-X") as get_value:
+			self.assertEqual(_mwo_realized_by_artifact("MWO-1"), "SE-X")
+		self.assertTrue(get_value.called)
+
+	def test_batch_ownership_served_from_the_prefetch(self):
+		frappe.local.eod_batch_ownership = {"B1": ("Customer Goods", "CUST-1")}
+		with patch(f"{_MOD}.frappe.db.get_all") as get_all:
+			out = _eod_batch_ownership(["B1"])
+		self.assertEqual(out, {"B1": ("Customer Goods", "CUST-1")})
+		self.assertFalse(get_all.called)
+
+	def test_a_batch_missing_from_the_prefetch_falls_through_to_a_real_query(self):
+		"""Treating an absent batch as "no ownership" would book a customer's metal as
+		company stock -- the exact failure _stamp_eod_row_ownership exists to prevent."""
+		frappe.local.eod_batch_ownership = {"B1": ("Customer Goods", "CUST-1")}
+		with patch(
+			f"{_MOD}.frappe.db.get_all",
+			return_value=[
+				FD(
+					{
+						"name": "B2",
+						"custom_inventory_type": "Regular Stock",
+						"custom_customer": None,
+					}
+				)
+			],
+		) as get_all:
+			out = _eod_batch_ownership(["B1", "B2"])
+		self.assertTrue(get_all.called, "a partial prefetch must not be trusted")
+		self.assertIn("B2", out)
+
+	def test_item_flags_served_from_the_prefetch(self):
+		frappe.local.eod_item_flags = {
+			"M-1": FD({"name": "M-1", "has_batch_no": 1, "has_serial_no": 0})
+		}
+		items = [{"item_code": "M-1", "qty": 1.0, "batch_no": "B1"}]
+		with patch(f"{_MOD}.frappe.db.get_all") as get_all:
+			_validate_eod_items_for_mwo_reservation(items)
+		self.assertFalse(get_all.called)
+
+	def test_item_flags_partial_prefetch_falls_through(self):
+		frappe.local.eod_item_flags = {
+			"M-1": FD({"name": "M-1", "has_batch_no": 0, "has_serial_no": 0})
+		}
+		items = [{"item_code": "M-9", "qty": 1.0}]
+		with patch(
+			f"{_MOD}.frappe.db.get_all",
+			return_value=[FD({"name": "M-9", "has_batch_no": 0, "has_serial_no": 0})],
+		) as get_all:
+			_validate_eod_items_for_mwo_reservation(items)
+		self.assertTrue(
+			get_all.called, "an unknown code must be looked up, not assumed absent"
+		)
+
+	def test_stop_clears_every_prefetch(self):
+		frappe.local.eod_artifact_map = {"a": "b"}
+		frappe.local.eod_item_flags = {"a": "b"}
+		frappe.local.eod_batch_ownership = {"a": "b"}
+		_eod_prefetch_stop()
+		self.assertIsNone(frappe.local.eod_artifact_map)
+		self.assertIsNone(frappe.local.eod_item_flags)
+		self.assertIsNone(frappe.local.eod_batch_ownership)

--- a/jewellery_erpnext/patches/retry_stuck_eod_submit_mwos.py
+++ b/jewellery_erpnext/patches/retry_stuck_eod_submit_mwos.py
@@ -84,14 +84,31 @@ def _classify(sync_log_name=None):
 
 		if not states:
 			continue
-		# (2) submitted by hand anywhere -> inconsistent, never auto-retry.
-		if any(ds == 1 for _, ds, _ in states):
-			skipped[mwo] = [se for se, ds, _ in states if ds == 1]
-			continue
 		# (1) only the real consolidated transfer drafts.
 		main_drafts = [
 			se for se, ds, src in states if ds == 0 and src == "MOP EOD Sync"
 		]
+		# (2) submitted by hand -> that stock already moved, so retrying would double it.
+		#
+		# EOD now writes one Stock Entry per CHUNK, so a single MWO can own several drafts.
+		# The old blanket `any(ds == 1)` quarantined the whole MWO the moment an operator
+		# submitted any one of them, stranding its still-retryable siblings. Quarantine only
+		# when a submitted SE exists AND no clean draft is left to retry: a mixed MWO is
+		# genuinely ambiguous, but "one submitted, none pending" is simply done.
+		submitted = [se for se, ds, _ in states if ds == 1]
+		if submitted and not main_drafts:
+			skipped[mwo] = submitted
+			continue
+		if submitted and main_drafts:
+			# Partially submitted across chunks -- a human has to decide. Report loudly
+			# rather than guessing which half already moved stock.
+			skipped[mwo] = submitted + main_drafts
+			print(
+				f"[retry-stuck-eod] {mwo}: {len(submitted)} submitted and "
+				f"{len(main_drafts)} draft EOD Stock Entry(s) — partially committed across "
+				"chunks. Skipped: reconcile by hand before retrying."
+			)
+			continue
 		if not main_drafts:
 			continue
 		# (3) nothing left to sync means it was already accounted for.
@@ -248,18 +265,28 @@ def execute(sync_log_name=None, dry_run=True):
 
 def verify(sync_log_name=DEFAULT_SYNC_LOG):
 	"""Read-only post-retry report: for each formerly-retryable MWO show its new
-	submitted transfer SE (if any) and active SRE count at the target."""
+	submitted transfer SE(s) and active SRE count at the target.
+
+	``custom_manufacturing_work_order`` lives on **Stock Entry Detail**, not on the Stock
+	Entry parent -- and the consolidated EOD Stock Entry deliberately leaves its header MWO
+	blank. Filtering the parent by it therefore returned nothing (or an Unknown column),
+	which made this report silently useless. Join through the child table instead, and
+	expect several SEs per MWO now that EOD writes one per chunk.
+	"""
 	retryable, _ = _classify(sync_log_name)
 	for mwo in retryable:
-		ses = frappe.get_all(
-			"Stock Entry",
-			filters={
-				"custom_manufacturing_work_order": mwo,
-				"stock_entry_type": "Material Transfer to Department",
-				"docstatus": 1,
-			},
-			fields=["name"],
-			limit_page_length=0,
+		ses = frappe.db.sql(
+			"""
+			SELECT DISTINCT se.name
+			FROM `tabStock Entry` se
+			INNER JOIN `tabStock Entry Detail` sed ON sed.parent = se.name
+			WHERE sed.custom_manufacturing_work_order = %s
+			  AND se.stock_entry_type = 'Material Transfer to Department'
+			  AND se.docstatus = 1
+			ORDER BY se.name
+			""",
+			(mwo,),
+			as_dict=True,
 		)
 		sres = frappe.get_all(
 			"Stock Reservation Entry",


### PR DESCRIPTION
- Refactor logic to better classify MWOs with mixed states of submitted and draft Stock Entries.
- Ensure that MWOs with submitted Stock Entries and no clean drafts are skipped to prevent double counting.
- Enhance reporting for MWOs that have both submitted and draft Stock Entries, prompting manual reconciliation.
- Update the verification process to correctly join Stock Entries with their details, ensuring accurate reporting of submitted transfers.