### PR TITLE
feat(product-tolerance): select the covering band and gate department

### DIFF
--- a/jewellery_erpnext/hooks.py
+++ b/jewellery_erpnext/hooks.py
@@ -91,6 +91,13 @@ doc_events = {
 		"before_cancel": [_EOD_LOCK_VALIDATOR, _RECON_WINDOW_MOVEMENT_VALIDATOR],
 	},
 	"Department IR": {
+		# On validate, not before_submit: the operator is told the weight is out of
+		# tolerance when the transfer is first saved, and Frappe runs validate on submit
+		# too, so this one entry covers both. See the module docstring for which weights
+		# it sees on each path -- before_validate refreshes them on save but not submit.
+		"validate": [
+			"jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.product_tolerance.validate_product_tolerance"
+		],
 		"before_save": [_EOD_LOCK_VALIDATOR, _RECON_WINDOW_MOVEMENT_VALIDATOR],
 		"before_submit": [
 			_EOD_LOCK_VALIDATOR,

--- a/jewellery_erpnext/jewellery_erpnext/doctype/customer_product_tolerance_master/customer_product_tolerance_master.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/customer_product_tolerance_master/customer_product_tolerance_master.py
@@ -1,9 +1,96 @@
 # Copyright (c) 2023, Nirali and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils import flt
+
+from jewellery_erpnext.jewellery_erpnext.doctype.customer_product_tolerance_master.tolerance_utils import (
+	NO_UPPER_BOUND,
+	diamond_group_key,
+	gemstone_group_key,
+	group_tolerance_rows,
+	metal_group_key,
+)
+
+# (child fieldname, label, from-field, to-field, group key) for every banded table.
+_BANDED_TABLES = (
+	(
+		"metal_tolerance_table",
+		"Metal Tolerance Table",
+		"from_weight",
+		"to_weight",
+		metal_group_key,
+	),
+	(
+		"diamond_tolerance_table",
+		"Diamond Tolerance Table",
+		"from_diamond",
+		"to_diamond",
+		diamond_group_key,
+	),
+	(
+		"gemstone_tolerance_table",
+		"Gemstone Tolerance Table",
+		"from_diamond",
+		"to_diamond",
+		gemstone_group_key,
+	),
+)
 
 
 class CustomerProductToleranceMaster(Document):
-	pass
+	def validate(self):
+		self.validate_tolerance_bands()
+
+	def validate_tolerance_bands(self):
+		"""Reject bands that Parent Manufacturing Order could not resolve to one winner.
+
+		Modelled on Refinery Price List.validate_slab_bands. Two rules only:
+
+		* From must not exceed To (skipped when To is 0, which encodes "and above").
+		* Two rows in the same group must not overlap, compared with STRICT inequality
+		  so contiguous bands that merely touch at a boundary are fine -- live masters
+		  express schedules as 3-5 / 5-10, and pick_tolerance_row resolves the shared
+		  endpoint deterministically by taking the first covering row.
+
+		Contiguity is deliberately NOT enforced: PTM-GJCU0009-00001 ships bands 0-50 and
+		51-100, and requiring gapless coverage would throw on every save of it.
+		"""
+		for fieldname, label, from_field, to_field, key in _BANDED_TABLES:
+			rows = self.get(fieldname) or []
+			for row in rows:
+				lower = flt(row.get(from_field))
+				upper = flt(row.get(to_field))
+				if upper and lower > upper:
+					frappe.throw(
+						_(
+							"{0} Row #{1}: From ({2}) cannot be greater than To ({3})."
+						).format(_(label), row.idx, lower, upper)
+					)
+
+			for group in group_tolerance_rows(rows, key).values():
+				_validate_no_overlap(group, label, from_field, to_field)
+
+
+def _validate_no_overlap(rows, label, from_field, to_field):
+	for i, a in enumerate(rows):
+		for b in rows[i + 1 :]:
+			a_hi = flt(a.get(to_field)) or NO_UPPER_BOUND
+			b_hi = flt(b.get(to_field)) or NO_UPPER_BOUND
+			if flt(a.get(from_field)) < b_hi and flt(b.get(from_field)) < a_hi:
+				frappe.throw(
+					_(
+						"{0} Rows #{1} and #{2} cover overlapping bands ({3}-{4} and "
+						"{5}-{6}). Only one row may apply to a given weight."
+					).format(
+						_(label),
+						a.idx,
+						b.idx,
+						flt(a.get(from_field)),
+						flt(a.get(to_field)) or "∞",
+						flt(b.get(from_field)),
+						flt(b.get(to_field)) or "∞",
+					)
+				)

--- a/jewellery_erpnext/jewellery_erpnext/doctype/customer_product_tolerance_master/tolerance_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/customer_product_tolerance_master/tolerance_utils.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, Nirali and contributors
+# For license information, please see license.txt
+
+"""Weight-band selection for Customer Product Tolerance Master rows.
+
+A tolerance master holds several rows per dimension, each covering a different weight
+band -- e.g. "0-50 g at +/-7%" and "51-100 g at +/-5%". For any one product exactly ONE
+of those rows applies: the one whose band covers the BOM weight.
+
+Shared by Parent Manufacturing Order.on_submit, which stamps the chosen band onto the
+PMO, and by the Department IR transfer gate, which checks actual weights against it, so
+the two can never disagree about which master row is in force.
+
+The band convention is the app's existing one, lifted from
+``refining.doctype.refinery_price_list.refinery_price_list.pick_price_slab``: inclusive
+at both ends, ``to == 0`` means no upper bound, first covering row by document order
+wins. Live masters rely on all three -- PTM-MHCU0009-00001's top row is "from 50 / to 0"
+(and above), and PTM-MHCU0008-00001 has touching bands 3-5 and 5-10 where the first must
+win deterministically.
+
+Pure -- no DB access -- so it unit-tests without a site.
+"""
+
+from frappe.utils import flt
+
+NO_UPPER_BOUND = 1e12
+
+
+def covers(row, weight, from_field="from_weight", to_field="to_weight"):
+	"""True when ``row``'s band contains ``weight``.
+
+	A row with both bounds unset covers everything, which is how band-less rows such as
+	the diamond table's "Universal" type are expressed.
+	"""
+	upper = flt(row.get(to_field)) or NO_UPPER_BOUND
+	return flt(row.get(from_field)) <= flt(weight) <= upper
+
+
+def pick_tolerance_row(rows, weight, from_field="from_weight", to_field="to_weight"):
+	"""First row of ``rows`` whose band covers ``weight``, or ``None``.
+
+	Callers must handle ``None`` -- it means the master has a gap at this weight, which
+	is a master-data error rather than a "no tolerance applies" answer.
+	"""
+	for row in rows or []:
+		if covers(row, weight, from_field, to_field):
+			return row
+	return None
+
+
+def group_tolerance_rows(rows, key):
+	"""``{key(row): [rows]}`` preserving document order within and across groups.
+
+	The group key is everything about a row that is NOT its band, so each independent
+	dimension a master defines -- Gross vs Net, Gold vs Silver, one sieve size vs
+	another -- competes for its own single winner instead of all rows being applied at
+	once.
+	"""
+	groups = {}
+	for row in rows or []:
+		groups.setdefault(key(row), []).append(row)
+	return groups
+
+
+# Group keys, shared so Customer Product Tolerance Master.validate and the Parent
+# Manufacturing Order populators can never disagree about what constitutes one band
+# schedule. The key is everything about a row EXCEPT its band.
+
+
+def metal_group_key(row):
+	return (row.weight_type or "", row.metal_type or "")
+
+
+def diamond_group_key(row):
+	"""weight_type decides what the band is scoped to.
+
+	``Universal`` is the band-less catch-all over every diamond, so it scopes on nothing.
+	"""
+	if row.weight_type == "MM Size wise":
+		return (row.weight_type, row.diamond_type or "", row.sieve_size or "")
+	if row.weight_type == "Group Size wise":
+		return (row.weight_type, row.diamond_type or "", row.sieve_size_range or "")
+	if row.weight_type == "Universal":
+		return (row.weight_type, "", "")
+	return (row.weight_type or "", row.diamond_type or "", "")
+
+
+def gemstone_group_key(row):
+	if row.weight_type == "Weight Range":
+		return (row.weight_type, row.gemstone_shape or "")
+	if row.weight_type == "Gemstone Type Range":
+		return (row.weight_type, row.gemstone_type or "")
+	return (row.weight_type or "", "")

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/doc_events/product_tolerance.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/doc_events/product_tolerance.py
@@ -45,6 +45,15 @@ WEIGHT_PRECISION = 3
 # skipped rather than mis-compared against a total.
 TOTAL_WEIGHT_TYPES = {"Weight wise", "Universal"}
 
+# Columns that narrow a stone band to part of the product. set_diamond_tolerance_table
+# and set_gemstone_tolerance_table scope their BOM aggregate by these, so a band with
+# one set is a SUBTOTAL -- not comparable to the single total a Department IR row
+# carries, for the same reason the per-sieve weight types above are excluded.
+SCOPE_FIELDS = {
+	"diamond": ("diamond_type",),
+	"gemstone": ("gemstone_type", "gemstone_shape"),
+}
+
 _MWO_FIELDS = (
 	"name",
 	"manufacturing_order",
@@ -124,7 +133,13 @@ def get_tolerance_failures(doc, rows):
 		pmo_bands = bands.get(pmo) or {}
 		failures += _check_metal(doc, pmo, bucket, pmo_bands.get("metal") or [])
 		failures += _check_stone(
-			doc, pmo, bucket, pmo_bands.get("diamond") or [], "diamond_wt", _("Diamond")
+			doc,
+			pmo,
+			bucket,
+			pmo_bands.get("diamond") or [],
+			"diamond_wt",
+			_("Diamond"),
+			SCOPE_FIELDS["diamond"],
 		)
 		failures += _check_stone(
 			doc,
@@ -133,6 +148,7 @@ def get_tolerance_failures(doc, rows):
 			pmo_bands.get("gemstone") or [],
 			"gemstone_wt",
 			_("Gemstone"),
+			SCOPE_FIELDS["gemstone"],
 		)
 	return failures
 
@@ -208,10 +224,13 @@ def get_tolerance_bands(pmo_names):
 		]
 		if category == "metal":
 			fields.append("metal_type")
-		# Metal Product Tolerance only gained weight_type alongside this feature; guard
-		# the read so the module works on a site that has not migrated yet.
-		if frappe.get_meta(doctype).has_field("weight_type"):
-			fields.append("weight_type")
+		# weight_type on Metal Product Tolerance and diamond_type on Diamond Product
+		# Tolerance were both added alongside this feature; guard every optional read so
+		# the module still works on a site that has not migrated yet.
+		meta = frappe.get_meta(doctype)
+		for optional in ("weight_type",) + SCOPE_FIELDS.get(category, ()):
+			if meta.has_field(optional):
+				fields.append(optional)
 		for row in frappe.get_all(
 			doctype,
 			# parenttype matters: these child tables must not be read across parents.
@@ -320,14 +339,23 @@ def _check_bands(doc, pmo, bucket, candidates, label, uom, actual_for):
 	return failures
 
 
-def _check_stone(doc, pmo, bucket, band_rows, weight_field, label):
+def _check_stone(doc, pmo, bucket, band_rows, weight_field, label, scope_fields=()):
 	# Carats throughout: the bands are built from BOM detail quantities, which are carats,
 	# and so is Manufacturing Operation.diamond_wt / gemstone_wt. Never the _in_gram twins.
 	actual = flt(bucket.get(weight_field), WEIGHT_PRECISION)
 	if not actual:
 		return []
 
-	candidates = [b for b in band_rows if b.get("weight_type") in TOTAL_WEIGHT_TYPES]
+	# A band scoped to one diamond type, gemstone type or shape covers part of the
+	# product, while the operation reports one total across all of them. Comparing the
+	# two would judge a subtotal's limits against the whole -- skipped, as the per-sieve
+	# weight types already are. Only unscoped whole-product bands are enforceable here.
+	candidates = [
+		b
+		for b in band_rows
+		if b.get("weight_type") in TOTAL_WEIGHT_TYPES
+		and not any(b.get(field) for field in scope_fields)
+	]
 	if not candidates:
 		return []
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/doc_events/product_tolerance.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/doc_events/product_tolerance.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, Nirali and contributors
+# For license information, please see license.txt
+
+"""Block a Department IR Issue whose weight is outside the PMO's product tolerance.
+
+Armed per department: only when the ``next_department`` -- the one about to receive the
+work -- has ``custom_apply_product_tolerance`` ticked. The bands come from the Parent
+Manufacturing Order's own tolerance tables, stamped there at PMO submit from the
+customer's Customer Product Tolerance Master, so a later edit of that master cannot
+retroactively block work already in progress.
+
+Wired on ``validate`` rather than ``before_submit`` so the error lands the moment the
+Department IR is saved, not after the operator has assembled the whole document. Frappe
+runs ``validate`` on both save and submit, so one hook covers both.
+
+On the SAVE path ``before_validate`` runs first and resolves each row's weights via
+``validate_and_update_gross_wt_from_mop``, so the grid weights -- including its
+previous-MOP fallback -- are fresh. On the SUBMIT path they are not: that whole body is
+wrapped in ``if self.docstatus != 1`` (department_ir.py:29) and Frappe sets docstatus
+before the submit-save, so the check sees whatever was persisted at the last draft save.
+That is the intended trade -- it validates exactly the numbers shown in the grid and in
+get_summary_data -- but it does mean an operation whose weight changed between draft and
+submit is judged on the older figure.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint, flt
+
+from jewellery_erpnext.jewellery_erpnext.doctype.customer_product_tolerance_master.tolerance_utils import (
+	group_tolerance_rows,
+)
+
+# Manufacturing Operation declares its weight fields at precision 3 and the app pins
+# System Settings float_precision to 3, while the PMO bands are stored as round(x, 4).
+# Rounding BOTH sides to 3 before comparing means a float-noise boundary such as
+# 16.0500001 against a limit of 16.05 compares equal instead of throwing.
+WEIGHT_PRECISION = 3
+
+# Stone band types that describe a PRODUCT TOTAL, and so are comparable to the single
+# total a Department IR row carries. Both are stamped by set_diamond_tolerance_table's
+# else-branch, which aggregates the whole BOM detail table -- keep this set in step with
+# that branch. "MM Size wise" and "Group Size wise" are per-sieve subtotals and
+# "Weight Range" / "Gemstone Type Range" are per-shape / per-type subtotals; those are
+# skipped rather than mis-compared against a total.
+TOTAL_WEIGHT_TYPES = {"Weight wise", "Universal"}
+
+_MWO_FIELDS = (
+	"name",
+	"manufacturing_order",
+	"metal_type",
+	"is_finding_mwo",
+	"for_fg",
+	"qty",
+)
+
+
+def validate_product_tolerance(doc, method=None):
+	"""Refuse the transfer when a work order's weight is outside its tolerance band."""
+	if getattr(doc, "type", None) != "Issue":
+		# Receive-leg rows are clones carrying the same weights, and blocking a Receive
+		# would strand physical metal in the in-transit warehouse with no legal way out.
+		return
+	# Deliberately NOT gated on doc.is_finding. That field is
+	# fetch_from: next_department.custom_is_finding -- it describes the DESTINATION
+	# department, not the cargo, and Tagging / Final Polish / Central all carry the flag.
+	# Skipping on it would disable this check for exactly the departments where a
+	# product-level weight band is meaningful (34% of the Issues on the dev site, all of
+	# them the Final Polish -> Tagging hand-offs this feature exists for). Finding
+	# COMPONENTS are excluded precisely and per row by the is_finding_mwo test in
+	# bucket_rows_by_pmo, which is the right granularity.
+	rows = doc.get("department_ir_operation") or []
+	if not rows or not doc.next_department:
+		return
+
+	# get_cached_value, not db.get_value: db.get_value names the column in the SELECT and
+	# raises "Unknown column" on any site that has not got the custom field yet, which
+	# would break every Department IR submit. get_cached_value reads the whole doc and
+	# returns None for a missing field, so the feature degrades to "off".
+	if not cint(
+		frappe.get_cached_value(
+			"Department", doc.next_department, "custom_apply_product_tolerance"
+		)
+	):
+		return
+
+	failures = get_tolerance_failures(doc, rows)
+	if failures:
+		frappe.throw(title=_("Product Tolerance Exceeded"), msg="<br>".join(failures))
+
+
+def get_tolerance_failures(doc, rows):
+	"""Human-readable failure lines, empty when every work order is within tolerance.
+
+	Never throws, so it can be unit-tested and reused by a report.
+	"""
+	mwo_names = sorted(
+		{row.manufacturing_work_order for row in rows if row.manufacturing_work_order}
+	)
+	if not mwo_names:
+		return []
+
+	# Resolve the PMO from the Manufacturing Work Order rather than trusting
+	# row.parent_manufacturing_order: that is a two-hop fetch_from chain
+	# (manufacturing_operation -> manufacturing_work_order -> manufacturing_order) which
+	# is not guaranteed to have resolved by the time this validation runs.
+	mwo_map = {
+		mwo.name: mwo
+		for mwo in frappe.get_all(
+			"Manufacturing Work Order",
+			filters={"name": ["in", mwo_names]},
+			fields=list(_MWO_FIELDS),
+		)
+	}
+
+	buckets = bucket_rows_by_pmo(rows, mwo_map)
+	if not buckets:
+		return []
+
+	bands = get_tolerance_bands(list(buckets))
+
+	failures = []
+	for pmo, bucket in buckets.items():
+		pmo_bands = bands.get(pmo) or {}
+		failures += _check_metal(doc, pmo, bucket, pmo_bands.get("metal") or [])
+		failures += _check_stone(
+			doc, pmo, bucket, pmo_bands.get("diamond") or [], "diamond_wt", _("Diamond")
+		)
+		failures += _check_stone(
+			doc,
+			pmo,
+			bucket,
+			pmo_bands.get("gemstone") or [],
+			"gemstone_wt",
+			_("Gemstone"),
+		)
+	return failures
+
+
+def bucket_rows_by_pmo(rows, mwo_map):
+	"""Sum the Department IR rows of each Parent Manufacturing Order into one bucket.
+
+	create_manufacturing_work_order mints one MWO per BOM Metal Detail row, so a
+	two-metal design has two producing work orders that together make one product. The
+	tolerance band describes the finished product, so the rows must be summed before
+	being compared to it.
+	"""
+	grouped = {}
+	for row in rows:
+		mwo = mwo_map.get(row.manufacturing_work_order)
+		if not mwo or cint(mwo.is_finding_mwo):
+			continue
+		pmo = mwo.manufacturing_order or row.get("parent_manufacturing_order")
+		if pmo:
+			grouped.setdefault(pmo, []).append((row, mwo))
+
+	buckets = {}
+	for pmo, pairs in grouped.items():
+		# sync_mwo_weights re-aggregates every sibling MWO onto the FG MWO when the work
+		# reaches Tagging, so counting both the FG row and its producing rows would
+		# double the product weight. Keep the producing rows when any are present; an
+		# Issue carrying only the FG MWO keeps it, which is right because it then IS the
+		# whole product.
+		if any(not cint(mwo.for_fg) for _row, mwo in pairs):
+			pairs = [(row, mwo) for row, mwo in pairs if not cint(mwo.for_fg)]
+
+		bucket = frappe._dict(
+			gross_wt=0.0,
+			net_wt=0.0,
+			finding_wt=0.0,
+			diamond_wt=0.0,
+			gemstone_wt=0.0,
+			metal_types=set(),
+			mops=[],
+			mwos=[],
+			qty=1,
+		)
+		for row, mwo in pairs:
+			bucket.gross_wt += flt(row.gross_wt)
+			bucket.net_wt += flt(row.net_wt)
+			bucket.finding_wt += flt(row.finding_wt)
+			bucket.diamond_wt += flt(row.diamond_wt)
+			bucket.gemstone_wt += flt(row.gemstone_wt)
+			if mwo.metal_type:
+				bucket.metal_types.add(mwo.metal_type)
+			if row.manufacturing_operation:
+				bucket.mops.append(row.manufacturing_operation)
+			bucket.mwos.append(mwo.name)
+			bucket.qty = max(bucket.qty, cint(mwo.qty) or 1)
+		buckets[pmo] = bucket
+	return buckets
+
+
+def get_tolerance_bands(pmo_names):
+	"""``{pmo: {"metal"|"diamond"|"gemstone": [band rows]}}`` in three batched reads."""
+	doctypes = {
+		"metal": "Metal Product Tolerance",
+		"diamond": "Diamond Product Tolerance",
+		"gemstone": "Gemstone Product Tolerance",
+	}
+	bands = {}
+	for category, doctype in doctypes.items():
+		fields = [
+			"parent",
+			"from_tolerance_wt",
+			"to_tolerance_wt",
+			"standard_tolerance_wt",
+		]
+		if category == "metal":
+			fields.append("metal_type")
+		# Metal Product Tolerance only gained weight_type alongside this feature; guard
+		# the read so the module works on a site that has not migrated yet.
+		if frappe.get_meta(doctype).has_field("weight_type"):
+			fields.append("weight_type")
+		for row in frappe.get_all(
+			doctype,
+			# parenttype matters: these child tables must not be read across parents.
+			filters={
+				"parent": ["in", pmo_names],
+				"parenttype": "Parent Manufacturing Order",
+			},
+			fields=fields,
+		):
+			bands.setdefault(row.parent, {}).setdefault(category, []).append(row)
+	return bands
+
+
+def _scaled_band(band, qty):
+	"""The stored band is per piece; a Department IR row covers the whole work order."""
+	factor = cint(qty) or 1
+	return (
+		flt(flt(band.get("from_tolerance_wt")) * factor, WEIGHT_PRECISION),
+		flt(flt(band.get("to_tolerance_wt")) * factor, WEIGHT_PRECISION),
+	)
+
+
+def _metal_actual(bucket, band):
+	"""The weight a metal band should be compared against.
+
+	A "Net Weight" band is built from the BOM's metal_and_finding_weight, whereas
+	Manufacturing Operation.net_wt is metal ONLY -- mop_log.update_wt_detail keeps
+	findings in their own bucket. So the counterpart of a Net band is net + finding, not
+	net. A blank weight_type means a legacy row written before the field existed; the
+	populator's own fallback for anything that is not "Gross Weight" was the net basis,
+	so blank reads as Net.
+	"""
+	if (band.get("weight_type") or "Net Weight") == "Gross Weight":
+		return flt(bucket.gross_wt)
+	return flt(bucket.net_wt) + flt(bucket.finding_wt)
+
+
+def _nearest_miss(misses):
+	"""The band whose edge is closest to the actual -- the one they were aiming at."""
+	return min(misses, key=lambda m: min(abs(m[0] - m[1]), abs(m[0] - m[2])))
+
+
+def _check_metal(doc, pmo, bucket, band_rows):
+	if not band_rows:
+		return []
+	# Zero is not a violation: a refined MWO legitimately arrives at zero because the
+	# Refining Entry moved the metal out, and so does a finding whose stock was consumed.
+	# Keying on the weight rather than on is_mwo_refined avoids permanently un-gating any
+	# work order that was ever refined.
+	if not flt(bucket.gross_wt, WEIGHT_PRECISION) and not flt(
+		bucket.net_wt, WEIGHT_PRECISION
+	):
+		return []
+
+	# Narrow to this order's metal; fall back to universal (blank metal_type) rows.
+	candidates = [b for b in band_rows if b.get("metal_type") in bucket.metal_types]
+	if not candidates:
+		candidates = [b for b in band_rows if not b.get("metal_type")]
+	if not candidates:
+		# The PMO carries bands, but none for this order's metal and no universal row.
+		# A Gold-only schedule must not be used to police a Platinum work order --
+		# falling back to every band would reject a legitimate transfer against a limit
+		# that was never meant to apply to it.
+		return []
+
+	return _check_bands(doc, pmo, bucket, candidates, _("Metal"), _("g"), _metal_actual)
+
+
+def _check_bands(doc, pmo, bucket, candidates, label, uom, actual_for):
+	"""One verdict per weight_type, not one for the whole set.
+
+	Gross and Net bands measure different things, so a work order that is inside its Net
+	band tells you nothing about whether it is inside its Gross band -- checking them as
+	one pool would let a gross overrun ride through on a passing net figure. Within a
+	single weight_type, being inside ANY band still passes: PMOs stamped before this
+	feature carry a whole schedule rather than the one applicable row, and that fails
+	open on legacy data rather than blocking real work on it.
+	"""
+	failures = []
+	for weight_type, group in group_tolerance_rows(
+		candidates, lambda band: band.get("weight_type") or ""
+	).items():
+		misses = []
+		for band in group:
+			actual = flt(actual_for(bucket, band), WEIGHT_PRECISION)
+			lower, upper = _scaled_band(band, bucket.qty)
+			if lower <= actual <= upper:
+				misses = []
+				break
+			misses.append((actual, lower, upper))
+
+		if misses:
+			actual, lower, upper = _nearest_miss(misses)
+			failures.append(
+				_failure_line(
+					doc,
+					pmo,
+					bucket,
+					"{0} ({1})".format(label, weight_type) if weight_type else label,
+					actual,
+					lower,
+					upper,
+					uom,
+				)
+			)
+	return failures
+
+
+def _check_stone(doc, pmo, bucket, band_rows, weight_field, label):
+	# Carats throughout: the bands are built from BOM detail quantities, which are carats,
+	# and so is Manufacturing Operation.diamond_wt / gemstone_wt. Never the _in_gram twins.
+	actual = flt(bucket.get(weight_field), WEIGHT_PRECISION)
+	if not actual:
+		return []
+
+	candidates = [b for b in band_rows if b.get("weight_type") in TOTAL_WEIGHT_TYPES]
+	if not candidates:
+		return []
+
+	return _check_bands(
+		doc, pmo, bucket, candidates, label, _("cts"), lambda _bucket, _band: actual
+	)
+
+
+def _failure_line(doc, pmo, bucket, label, actual, lower, upper, uom):
+	return _(
+		"{pmo} (Work Order {mwo}, Operation {mop}): {label} is <b>{actual} {uom}</b>, "
+		"outside the product tolerance required by department {dept} — allowed "
+		"<b>{lower} {uom}</b> to <b>{upper} {uom}</b>."
+	).format(
+		pmo=frappe.bold(pmo),
+		mwo=", ".join(sorted(set(bucket.mwos))),
+		mop=", ".join(sorted(set(bucket.mops))) or _("n/a"),
+		label=label,
+		actual=flt(actual, WEIGHT_PRECISION),
+		lower=flt(lower, WEIGHT_PRECISION),
+		upper=flt(upper, WEIGHT_PRECISION),
+		dept=frappe.bold(doc.next_department),
+		uom=uom,
+	)

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/test_department_ir.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/test_department_ir.py
@@ -816,3 +816,90 @@ class TestProductToleranceBandSelection(UnitTestCase):
 		)
 		self.assertEqual(len(failures), 1)
 		self.assertIn("cts", failures[0])
+
+
+class TestScopedStoneBandsAreNotEnforced(UnitTestCase):
+	"""A type- or shape-scoped stone band is a subtotal; the row carries a total."""
+
+	def _failures(self, rows, mwos, bands):
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=0,
+			next_department="Tagging - T",
+			current_department="Final Polish - T",
+			department_ir_operation=rows,
+		)
+		with patch(
+			f"{_TOL_MODULE}.frappe.get_all",
+			side_effect=lambda doctype, **kw: mwos
+			if doctype == "Manufacturing Work Order"
+			else bands.get(doctype, []),
+		), patch(f"{_TOL_MODULE}.frappe.get_meta") as meta:
+			meta.return_value.has_field.return_value = True
+			return get_tolerance_failures(doc, rows)
+
+	def _diamond(self, **kwargs):
+		band = FrappeDict(
+			parent="PMO-0001",
+			weight_type="Weight wise",
+			diamond_type=None,
+			from_tolerance_wt=2.0,
+			to_tolerance_wt=2.2,
+			standard_tolerance_wt=2.1,
+		)
+		band.update(kwargs)
+		return band
+
+	def test_type_scoped_diamond_band_is_not_enforced(self):
+		failures = self._failures(
+			[_dir_row(diamond_wt=9.9)],
+			[_mwo()],
+			{"Diamond Product Tolerance": [self._diamond(diamond_type="Natural")]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_unscoped_diamond_band_is_still_enforced(self):
+		failures = self._failures(
+			[_dir_row(diamond_wt=9.9)],
+			[_mwo()],
+			{"Diamond Product Tolerance": [self._diamond()]},
+		)
+		self.assertEqual(len(failures), 1)
+
+	def test_scoped_band_does_not_mask_an_unscoped_one(self):
+		"""A loose type-scoped band must not excuse a breach of the whole-product band."""
+		failures = self._failures(
+			[_dir_row(diamond_wt=9.9)],
+			[_mwo()],
+			{
+				"Diamond Product Tolerance": [
+					self._diamond(
+						diamond_type="Natural",
+						from_tolerance_wt=0.0,
+						to_tolerance_wt=100.0,
+					),
+					self._diamond(),
+				]
+			},
+		)
+		self.assertEqual(len(failures), 1)
+
+	def test_type_scoped_gemstone_band_is_not_enforced(self):
+		failures = self._failures(
+			[_dir_row(gemstone_wt=9.9)],
+			[_mwo()],
+			{
+				"Gemstone Product Tolerance": [
+					FrappeDict(
+						parent="PMO-0001",
+						weight_type="Weight wise",
+						gemstone_type="Ruby",
+						gemstone_shape=None,
+						from_tolerance_wt=2.0,
+						to_tolerance_wt=2.2,
+						standard_tolerance_wt=2.1,
+					)
+				]
+			},
+		)
+		self.assertEqual(failures, [])

--- a/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/test_department_ir.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/department_ir/test_department_ir.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.types.frappedict import _dict as FrappeDict
 
 from jewellery_erpnext.jewellery_erpnext.doctype.department_ir.department_ir import (
@@ -12,6 +12,10 @@ from jewellery_erpnext.jewellery_erpnext.doctype.department_ir.department_ir imp
 	department_receive_query,
 	fetch_and_update,
 	get_manufacturing_operations,
+)
+from jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.product_tolerance import (
+	get_tolerance_failures,
+	validate_product_tolerance,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.test_manufacturing_operation import (
 	dir_for_issue,
@@ -384,3 +388,431 @@ def mo_creation():
 	mo.save()
 
 	return mo
+
+
+_TOL_MODULE = "jewellery_erpnext.jewellery_erpnext.doctype.department_ir.doc_events.product_tolerance"
+
+
+def _dir_row(**kwargs):
+	row = FrappeDict(
+		manufacturing_operation="MOP-0001",
+		manufacturing_work_order="MWO-0001",
+		gross_wt=0.0,
+		net_wt=0.0,
+		finding_wt=0.0,
+		diamond_wt=0.0,
+		gemstone_wt=0.0,
+	)
+	row.update(kwargs)
+	return row
+
+
+def _mwo(**kwargs):
+	mwo = FrappeDict(
+		name="MWO-0001",
+		manufacturing_order="PMO-0001",
+		metal_type="Gold",
+		is_finding_mwo=0,
+		for_fg=0,
+		qty=1,
+	)
+	mwo.update(kwargs)
+	return mwo
+
+
+def _metal_band(**kwargs):
+	band = FrappeDict(
+		parent="PMO-0001",
+		metal_type="Gold",
+		weight_type="Net Weight",
+		from_tolerance_wt=13.95,
+		to_tolerance_wt=16.05,
+		standard_tolerance_wt=15.0,
+	)
+	band.update(kwargs)
+	return band
+
+
+class TestProductToleranceGate(UnitTestCase):
+	"""Department IR Issue is refused when the weight leaves the PMO's band."""
+
+	def _failures(self, rows, mwos, bands, dept="Tagging - T"):
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=0,
+			next_department=dept,
+			current_department="Final Polish - T",
+			department_ir_operation=rows,
+		)
+		with patch(
+			f"{_TOL_MODULE}.frappe.get_all",
+			side_effect=lambda doctype, **kw: mwos
+			if doctype == "Manufacturing Work Order"
+			else bands.get(doctype, []),
+		), patch(f"{_TOL_MODULE}.frappe.get_meta") as meta:
+			meta.return_value.has_field.return_value = True
+			return get_tolerance_failures(doc, rows)
+
+	def _validate(self, doc, flag=1):
+		with patch(
+			f"{_TOL_MODULE}.frappe.get_cached_value", return_value=flag
+		) as cached:
+			with patch(
+				f"{_TOL_MODULE}.get_tolerance_failures", return_value=[]
+			) as calc:
+				validate_product_tolerance(doc)
+		return cached, calc
+
+	# ---- gating ----
+
+	def test_receive_leg_is_never_checked(self):
+		doc = FrappeDict(
+			type="Receive",
+			is_finding=0,
+			next_department=None,
+			department_ir_operation=[_dir_row()],
+		)
+		cached, calc = self._validate(doc)
+		cached.assert_not_called()
+		calc.assert_not_called()
+
+	def test_finding_department_is_still_checked(self):
+		"""is_finding is fetched from next_department.custom_is_finding.
+
+		Tagging, Final Polish and Central all carry that flag, so treating it as
+		"this transfer is a finding run" would switch the check off for exactly the
+		hand-offs it exists to guard.
+		"""
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=1,
+			next_department="Tagging - T",
+			department_ir_operation=[_dir_row()],
+		)
+		cached, calc = self._validate(doc)
+		cached.assert_called_once()
+		calc.assert_called_once()
+
+	def test_unflagged_department_issues_no_tolerance_query(self):
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=0,
+			next_department="Tagging - T",
+			department_ir_operation=[_dir_row()],
+		)
+		_cached, calc = self._validate(doc, flag=0)
+		calc.assert_not_called()
+
+	def test_missing_custom_field_degrades_to_off(self):
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=0,
+			next_department="Tagging - T",
+			department_ir_operation=[_dir_row()],
+		)
+		_cached, calc = self._validate(doc, flag=None)
+		calc.assert_not_called()
+
+	# ---- boundaries ----
+
+	def test_weight_above_band_fails_with_a_named_message(self):
+		failures = self._failures(
+			[_dir_row(net_wt=16.9)],
+			[_mwo()],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(len(failures), 1)
+		for token in (
+			"PMO-0001",
+			"MWO-0001",
+			"MOP-0001",
+			"Tagging - T",
+			"16.9",
+			"13.95",
+			"16.05",
+		):
+			self.assertIn(token, failures[0])
+
+	def test_weight_below_band_fails(self):
+		failures = self._failures(
+			[_dir_row(net_wt=13.0)],
+			[_mwo()],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(len(failures), 1)
+
+	def test_float_noise_at_the_boundary_passes(self):
+		failures = self._failures(
+			[_dir_row(net_wt=16.0500001)],
+			[_mwo()],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_exact_bounds_pass(self):
+		for weight in (13.95, 16.05):
+			self.assertEqual(
+				self._failures(
+					[_dir_row(net_wt=weight)],
+					[_mwo()],
+					{"Metal Product Tolerance": [_metal_band()]},
+				),
+				[],
+			)
+
+	def test_net_band_compares_net_plus_finding(self):
+		"""MOP net_wt is metal only; the band's source includes findings."""
+		failures = self._failures(
+			[_dir_row(net_wt=15.0, finding_wt=2.0)],
+			[_mwo()],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(len(failures), 1)
+
+	def test_gross_band_compares_gross(self):
+		failures = self._failures(
+			[_dir_row(gross_wt=15.0, net_wt=99.0)],
+			[_mwo()],
+			{"Metal Product Tolerance": [_metal_band(weight_type="Gross Weight")]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_zero_weight_is_not_a_violation(self):
+		failures = self._failures(
+			[_dir_row()], [_mwo()], {"Metal Product Tolerance": [_metal_band()]}
+		)
+		self.assertEqual(failures, [])
+
+	def test_pmo_without_bands_passes(self):
+		failures = self._failures([_dir_row(net_wt=999.0)], [_mwo()], {})
+		self.assertEqual(failures, [])
+
+	# ---- selection and bucketing ----
+
+	def test_band_for_another_metal_is_ignored(self):
+		failures = self._failures(
+			[_dir_row(net_wt=16.9)],
+			[_mwo(metal_type="Gold")],
+			{
+				"Metal Product Tolerance": [
+					_metal_band(metal_type="Gold"),
+					_metal_band(
+						metal_type="Silver", from_tolerance_wt=0, to_tolerance_wt=100
+					),
+				]
+			},
+		)
+		self.assertEqual(len(failures), 1)
+
+	def test_producing_work_orders_of_one_pmo_are_summed(self):
+		failures = self._failures(
+			[
+				_dir_row(
+					manufacturing_work_order="MWO-A",
+					manufacturing_operation="MOP-A",
+					net_wt=8.0,
+				),
+				_dir_row(
+					manufacturing_work_order="MWO-B",
+					manufacturing_operation="MOP-B",
+					net_wt=7.0,
+				),
+			],
+			[_mwo(name="MWO-A"), _mwo(name="MWO-B")],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_fg_row_is_dropped_when_producing_rows_are_present(self):
+		failures = self._failures(
+			[
+				_dir_row(manufacturing_work_order="MWO-A", net_wt=15.0),
+				_dir_row(manufacturing_work_order="MWO-FG", net_wt=15.0),
+			],
+			[_mwo(name="MWO-A"), _mwo(name="MWO-FG", for_fg=1)],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_finding_work_orders_are_excluded(self):
+		failures = self._failures(
+			[_dir_row(net_wt=999.0)],
+			[_mwo(is_finding_mwo=1)],
+			{"Metal Product Tolerance": [_metal_band()]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_band_is_scaled_by_quantity(self):
+		self.assertEqual(
+			self._failures(
+				[_dir_row(net_wt=45.0)],
+				[_mwo(qty=3)],
+				{"Metal Product Tolerance": [_metal_band()]},
+			),
+			[],
+		)
+		self.assertEqual(
+			len(
+				self._failures(
+					[_dir_row(net_wt=15.0)],
+					[_mwo(qty=3)],
+					{"Metal Product Tolerance": [_metal_band()]},
+				)
+			),
+			1,
+		)
+
+	# ---- stones ----
+
+	def test_diamond_band_is_checked_in_carats(self):
+		failures = self._failures(
+			[_dir_row(diamond_wt=2.5)],
+			[_mwo()],
+			{
+				"Diamond Product Tolerance": [
+					FrappeDict(
+						parent="PMO-0001",
+						weight_type="Weight wise",
+						from_tolerance_wt=2.0,
+						to_tolerance_wt=2.2,
+						standard_tolerance_wt=2.1,
+					)
+				]
+			},
+		)
+		self.assertEqual(len(failures), 1)
+		self.assertIn("cts", failures[0])
+
+	def test_per_sieve_diamond_bands_are_not_compared_to_a_total(self):
+		failures = self._failures(
+			[_dir_row(diamond_wt=9.9)],
+			[_mwo()],
+			{
+				"Diamond Product Tolerance": [
+					FrappeDict(
+						parent="PMO-0001",
+						weight_type="MM Size wise",
+						from_tolerance_wt=2.0,
+						to_tolerance_wt=2.2,
+						standard_tolerance_wt=2.1,
+					)
+				]
+			},
+		)
+		self.assertEqual(failures, [])
+
+	def test_several_failures_are_reported_together(self):
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=0,
+			next_department="Tagging - T",
+			department_ir_operation=[],
+		)
+		with patch(f"{_TOL_MODULE}.frappe.get_cached_value", return_value=1), patch(
+			f"{_TOL_MODULE}.get_tolerance_failures", return_value=["first", "second"]
+		):
+			doc.department_ir_operation = [_dir_row()]
+			with self.assertRaises(frappe.ValidationError):
+				validate_product_tolerance(doc)
+
+
+class TestProductToleranceBandSelection(UnitTestCase):
+	"""Regressions found by review: each weight basis must be judged on its own."""
+
+	def _failures(self, rows, mwos, bands):
+		doc = FrappeDict(
+			type="Issue",
+			is_finding=0,
+			next_department="Tagging - T",
+			current_department="Final Polish - T",
+			department_ir_operation=rows,
+		)
+		with patch(
+			f"{_TOL_MODULE}.frappe.get_all",
+			side_effect=lambda doctype, **kw: mwos
+			if doctype == "Manufacturing Work Order"
+			else bands.get(doctype, []),
+		), patch(f"{_TOL_MODULE}.frappe.get_meta") as meta:
+			meta.return_value.has_field.return_value = True
+			return get_tolerance_failures(doc, rows)
+
+	def test_passing_net_band_does_not_excuse_a_gross_overrun(self):
+		"""Gross and Net measure different things and are judged separately."""
+		failures = self._failures(
+			[_dir_row(gross_wt=30.0, net_wt=15.0)],
+			[_mwo()],
+			{
+				"Metal Product Tolerance": [
+					_metal_band(weight_type="Net Weight"),
+					_metal_band(
+						weight_type="Gross Weight",
+						from_tolerance_wt=19.8,
+						to_tolerance_wt=22.0,
+					),
+				]
+			},
+		)
+		self.assertEqual(len(failures), 1)
+		self.assertIn("Gross Weight", failures[0])
+		self.assertIn("30.0", failures[0])
+
+	def test_both_bases_can_fail_at_once(self):
+		failures = self._failures(
+			[_dir_row(gross_wt=30.0, net_wt=99.0)],
+			[_mwo()],
+			{
+				"Metal Product Tolerance": [
+					_metal_band(weight_type="Net Weight"),
+					_metal_band(
+						weight_type="Gross Weight",
+						from_tolerance_wt=19.8,
+						to_tolerance_wt=22.0,
+					),
+				]
+			},
+		)
+		self.assertEqual(len(failures), 2)
+
+	def test_duplicate_bands_of_one_basis_still_fail_open(self):
+		"""Legacy PMOs carry a whole schedule for one basis; any match passes."""
+		failures = self._failures(
+			[_dir_row(net_wt=15.0)],
+			[_mwo()],
+			{
+				"Metal Product Tolerance": [
+					_metal_band(from_tolerance_wt=1.0, to_tolerance_wt=2.0),
+					_metal_band(),
+				]
+			},
+		)
+		self.assertEqual(failures, [])
+
+	def test_foreign_metal_band_is_not_applied(self):
+		"""A Gold-only schedule must not police a Platinum work order."""
+		failures = self._failures(
+			[_dir_row(net_wt=40.0)],
+			[_mwo(metal_type="Platinum")],
+			{"Metal Product Tolerance": [_metal_band(metal_type="Gold")]},
+		)
+		self.assertEqual(failures, [])
+
+	def test_universal_diamond_band_is_enforced(self):
+		"""set_diamond_tolerance_table stamps Universal from the whole BOM aggregate,
+		so it is a product total and must be compared like one."""
+		failures = self._failures(
+			[_dir_row(diamond_wt=9.9)],
+			[_mwo()],
+			{
+				"Diamond Product Tolerance": [
+					FrappeDict(
+						parent="PMO-0001",
+						weight_type="Universal",
+						from_tolerance_wt=2.0,
+						to_tolerance_wt=2.2,
+						standard_tolerance_wt=2.1,
+					)
+				]
+			},
+		)
+		self.assertEqual(len(failures), 1)
+		self.assertIn("cts", failures[0])

--- a/jewellery_erpnext/jewellery_erpnext/doctype/diamond_product_tolerance/diamond_product_tolerance.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/diamond_product_tolerance/diamond_product_tolerance.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "weight_type",
+  "diamond_type",
   "sieve_size",
   "sieve_size_range",
   "size_in_mm",
@@ -70,12 +71,20 @@
    "fieldname": "size_in_mm",
    "fieldtype": "Float",
    "label": "Size In MM"
+  },
+  {
+   "description": "Set when the band applies to one diamond type only",
+   "fieldname": "diamond_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Diamond Type",
+   "options": "Attribute Value"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-12-28 12:08:32.164488",
+ "modified": "2026-08-03 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Jewellery Erpnext",
  "name": "Diamond Product Tolerance",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/metal_product_tolerance/metal_product_tolerance.json
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/metal_product_tolerance/metal_product_tolerance.json
@@ -6,13 +6,38 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "weight_type",
   "metal_type",
+  "from_weight",
+  "to_weight",
   "from_tolerance_wt",
   "to_tolerance_wt",
   "standard_tolerance_wt",
   "product_wt"
  ],
  "fields": [
+  {
+   "description": "Gross Weight or Net Weight -- which BOM weight this band was built from",
+   "fieldname": "weight_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Weight Type",
+   "options": "Tolerance Weight Type"
+  },
+  {
+   "description": "Source band From Weight on the Customer Product Tolerance Master",
+   "fieldname": "from_weight",
+   "fieldtype": "Float",
+   "label": "From Weight",
+   "read_only": 1
+  },
+  {
+   "description": "Source band To Weight on the Customer Product Tolerance Master (0 = no upper bound)",
+   "fieldname": "to_weight",
+   "fieldtype": "Float",
+   "label": "To Weight",
+   "read_only": 1
+  },
   {
    "description": "Default BOM Minus(-) Tolerance Wt",
    "fieldname": "from_tolerance_wt",
@@ -52,7 +77,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-12-27 19:59:59.743997",
+ "modified": "2026-08-03 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Jewellery Erpnext",
  "name": "Metal Product Tolerance",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.py
@@ -7,9 +7,16 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder.functions import Max
-from frappe.utils import get_link_to_form
+from frappe.utils import flt, get_link_to_form
 
 from jewellery_erpnext.jewellery_erpnext.doc_events.bom import set_item_variant
+from jewellery_erpnext.jewellery_erpnext.doctype.customer_product_tolerance_master.tolerance_utils import (
+	diamond_group_key,
+	gemstone_group_key,
+	group_tolerance_rows,
+	metal_group_key,
+	pick_tolerance_row,
+)
 from jewellery_erpnext.jewellery_erpnext.doctype.mould.doc_events.utils import (
 	get_current_mould_id,
 )
@@ -374,9 +381,18 @@ class ParentManufacturingOrder(Document):
 
 	def on_submit(self):
 		if not self.order_form_type or self.order_form_type == "Order":
-			set_metal_tolerance_table(self)
-			set_diamond_tolerance_table(self)
-			# set_gemstone_tolerance_table(self)
+			# One update_after_submit cycle for all three tolerance tables instead of one
+			# per populator, and none at all for a customer with no tolerance master --
+			# the populators return False in that case, matching the old behaviour where
+			# they returned before ever reaching their own save(). Must stay ahead of
+			# submit_bom / create_material_requests / create_manufacturing_work_order:
+			# those db.set_value the PMO row, so a save() after them would raise
+			# TimestampMismatchError.
+			touched = set_metal_tolerance_table(self)
+			touched = set_diamond_tolerance_table(self) or touched
+			# touched = set_gemstone_tolerance_table(self) or touched
+			if touched:
+				self.save()
 			self.submit_bom()
 			if self.type != "Finding Manufacturing":
 				self.create_material_requests()
@@ -1021,297 +1037,239 @@ def gemstone_details_set_mandatory_field(self):
 		frappe.throw("<br>".join(errors))
 
 
-def set_metal_tolerance_table(self):
-	cpt = frappe.db.get_value(
-		"Customer Product Tolerance Master", {"customer_name": self.customer}, "name"
+def _get_tolerance_master(customer):
+	"""Name of the Customer Product Tolerance Master for ``customer``, or None."""
+	return frappe.db.get_value(
+		"Customer Product Tolerance Master", {"customer_name": customer}, "name"
 	)
+
+
+def _throw_no_band(cptm_name, category, group_label, weight):
+	"""No master row's From/To band covers ``weight``.
+
+	This is master-data breakage, not "no tolerance applies": the operator has entered
+	bands that leave this weight in a gap, so silently skipping would ship an order with
+	no tolerance at all. Name the master, the group and the weight so the gap can be
+	closed. Customer Product Tolerance Master.validate refuses new overlapping bands, so
+	in practice this fires on gaps left by historic data.
+	"""
+	frappe.throw(
+		_(
+			"{0}: no tolerance band covers a weight of <b>{1}</b> for {2} in Customer "
+			"Product Tolerance Master {3}. Add or correct the From/To band so this "
+			"weight falls inside one."
+		).format(
+			category,
+			weight,
+			group_label,
+			get_link_to_form("Customer Product Tolerance Master", cptm_name),
+		),
+		title=_("Product Tolerance Band Missing"),
+	)
+
+
+def _group_label(*parts):
+	"""Human-readable name for a tolerance group, e.g. "Net Weight / Gold"."""
+	return " / ".join([str(part) for part in parts if part]) or _("all rows")
+
+
+def _percent_bounds(base, minus_percent, plus_percent):
+	return (
+		round(base * ((100 - flt(minus_percent)) / 100), 4),
+		round(base * ((100 + flt(plus_percent)) / 100), 4),
+	)
+
+
+def set_metal_tolerance_table(self):
+	cpt = _get_tolerance_master(self.customer)
 	if not cpt:
-		return
+		return False
 	cptm = frappe.get_doc("Customer Product Tolerance Master", cpt)
 	bom = self.custom_tracking_bom
 	if not bom:
 		frappe.throw(_("BOM is missing"))
 	bom_doc = frappe.get_doc("Tracking Bom", bom)
-	if cptm.metal_tolerance_table:
-		for mtt_tbl in cptm.metal_tolerance_table:
-			bom_gross_wt = (
-				bom_doc.gross_weight
-				if mtt_tbl.weight_type == "Gross Weight"
-				else bom_doc.metal_and_finding_weight
-			)
-			if mtt_tbl.range_type == "Weight Range":
-				from_tolerance_wt = round(bom_gross_wt - mtt_tbl.tolerance_range, 4)
-				to_tolerance_wt = round(bom_gross_wt + mtt_tbl.tolerance_range, 4)
-			else:
-				from_tolerance_wt = round(
-					bom_gross_wt * ((100 - mtt_tbl.minus_percent) / 100), 4
-				)
-				to_tolerance_wt = round(
-					bom_gross_wt * ((100 + mtt_tbl.plus_percent) / 100), 4
-				)
 
-			child_row = {
-				"doctype": "Metal Product Tolerance",
-				"parent": self.name,
-				"parenttype": self.doctype,
-				"parentfield": "metal_product_tolerance",
+	# Rebuilt from scratch on every run. The table carries no no_copy, so an amended PMO
+	# arrives holding the previous document's rows and would otherwise accumulate a
+	# second full set on submit.
+	self.set("metal_product_tolerance", [])
+
+	# One winner per (weight_type, metal_type): a master legitimately defines Gross AND
+	# Net bands, or Gold AND Silver bands, and each dimension picks its own row. Within a
+	# group the rows are weight bands and exactly one covers the BOM weight.
+	groups = group_tolerance_rows(cptm.metal_tolerance_table or [], metal_group_key)
+	for (weight_type, metal_type), rows in groups.items():
+		bom_gross_wt = flt(
+			bom_doc.gross_weight
+			if weight_type == "Gross Weight"
+			else bom_doc.metal_and_finding_weight
+		)
+		mtt_tbl = pick_tolerance_row(rows, bom_gross_wt)
+		if not mtt_tbl:
+			_throw_no_band(
+				cpt, _("Metal"), _group_label(weight_type, metal_type), bom_gross_wt
+			)
+
+		if mtt_tbl.range_type == "Weight Range":
+			from_tolerance_wt = round(bom_gross_wt - flt(mtt_tbl.tolerance_range), 4)
+			to_tolerance_wt = round(bom_gross_wt + flt(mtt_tbl.tolerance_range), 4)
+		else:
+			from_tolerance_wt, to_tolerance_wt = _percent_bounds(
+				bom_gross_wt, mtt_tbl.minus_percent, mtt_tbl.plus_percent
+			)
+
+		self.append(
+			"metal_product_tolerance",
+			{
+				"weight_type": weight_type or None,
 				"metal_type": mtt_tbl.metal_type,
+				"from_weight": flt(mtt_tbl.from_weight),
+				"to_weight": flt(mtt_tbl.to_weight),
 				"from_tolerance_wt": from_tolerance_wt,
 				"to_tolerance_wt": to_tolerance_wt,
 				"standard_tolerance_wt": round(bom_gross_wt, 4),
-				"product_wt": self.gross_weight
-				if mtt_tbl.weight_type == "Gross Weight"
-				else self.net_weight,
-			}
-			try:
-				self.append("metal_product_tolerance", child_row)
-			except Exception as e:
-				frappe.throw(
-					f"Error appending <b>Metal Product Tolerance Table</b> Please check <b>Customer Product Tolerance Master</b> Doctype Correctly configured or not:</br></br> {str(e)}"
-				)
-	self.save()
+				"product_wt": flt(
+					self.gross_weight
+					if weight_type == "Gross Weight"
+					else self.net_weight
+				),
+			},
+		)
+	return True
 
 
 def set_diamond_tolerance_table(self):
-	cpt = frappe.db.get_value(
-		"Customer Product Tolerance Master", {"customer_name": self.customer}, "name"
-	)
+	cpt = _get_tolerance_master(self.customer)
 	if not cpt:
-		return
+		return False
 	cptm = frappe.get_doc("Customer Product Tolerance Master", cpt)
 	bom = self.custom_tracking_bom
 	if not bom:
 		frappe.throw(_("BOM is missing"))
 	bom_doc = frappe.get_doc("Tracking Bom", bom)
-	if cptm.diamond_tolerance_table:
-		for dtt_tbl in cptm.diamond_tolerance_table:
-			child_row = {}
-			if dtt_tbl.weight_type == "MM Size wise":
-				for dimond_row in bom_doc.diamond_detail:
-					if dimond_row.diamond_sieve_size == dtt_tbl.sieve_size:
-						weight_in_cts = dimond_row.quantity
-						from_tolerance_wt = round(
-							weight_in_cts * ((100 - dtt_tbl.minus_percent) / 100), 4
-						)
-						to_tolerance_wt = round(
-							weight_in_cts * ((100 + dtt_tbl.minus_percent) / 100), 4
-						)
-						child_row = {
-							"doctype": "Diamond Product Tolerance",
-							"parent": self.name,
-							"parenttype": self.doctype,
-							"parentfield": "diamond_product_tolerance",
-							"weight_type": dtt_tbl.weight_type,
-							"sieve_size": dtt_tbl.sieve_size,
-							"size_in_mm": round(dimond_row.size_in_mm, 4),
-							"from_tolerance_wt": from_tolerance_wt,
-							"to_tolerance_wt": to_tolerance_wt,
-							"standard_tolerance_wt": round(weight_in_cts, 4),
-							"product_wt": self.diamond_weight,
-						}
 
-			if dtt_tbl.weight_type == "Group Size wise":
-				sieve_size_ranges = set()
-				quantity_sum = 0
-				size_in_mm = 0
-				for dimond_row in bom_doc.diamond_detail:
-					if dtt_tbl.sieve_size_range == dimond_row.sieve_size_range:
-						quantity_sum += dimond_row.quantity
-						size_in_mm += dimond_row.size_in_mm
-						sieve_size_ranges.add(dimond_row.sieve_size_range)
-				from_tolerance_wt = round(
-					quantity_sum * ((100 - dtt_tbl.minus_percent) / 100), 4
-				)
-				to_tolerance_wt = round(
-					quantity_sum * ((100 + dtt_tbl.plus_percent) / 100), 4
-				)
-				for sieve_size_range in sorted(sieve_size_ranges):
-					if dtt_tbl.sieve_size_range == sieve_size_range:
-						child_row = {
-							"doctype": "Diamond Product Tolerance",
-							"parent": self.name,
-							"parenttype": self.doctype,
-							"parentfield": "diamond_product_tolerance",
-							"weight_type": dtt_tbl.weight_type,
-							"sieve_size": None,
-							"sieve_size_range": sieve_size_range,
-							"size_in_mm": round(size_in_mm, 4),
-							"from_tolerance_wt": from_tolerance_wt,
-							"to_tolerance_wt": to_tolerance_wt,
-							"standard_tolerance_wt": round(quantity_sum, 4),
-							"product_wt": self.diamond_weight,
-						}
+	self.set("diamond_product_tolerance", [])
 
-			if dtt_tbl.weight_type == "Weight wise":
-				diamond_total_wt = 0
-				for dimond_row in bom_doc.diamond_detail:
-					diamond_total_wt += dimond_row.quantity
-					from_tolerance_wt = round(
-						diamond_total_wt * ((100 - dtt_tbl.minus_percent) / 100), 4
-					)
-					to_tolerance_wt = round(
-						diamond_total_wt * ((100 + dtt_tbl.plus_percent) / 100), 4
-					)
-					child_row = {
-						"doctype": "Diamond Product Tolerance",
-						"parent": self.name,
-						"parenttype": self.doctype,
-						"parentfield": "diamond_product_tolerance",
-						"weight_type": dtt_tbl.weight_type,
-						"sieve_size": None,
-						"sieve_size_range": None,
-						"from_tolerance_wt": from_tolerance_wt,
-						"to_tolerance_wt": to_tolerance_wt,
-						"standard_tolerance_wt": round(diamond_total_wt, 4),
-						"product_wt": self.diamond_weight,
-					}
+	groups = group_tolerance_rows(cptm.diamond_tolerance_table or [], diamond_group_key)
+	for (weight_type, _diamond_type, scope), rows in groups.items():
+		matched_rows = []
+		if weight_type == "MM Size wise":
+			matched_rows = [
+				d for d in bom_doc.diamond_detail if d.diamond_sieve_size == scope
+			]
+		elif weight_type == "Group Size wise":
+			matched_rows = [
+				d for d in bom_doc.diamond_detail if d.sieve_size_range == scope
+			]
+		else:
+			# "Weight wise" bands the whole product's diamond weight; "Universal" is the
+			# band-less catch-all over every diamond. Both aggregate the full detail
+			# table -- the old code filtered Universal on `sieve_size_range is None`,
+			# which never matches a blank Link stored as "".
+			matched_rows = list(bom_doc.diamond_detail)
 
-			if dtt_tbl.weight_type == "Universal":
-				empty_sieve_size_ranges = set()
-				empty_quantity_sum = 0
-				empty_size_in_mm = 0
-				for dimond_row in bom_doc.diamond_detail:
-					if dimond_row.sieve_size_range is None:
-						empty_quantity_sum += dimond_row.quantity
-						empty_size_in_mm += dimond_row.size_in_mm
-						empty_sieve_size_ranges.add(dimond_row.sieve_size_range)
-				empty_from_tolerance_wt = round(
-					empty_quantity_sum * ((100 - dtt_tbl.minus_percent) / 100), 4
-				)
-				empty_to_tolerance_wt = round(
-					empty_quantity_sum * ((100 + dtt_tbl.plus_percent) / 100), 4
-				)
-				if empty_sieve_size_ranges:
-					for sieve_size_range in sorted(empty_sieve_size_ranges):
-						child_row = {
-							"doctype": "Diamond Product Tolerance",
-							"parent": self.name,
-							"parenttype": self.doctype,
-							"parentfield": "diamond_product_tolerance",
-							"weight_type": "Universal",
-							"sieve_size": None,
-							"sieve_size_range": None,
-							"size_in_mm": round(empty_size_in_mm, 4),
-							"from_tolerance_wt": empty_from_tolerance_wt,
-							"to_tolerance_wt": empty_to_tolerance_wt,
-							"standard_tolerance_wt": round(empty_quantity_sum, 4),
-							"product_wt": self.diamond_weight,
-						}
+		if not matched_rows:
+			continue
 
-			try:
-				if child_row:
-					self.append("diamond_product_tolerance", child_row)
-			except Exception as e:
-				frappe.throw(
-					f"Error appending <b>Diamond Product Tolerance Table</b> Please check <b>Customer Product Tolerance Master</b> Doctype Correctly configured or not:</br></br> {str(e)}"
-				)
-	self.save()
+		weight_in_cts = sum(flt(d.quantity) for d in matched_rows)
+		# Quantities add up; a stone diameter does not. Every row in this group shares a
+		# sieve size, so take the size rather than summing it -- summing turned a 1.75 mm
+		# sieve into 3.5 mm as soon as two BOM rows shared it.
+		size_in_mm = flt(matched_rows[0].size_in_mm)
+
+		dtt_tbl = pick_tolerance_row(rows, weight_in_cts, "from_diamond", "to_diamond")
+		if not dtt_tbl:
+			_throw_no_band(
+				cpt,
+				_("Diamond"),
+				_group_label(weight_type, _diamond_type, scope),
+				weight_in_cts,
+			)
+
+		from_tolerance_wt, to_tolerance_wt = _percent_bounds(
+			weight_in_cts, dtt_tbl.minus_percent, dtt_tbl.plus_percent
+		)
+
+		self.append(
+			"diamond_product_tolerance",
+			{
+				"weight_type": dtt_tbl.weight_type,
+				"sieve_size": dtt_tbl.sieve_size
+				if weight_type == "MM Size wise"
+				else None,
+				"sieve_size_range": dtt_tbl.sieve_size_range
+				if weight_type == "Group Size wise"
+				else None,
+				"size_in_mm": round(size_in_mm, 4),
+				"from_tolerance_wt": from_tolerance_wt,
+				"to_tolerance_wt": to_tolerance_wt,
+				"standard_tolerance_wt": round(weight_in_cts, 4),
+				"product_wt": flt(self.diamond_weight),
+			},
+		)
+	return True
 
 
 def set_gemstone_tolerance_table(self):
-	cpt = frappe.db.get_value(
-		"Customer Product Tolerance Master", {"customer_name": self.customer}, "name"
-	)
+	cpt = _get_tolerance_master(self.customer)
 	if not cpt:
-		return
+		return False
 	cptm = frappe.get_doc("Customer Product Tolerance Master", cpt)
 	bom = self.custom_tracking_bom
 	if not bom:
 		frappe.throw(_("BOM is missing"))
 	bom_doc = frappe.get_doc("Tracking Bom", bom)
-	if cptm.gemstone_tolerance_table:
-		for dtt_tbl in cptm.gemstone_tolerance_table:
-			child_row = {}
-			if dtt_tbl.weight_type == "Weight Range":
-				shapes = set()
-				quantity_sum = 0
-				for gem_row in bom_doc.gemstone_detail:
-					if dtt_tbl.from_diamond <= gem_row.quantity <= dtt_tbl.to_diamond:
-						quantity_sum += gem_row.quantity
-						shapes.add(gem_row.stone_shape)
-				from_tolerance_wt = round(
-					quantity_sum * ((100 - dtt_tbl.minus_percent) / 100), 4
-				)
-				to_tolerance_wt = round(
-					quantity_sum * ((100 + dtt_tbl.plus_percent) / 100), 4
-				)
-				for shape in sorted(shapes):
-					if dtt_tbl.gemstone_shape == shape:
-						child_row = {
-							"doctype": "Gemstone Product Tolerance",
-							"parent": self.name,
-							"parenttype": self.doctype,
-							"parentfield": "gemstone_product_tolerance",
-							"weight_type": dtt_tbl.weight_type,
-							"gemstone_shape": shape,
-							"gemstone_type": dtt_tbl.gemstone_type,
-							"standard_tolerance_wt": quantity_sum,
-							"from_tolerance_wt": from_tolerance_wt,
-							"to_tolerance_wt": to_tolerance_wt,
-							"product_wt": self.diamond_weight,
-						}
 
-			if dtt_tbl.weight_type == "Gemstone Type Range":
-				gemstone_types = set()
-				quantity_sum = 0
-				for gem_row in bom_doc.gemstone_detail:
-					if dtt_tbl.gemstone_type == gem_row.gemstone_type:
-						quantity_sum += gem_row.quantity
-						gemstone_types.add(gem_row.gemstone_type)
-				from_tolerance_wt = round(
-					quantity_sum * ((100 - dtt_tbl.minus_percent) / 100), 4
-				)
-				to_tolerance_wt = round(
-					quantity_sum * ((100 + dtt_tbl.plus_percent) / 100), 4
-				)
-				for gemstone_type in sorted(gemstone_types):
-					if dtt_tbl.gemstone_type == gemstone_type:
-						child_row = {
-							"doctype": "Gemstone Product Tolerance",
-							"parent": self.name,
-							"parenttype": self.doctype,
-							"parentfield": "gemstone_product_tolerance",
-							"weight_type": dtt_tbl.weight_type,
-							"gemstone_shape": None,
-							"gemstone_type": gemstone_type,
-							"standard_tolerance_wt": quantity_sum,
-							"from_tolerance_wt": from_tolerance_wt,
-							"to_tolerance_wt": to_tolerance_wt,
-							"product_wt": self.diamond_weight,
-						}
+	self.set("gemstone_product_tolerance", [])
 
-			if dtt_tbl.weight_type == "Weight wise":
-				quantity_sum = 0
-				for gem_row in bom_doc.gemstone_detail:
-					quantity_sum += gem_row.quantity
-					from_tolerance_wt = round(
-						quantity_sum * ((100 - dtt_tbl.minus_percent) / 100), 4
-					)
-					to_tolerance_wt = round(
-						quantity_sum * ((100 + dtt_tbl.plus_percent) / 100), 4
-					)
-					child_row = {
-						"doctype": "Gemstone Product Tolerance",
-						"parent": self.name,
-						"parenttype": self.doctype,
-						"parentfield": "gemstone_product_tolerance",
-						"weight_type": dtt_tbl.weight_type,
-						"gemstone_shape": None,
-						"gemstone_type": None,
-						"standard_tolerance_wt": quantity_sum,
-						"from_tolerance_wt": from_tolerance_wt,
-						"to_tolerance_wt": to_tolerance_wt,
-						"product_wt": self.diamond_weight,
-					}
+	groups = group_tolerance_rows(
+		cptm.gemstone_tolerance_table or [], gemstone_group_key
+	)
+	for (weight_type, scope), rows in groups.items():
+		if weight_type == "Weight Range":
+			matched_rows = [
+				g for g in bom_doc.gemstone_detail if g.stone_shape == scope
+			]
+		elif weight_type == "Gemstone Type Range":
+			matched_rows = [
+				g for g in bom_doc.gemstone_detail if g.gemstone_type == scope
+			]
+		else:
+			matched_rows = list(bom_doc.gemstone_detail)
 
-			try:
-				if child_row:
-					self.append("gemstone_product_tolerance", child_row)
-			except Exception as e:
-				frappe.throw(
-					f"Error appending <b>Gemstone Product Tolerance Table</b> Please check <b>Customer Product Tolerance Master</b> Doctype Correctly configured or not:</br></br> {str(e)}"
-				)
-	self.save()
+		if not matched_rows:
+			continue
+
+		quantity_sum = sum(flt(g.quantity) for g in matched_rows)
+
+		gtt_tbl = pick_tolerance_row(rows, quantity_sum, "from_diamond", "to_diamond")
+		if not gtt_tbl:
+			_throw_no_band(
+				cpt, _("Gemstone"), _group_label(weight_type, scope), quantity_sum
+			)
+
+		from_tolerance_wt, to_tolerance_wt = _percent_bounds(
+			quantity_sum, gtt_tbl.minus_percent, gtt_tbl.plus_percent
+		)
+
+		self.append(
+			"gemstone_product_tolerance",
+			{
+				"weight_type": gtt_tbl.weight_type,
+				"gemstone_shape": gtt_tbl.gemstone_shape
+				if weight_type == "Weight Range"
+				else None,
+				"gemstone_type": gtt_tbl.gemstone_type
+				if weight_type == "Gemstone Type Range"
+				else None,
+				"standard_tolerance_wt": round(quantity_sum, 4),
+				"from_tolerance_wt": from_tolerance_wt,
+				"to_tolerance_wt": to_tolerance_wt,
+				"product_wt": flt(self.gemstone_weight),
+			},
+		)
+	return True
 
 
 def create_repair_un_pack_stock_entry(self):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order.py
@@ -1152,38 +1152,46 @@ def set_diamond_tolerance_table(self):
 	self.set("diamond_product_tolerance", [])
 
 	groups = group_tolerance_rows(cptm.diamond_tolerance_table or [], diamond_group_key)
-	for (weight_type, _diamond_type, scope), rows in groups.items():
-		matched_rows = []
+	for (weight_type, diamond_type, scope), rows in groups.items():
+		matched_rows = list(bom_doc.diamond_detail)
+
+		# diamond_type scopes the aggregate independently of the sieve scope, so it is
+		# applied first and each branch narrows further. Without it a band scoped to one
+		# type was computed from every stone of that sieve, other types included --
+		# diamond_group_key has always carried the type, the filter just never did.
+		# "Universal" keys on "" (the master hides the field for it) and stays unfiltered.
+		if diamond_type:
+			matched_rows = [d for d in matched_rows if d.diamond_type == diamond_type]
+
 		if weight_type == "MM Size wise":
-			matched_rows = [
-				d for d in bom_doc.diamond_detail if d.diamond_sieve_size == scope
-			]
+			matched_rows = [d for d in matched_rows if d.diamond_sieve_size == scope]
 		elif weight_type == "Group Size wise":
-			matched_rows = [
-				d for d in bom_doc.diamond_detail if d.sieve_size_range == scope
-			]
-		else:
-			# "Weight wise" bands the whole product's diamond weight; "Universal" is the
-			# band-less catch-all over every diamond. Both aggregate the full detail
-			# table -- the old code filtered Universal on `sieve_size_range is None`,
-			# which never matches a blank Link stored as "".
-			matched_rows = list(bom_doc.diamond_detail)
+			matched_rows = [d for d in matched_rows if d.sieve_size_range == scope]
+		# "Weight wise" bands the whole product's diamond weight and "Universal" is the
+		# band-less catch-all over every diamond, so both take the type-filtered set
+		# as-is. The old code filtered Universal on `sieve_size_range is None`, which
+		# never matches a blank Link stored as "".
 
 		if not matched_rows:
+			# Includes a band whose diamond type does not appear in this BOM at all --
+			# it must produce no row rather than one over somebody else's weight.
 			continue
 
 		weight_in_cts = sum(flt(d.quantity) for d in matched_rows)
-		# Quantities add up; a stone diameter does not. Every row in this group shares a
-		# sieve size, so take the size rather than summing it -- summing turned a 1.75 mm
-		# sieve into 3.5 mm as soon as two BOM rows shared it.
-		size_in_mm = flt(matched_rows[0].size_in_mm)
+		# A sieve's stone diameter, so only meaningful for MM Size wise where the group
+		# is exactly one sieve. Group Size wise spans a range of sieves and Weight wise /
+		# Universal span every sieve, so any single row's diameter there is an arbitrary
+		# pick and summing them (what this did originally) is meaningless.
+		size_in_mm = (
+			flt(matched_rows[0].size_in_mm) if weight_type == "MM Size wise" else 0
+		)
 
 		dtt_tbl = pick_tolerance_row(rows, weight_in_cts, "from_diamond", "to_diamond")
 		if not dtt_tbl:
 			_throw_no_band(
 				cpt,
 				_("Diamond"),
-				_group_label(weight_type, _diamond_type, scope),
+				_group_label(weight_type, diamond_type, scope),
 				weight_in_cts,
 			)
 
@@ -1195,6 +1203,7 @@ def set_diamond_tolerance_table(self):
 			"diamond_product_tolerance",
 			{
 				"weight_type": dtt_tbl.weight_type,
+				"diamond_type": dtt_tbl.diamond_type or None,
 				"sieve_size": dtt_tbl.sieve_size
 				if weight_type == "MM Size wise"
 				else None,

--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/test_parent_manufacturing_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/test_parent_manufacturing_order.py
@@ -4,14 +4,23 @@
 from unittest.mock import patch
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 
+from jewellery_erpnext.jewellery_erpnext.doctype.customer_product_tolerance_master.customer_product_tolerance_master import (
+	CustomerProductToleranceMaster,
+)
+from jewellery_erpnext.jewellery_erpnext.doctype.customer_product_tolerance_master.tolerance_utils import (
+	group_tolerance_rows,
+	metal_group_key,
+	pick_tolerance_row,
+)
 from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_plan.test_manufacturing_plan import (
 	create_sales_order,
 	manufacturing_plan_creation,
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.parent_manufacturing_order import (
 	get_item_code,
+	set_metal_tolerance_table,
 	validate_mfg_date,
 )
 
@@ -487,3 +496,363 @@ def create_man_plan(self):
 	man_plan.save()
 	man_plan.submit()
 	return man_plan
+
+
+class FakeToleranceMaster(frappe._dict):
+	pass
+
+
+class FakePMO(frappe._dict):
+	"""Just enough Document surface for the tolerance populators."""
+
+	def set(self, key, value):
+		self[key] = value
+
+	def append(self, key, value):
+		self.setdefault(key, []).append(frappe._dict(value))
+
+
+def _metal_row(**kwargs):
+	row = frappe._dict(
+		weight_type="Net Weight",
+		metal_type=None,
+		range_type="",
+		tolerance_range=0,
+		from_weight=0,
+		to_weight=0,
+		plus_percent=0,
+		minus_percent=0,
+	)
+	row.update(kwargs)
+	return row
+
+
+class TestToleranceBandSelection(UnitTestCase):
+	"""Only the master row whose band covers the BOM weight may reach the PMO."""
+
+	def _run_metal(self, master_rows, bom_gross=0.0, bom_net=15.0, customer="CUST"):
+		pmo = FakePMO(
+			name="PMO-TEST-0001",
+			doctype="Parent Manufacturing Order",
+			customer=customer,
+			custom_tracking_bom="TB-0001",
+			gross_weight=0.0,
+			net_weight=0.0,
+			metal_product_tolerance=[],
+		)
+		master = FakeToleranceMaster(metal_tolerance_table=master_rows)
+		bom = frappe._dict(gross_weight=bom_gross, metal_and_finding_weight=bom_net)
+
+		def fake_get_doc(doctype, name):
+			return master if doctype == "Customer Product Tolerance Master" else bom
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order."
+			"parent_manufacturing_order.frappe.db.get_value",
+			return_value="PTM-TEST-0001",
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order."
+			"parent_manufacturing_order.frappe.get_doc",
+			side_effect=fake_get_doc,
+		):
+			set_metal_tolerance_table(pmo)
+		return pmo.metal_product_tolerance
+
+	def test_only_the_covering_band_reaches_the_pmo(self):
+		"""The reported bug: 15 g against 0-50 @7% and 51-100 @5% must yield ONE row."""
+		rows = self._run_metal(
+			[
+				_metal_row(
+					from_weight=0, to_weight=50, plus_percent=7, minus_percent=7
+				),
+				_metal_row(
+					from_weight=51, to_weight=100, plus_percent=5, minus_percent=5
+				),
+			],
+			bom_net=15.0,
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].from_tolerance_wt, 13.95)
+		self.assertEqual(rows[0].to_tolerance_wt, 16.05)
+		self.assertEqual(rows[0].standard_tolerance_wt, 15.0)
+		self.assertEqual(rows[0].from_weight, 0)
+		self.assertEqual(rows[0].to_weight, 50)
+
+	def test_higher_weight_picks_the_second_band(self):
+		rows = self._run_metal(
+			[
+				_metal_row(
+					from_weight=0, to_weight=50, plus_percent=7, minus_percent=7
+				),
+				_metal_row(
+					from_weight=51, to_weight=100, plus_percent=5, minus_percent=5
+				),
+			],
+			bom_net=80.0,
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].from_tolerance_wt, 76.0)
+		self.assertEqual(rows[0].to_tolerance_wt, 84.0)
+
+	def test_band_upper_bound_is_inclusive_and_first_row_wins(self):
+		rows = self._run_metal(
+			[
+				_metal_row(
+					from_weight=0, to_weight=50, plus_percent=7, minus_percent=7
+				),
+				_metal_row(
+					from_weight=50, to_weight=100, plus_percent=5, minus_percent=5
+				),
+			],
+			bom_net=50.0,
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].to_tolerance_wt, 53.5)
+
+	def test_zero_to_weight_means_no_upper_bound(self):
+		rows = self._run_metal(
+			[
+				_metal_row(
+					from_weight=0, to_weight=50, plus_percent=7, minus_percent=7
+				),
+				_metal_row(
+					from_weight=50, to_weight=0, plus_percent=5, minus_percent=5
+				),
+			],
+			bom_net=5000.0,
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].to_tolerance_wt, 5250.0)
+
+	def test_gap_between_bands_throws(self):
+		"""50.5 g falls between 0-50 and 51-100: master data must be corrected."""
+		with self.assertRaises(frappe.ValidationError):
+			self._run_metal(
+				[
+					_metal_row(
+						from_weight=0, to_weight=50, plus_percent=7, minus_percent=7
+					),
+					_metal_row(
+						from_weight=51, to_weight=100, plus_percent=5, minus_percent=5
+					),
+				],
+				bom_net=50.5,
+			)
+
+	def test_gross_and_net_groups_each_yield_one_row(self):
+		rows = self._run_metal(
+			[
+				_metal_row(
+					weight_type="Gross Weight",
+					from_weight=0,
+					to_weight=50,
+					plus_percent=10,
+					minus_percent=10,
+				),
+				_metal_row(
+					weight_type="Net Weight",
+					from_weight=0,
+					to_weight=50,
+					plus_percent=7,
+					minus_percent=7,
+				),
+			],
+			bom_gross=20.0,
+			bom_net=15.0,
+		)
+		self.assertEqual(len(rows), 2)
+		by_type = {row.weight_type: row for row in rows}
+		self.assertEqual(by_type["Gross Weight"].standard_tolerance_wt, 20.0)
+		self.assertEqual(by_type["Net Weight"].standard_tolerance_wt, 15.0)
+
+	def test_metal_types_are_independent_groups(self):
+		rows = self._run_metal(
+			[
+				_metal_row(
+					metal_type="Gold",
+					from_weight=0,
+					to_weight=50,
+					plus_percent=7,
+					minus_percent=7,
+				),
+				_metal_row(
+					metal_type="Silver",
+					from_weight=0,
+					to_weight=50,
+					plus_percent=5,
+					minus_percent=5,
+				),
+			],
+			bom_net=15.0,
+		)
+		self.assertEqual(len(rows), 2)
+		self.assertEqual({row.metal_type for row in rows}, {"Gold", "Silver"})
+
+	def test_weight_range_uses_flat_tolerance_range(self):
+		rows = self._run_metal(
+			[
+				_metal_row(
+					range_type="Weight Range",
+					from_weight=0,
+					to_weight=50,
+					tolerance_range=2,
+				)
+			],
+			bom_net=15.0,
+		)
+		self.assertEqual(rows[0].from_tolerance_wt, 13.0)
+		self.assertEqual(rows[0].to_tolerance_wt, 17.0)
+
+	def test_rebuilds_instead_of_appending(self):
+		"""An amended PMO arrives with the old rows; submit must not double them."""
+		master_rows = [
+			_metal_row(from_weight=0, to_weight=50, plus_percent=7, minus_percent=7)
+		]
+		self.assertEqual(len(self._run_metal(master_rows)), 1)
+		self.assertEqual(len(self._run_metal(master_rows)), 1)
+
+	def test_no_master_leaves_the_table_untouched(self):
+		pmo = FakePMO(customer="CUST", metal_product_tolerance=["existing"])
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order."
+			"parent_manufacturing_order.frappe.db.get_value",
+			return_value=None,
+		):
+			set_metal_tolerance_table(pmo)
+		self.assertEqual(pmo.metal_product_tolerance, ["existing"])
+
+
+class TestToleranceUtils(UnitTestCase):
+	def test_pick_returns_none_on_gap(self):
+		rows = [
+			frappe._dict(from_weight=0, to_weight=50),
+			frappe._dict(from_weight=51, to_weight=100),
+		]
+		self.assertIsNone(pick_tolerance_row(rows, 50.5))
+		self.assertIsNotNone(pick_tolerance_row(rows, 50))
+		self.assertIsNotNone(pick_tolerance_row(rows, 51))
+
+	def test_bandless_row_covers_everything(self):
+		rows = [frappe._dict(from_diamond=0, to_diamond=0)]
+		self.assertIsNotNone(
+			pick_tolerance_row(rows, 999, "from_diamond", "to_diamond")
+		)
+
+	def test_group_preserves_document_order(self):
+		rows = [
+			frappe._dict(weight_type="Net Weight", metal_type="Gold", idx=1),
+			frappe._dict(weight_type="Net Weight", metal_type="Gold", idx=2),
+			frappe._dict(weight_type="Gross Weight", metal_type="Gold", idx=3),
+		]
+		groups = group_tolerance_rows(rows, metal_group_key)
+		self.assertEqual(len(groups), 2)
+		self.assertEqual([row.idx for row in groups[("Net Weight", "Gold")]], [1, 2])
+
+
+class TestToleranceMasterBandValidation(UnitTestCase):
+	"""Band sanity rules on Customer Product Tolerance Master.
+
+	Housed here rather than in test_customer_product_tolerance_master.py because CI runs
+	a curated allowlist -- `--doctype "Parent Manufacturing Order"` already loads this
+	module, while nothing runs the tolerance master's own test file. These rules decide
+	which bands set_metal_tolerance_table can resolve, so this is their nearest home.
+	"""
+
+	def _doc(
+		self, bands, table="metal_tolerance_table", frm="from_weight", to="to_weight"
+	):
+		doc = frappe._dict(
+			metal_tolerance_table=[],
+			diamond_tolerance_table=[],
+			gemstone_tolerance_table=[],
+		)
+		doc[table] = [
+			frappe._dict(
+				{
+					"weight_type": "Net Weight",
+					"metal_type": "Gold",
+					frm: a,
+					to: b,
+					"idx": i + 1,
+				}
+			)
+			for i, (a, b) in enumerate(bands)
+		]
+		return doc
+
+	def _validate(self, doc):
+		CustomerProductToleranceMaster.validate_tolerance_bands(doc)
+
+	def test_real_master_schedules_still_save(self):
+		"""Live gk/production band shapes must not be rejected."""
+		for label, bands in {
+			"MHCU0008 (11 contiguous bands, some touching)": [
+				(0, 1.5),
+				(1.51, 3),
+				(3, 5),
+				(5, 10),
+				(10, 15),
+				(15, 25),
+				(25, 50),
+				(50, 75),
+				(75, 100),
+				(100, 150),
+				(150, 99999),
+			],
+			"MHCU0009 (open-ended top band)": [
+				(0, 4.999),
+				(5, 14.999),
+				(15, 49.999),
+				(50, 0),
+			],
+			"GJCU0009 (the reported master, with a gap)": [(0, 50), (51, 100)],
+		}.items():
+			with self.subTest(master=label):
+				self._validate(self._doc(bands))
+
+	def test_overlapping_bands_are_rejected(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._validate(self._doc([(0, 50), (20, 80)]))
+
+	def test_from_greater_than_to_is_rejected(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._validate(self._doc([(50, 10)]))
+
+	def test_two_identical_bands_are_rejected(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._validate(self._doc([(0, 50), (0, 50)]))
+
+	def test_different_groups_may_reuse_the_same_band(self):
+		"""Gold 0-50 and Silver 0-50 are independent schedules, not an overlap."""
+		doc = frappe._dict(
+			diamond_tolerance_table=[],
+			gemstone_tolerance_table=[],
+			metal_tolerance_table=[
+				frappe._dict(
+					weight_type="Net Weight",
+					metal_type="Gold",
+					from_weight=0,
+					to_weight=50,
+					idx=1,
+				),
+				frappe._dict(
+					weight_type="Net Weight",
+					metal_type="Silver",
+					from_weight=0,
+					to_weight=50,
+					idx=2,
+				),
+				frappe._dict(
+					weight_type="Gross Weight",
+					metal_type="Gold",
+					from_weight=0,
+					to_weight=50,
+					idx=3,
+				),
+			],
+		)
+		self._validate(doc)
+
+	def test_touching_bands_are_allowed(self):
+		"""...-50 and 50-... share an endpoint; pick_tolerance_row takes the first."""
+		self._validate(self._doc([(0, 50), (50, 100)]))

--- a/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/test_parent_manufacturing_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/parent_manufacturing_order/test_parent_manufacturing_order.py
@@ -20,6 +20,7 @@ from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_plan.test_manufac
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.parent_manufacturing_order import (
 	get_item_code,
+	set_diamond_tolerance_table,
 	set_metal_tolerance_table,
 	validate_mfg_date,
 )
@@ -856,3 +857,168 @@ class TestToleranceMasterBandValidation(UnitTestCase):
 	def test_touching_bands_are_allowed(self):
 		"""...-50 and 50-... share an endpoint; pick_tolerance_row takes the first."""
 		self._validate(self._doc([(0, 50), (50, 100)]))
+
+
+def _bom_diamond(**kwargs):
+	row = frappe._dict(
+		diamond_type="Natural",
+		diamond_sieve_size="+4.5-5",
+		sieve_size_range="Group A",
+		quantity=1.0,
+		size_in_mm=1.75,
+	)
+	row.update(kwargs)
+	return row
+
+
+def _diamond_band(**kwargs):
+	row = frappe._dict(
+		weight_type="MM Size wise",
+		diamond_type=None,
+		sieve_size="+4.5-5",
+		sieve_size_range=None,
+		from_diamond=0,
+		to_diamond=0,
+		plus_percent=10,
+		minus_percent=10,
+	)
+	row.update(kwargs)
+	return row
+
+
+class TestDiamondToleranceScoping(UnitTestCase):
+	"""A diamond band must aggregate only the stones it is scoped to.
+
+	No test previously exercised a populated diamond_tolerance_table at all, which is
+	how the missing diamond_type filter went unnoticed.
+	"""
+
+	def _run(self, master_rows, bom_rows, diamond_weight=0.0):
+		pmo = FakePMO(
+			name="PMO-TEST-0001",
+			doctype="Parent Manufacturing Order",
+			customer="CUST",
+			custom_tracking_bom="TB-0001",
+			diamond_weight=diamond_weight,
+			diamond_product_tolerance=[],
+		)
+		master = FakeToleranceMaster(diamond_tolerance_table=master_rows)
+		bom = frappe._dict(diamond_detail=bom_rows)
+
+		def fake_get_doc(doctype, name):
+			return master if doctype == "Customer Product Tolerance Master" else bom
+
+		with patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order."
+			"parent_manufacturing_order.frappe.db.get_value",
+			return_value="PTM-TEST-0001",
+		), patch(
+			"jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order."
+			"parent_manufacturing_order.frappe.get_doc",
+			side_effect=fake_get_doc,
+		):
+			set_diamond_tolerance_table(pmo)
+		return pmo.diamond_product_tolerance
+
+	def test_each_type_is_measured_on_its_own_stones(self):
+		"""The reported bug: both bands summed 2 + 3 = 5 cts instead of 2 and 3."""
+		rows = self._run(
+			[
+				_diamond_band(diamond_type="Natural"),
+				_diamond_band(diamond_type="LGD"),
+			],
+			[
+				_bom_diamond(diamond_type="Natural", quantity=2.0),
+				_bom_diamond(diamond_type="LGD", quantity=3.0),
+			],
+		)
+		self.assertEqual(len(rows), 2)
+		by_type = {row.diamond_type: row for row in rows}
+		self.assertEqual(by_type["Natural"].standard_tolerance_wt, 2.0)
+		self.assertEqual(by_type["LGD"].standard_tolerance_wt, 3.0)
+		self.assertEqual(by_type["Natural"].from_tolerance_wt, 1.8)
+		self.assertEqual(by_type["Natural"].to_tolerance_wt, 2.2)
+
+	def test_band_for_a_type_absent_from_the_bom_emits_no_row(self):
+		rows = self._run(
+			[_diamond_band(diamond_type="LGD")],
+			[_bom_diamond(diamond_type="Natural", quantity=2.0)],
+		)
+		self.assertEqual(rows, [])
+
+	def test_universal_still_aggregates_every_type(self):
+		rows = self._run(
+			[
+				_diamond_band(
+					weight_type="Universal", diamond_type=None, sieve_size=None
+				)
+			],
+			[
+				_bom_diamond(diamond_type="Natural", quantity=2.0),
+				_bom_diamond(diamond_type="LGD", quantity=3.0),
+			],
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].standard_tolerance_wt, 5.0)
+
+	def test_weight_wise_scoped_by_type_ignores_sieve(self):
+		rows = self._run(
+			[
+				_diamond_band(
+					weight_type="Weight wise", diamond_type="Natural", sieve_size=None
+				)
+			],
+			[
+				_bom_diamond(
+					diamond_type="Natural", diamond_sieve_size="+4.5-5", quantity=2.0
+				),
+				_bom_diamond(
+					diamond_type="Natural", diamond_sieve_size="+6-7", quantity=1.0
+				),
+				_bom_diamond(
+					diamond_type="LGD", diamond_sieve_size="+4.5-5", quantity=9.0
+				),
+			],
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].standard_tolerance_wt, 3.0)
+
+	def test_sieve_scope_still_applies_alongside_type(self):
+		rows = self._run(
+			[_diamond_band(diamond_type="Natural", sieve_size="+4.5-5")],
+			[
+				_bom_diamond(
+					diamond_type="Natural", diamond_sieve_size="+4.5-5", quantity=2.0
+				),
+				_bom_diamond(
+					diamond_type="Natural", diamond_sieve_size="+6-7", quantity=4.0
+				),
+				_bom_diamond(
+					diamond_type="LGD", diamond_sieve_size="+4.5-5", quantity=8.0
+				),
+			],
+		)
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0].standard_tolerance_wt, 2.0)
+
+	def test_size_in_mm_only_for_mm_size_wise(self):
+		mm = self._run(
+			[_diamond_band()],
+			[_bom_diamond(quantity=2.0, size_in_mm=1.75)],
+		)
+		self.assertEqual(mm[0].size_in_mm, 1.75)
+
+		for weight_type, extra in (
+			("Group Size wise", {"sieve_size": None, "sieve_size_range": "Group A"}),
+			("Weight wise", {"sieve_size": None}),
+			("Universal", {"sieve_size": None}),
+		):
+			with self.subTest(weight_type=weight_type):
+				rows = self._run(
+					[_diamond_band(weight_type=weight_type, **extra)],
+					[
+						_bom_diamond(quantity=2.0, size_in_mm=1.75),
+						_bom_diamond(quantity=1.0, size_in_mm=2.5),
+					],
+				)
+				self.assertEqual(rows[0].size_in_mm, 0)


### PR DESCRIPTION

Customer Product Tolerance Master stores tolerance rows banded by weight (from_weight/to_weight, from_diamond/to_diamond). For a given BOM weight exactly one band applies, but the PMO populators looped every master row and appended all of them.