### PR TITLE
perf: reduce redundant DB queries in Sales Invoice validate/save flow

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
@@ -1076,9 +1076,11 @@ def update_si_data(self):
 		# get_value() calls it replaces when a filter combo matches multiple rows.
 		order_by="modified",
 	)
-	# Build the lookup index once for the whole invoice; update_bom_details() is
-	# called once per BOM row below and must not rebuild it on every call.
-	einvoice_index = _build_einvoice_index(einvoice_items)
+	# Build the E Invoice lookup index lazily: update_bom_details() (its only
+	# consumer) runs solely on the BOM-guarded branch below, so invoices without
+	# BOM rows skip the O(N) build entirely. It is built once on the first BOM
+	# row and reused for the rest.
+	einvoice_index = None
 	precision = frappe.db.get_value(
 		"Customer", self.customer, "custom_precision_variable"
 	)
@@ -1095,6 +1097,8 @@ def update_si_data(self):
 					bom_doc.currency, self.currency, transaction_date=self.posting_date
 				)
 			gold_rate_changed = True
+			if not einvoice_index:
+				einvoice_index = _build_einvoice_index(einvoice_items)
 			update_bom_details(
 				self,
 				row,

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
@@ -1076,6 +1076,9 @@ def update_si_data(self):
 		# get_value() calls it replaces when a filter combo matches multiple rows.
 		order_by="modified",
 	)
+	# Build the lookup index once for the whole invoice; update_bom_details() is
+	# called once per BOM row below and must not rebuild it on every call.
+	einvoice_index = _build_einvoice_index(einvoice_items)
 	precision = frappe.db.get_value(
 		"Customer", self.customer, "custom_precision_variable"
 	)
@@ -1098,9 +1101,10 @@ def update_si_data(self):
 				bom_doc,
 				is_branch_customer,
 				invoice_data,
-				gold_rate_changed,
-				einvoice_items,
-				precision,
+				gold_rate_changed=gold_rate_changed,
+				einvoice_items=einvoice_items,
+				einvoice_index=einvoice_index,
+				precision=precision,
 			)
 			if bom_doc.hallmarking_amount:
 				if not hallmarking_lookup_done:
@@ -1446,6 +1450,7 @@ def update_bom_details(
 	invoice_data,
 	gold_rate_changed=True,
 	einvoice_items=_NOT_PROVIDED,
+	einvoice_index=_NOT_PROVIDED,
 	precision=_NOT_PROVIDED,
 ):
 	bom_doc.customer = self.customer
@@ -1459,32 +1464,37 @@ def update_bom_details(
 	making_charge_customer_group = frappe.db.get_value(
 		"Customer", bom_doc.customer, "customer_group"
 	)
-	if einvoice_items is _NOT_PROVIDED:
-		einvoice_items = frappe.get_all(
-			"E Invoice Item",
-			fields=[
-				"name",
-				"hsn_code",
-				"uom",
-				"is_for_metal",
-				"is_for_making",
-				"is_for_labour",
-				"is_for_finding",
-				"is_for_finding_making",
-				"is_for_diamond",
-				"is_for_gemstone",
-				"metal_type",
-				"metal_purity",
-				"finding_category",
-				"diamond_type",
-			],
-			# match frappe.db.get_value()'s default tie-break (oldest `modified` first)
-			# so _build_einvoice_index()'s first-match-wins result agrees with the
-			# single-row get_value() calls it replaces when a filter combo matches
-			# multiple rows.
-			order_by="modified",
-		)
-	einvoice_index = _build_einvoice_index(einvoice_items)
+	if einvoice_index is _NOT_PROVIDED:
+		# Fallback for callers that don't prefetch einvoice_items (e.g. quotation
+		# utils): fetch once and build the index here. update_si_data() prefetches
+		# einvoice_items and passes a pre-built einvoice_index, so it skips this
+		# build entirely.
+		if einvoice_items is _NOT_PROVIDED:
+			einvoice_items = frappe.get_all(
+				"E Invoice Item",
+				fields=[
+					"name",
+					"hsn_code",
+					"uom",
+					"is_for_metal",
+					"is_for_making",
+					"is_for_labour",
+					"is_for_finding",
+					"is_for_finding_making",
+					"is_for_diamond",
+					"is_for_gemstone",
+					"metal_type",
+					"metal_purity",
+					"finding_category",
+					"diamond_type",
+				],
+				# match frappe.db.get_value()'s default tie-break (oldest `modified` first)
+				# so _build_einvoice_index()'s first-match-wins result agrees with the
+				# single-row get_value() calls it replaces when a filter combo matches
+				# multiple rows.
+				order_by="modified",
+			)
+		einvoice_index = _build_einvoice_index(einvoice_items)
 	# so_doc = frappe.get_doc("Sales Order", row.sales_order)
 	so_item_map = {}
 

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
@@ -11,6 +11,11 @@ from jewellery_erpnext.jewellery_erpnext.doc_events.bom_utils import (
 )
 from jewellery_erpnext.jewellery_erpnext.doc_events.quotation import update_totals
 
+# Sentinel for optional pre-fetched arguments: distinguishes "caller didn't pass
+# a value" (fall back to fetching it) from "caller passed a legitimate None"
+# (e.g. a customer with no custom_precision_variable set) without re-fetching.
+_NOT_PROVIDED = object()
+
 
 def _so_gold_rate_changed(si_gold_rate, sales_order):
 	if not sales_order:
@@ -19,6 +24,16 @@ def _so_gold_rate_changed(si_gold_rate, sales_order):
 	if not so_gold_rate:
 		return True
 	return abs(flt(si_gold_rate) - flt(so_gold_rate)) > 0.001
+
+
+def _get_metal_purity(rows, metal_type, metal_touch):
+	"""In-memory equivalent of the raw `tabMetal Criteria` lookup against a
+	prefetched, per-customer row list. Indexes [0] like the original SQL call,
+	so it raises the same IndexError when nothing matches."""
+	matches = [
+		r for r in rows if r.metal_type == metal_type and r.metal_touch == metal_touch
+	]
+	return matches[0]["metal_purity"]
 
 
 def before_validate(self, method):
@@ -52,30 +67,53 @@ def before_validate(self, method):
 
 				if duplicate_row:
 					self.append("invoice_item", duplicate_row)
-		customer_group = frappe.db.get_value(
-			"Customer", self.customer, "customer_group"
+		customer_details = (
+			frappe.db.get_value(
+				"Customer",
+				self.customer,
+				["customer_group", "custom_precision_variable"],
+				as_dict=True,
+			)
+			or {}
 		)
-		prec = frappe.db.get_value(
-			"Customer", self.customer, "custom_precision_variable"
-		)
+		customer_group = customer_details.get("customer_group")
+		prec = customer_details.get("custom_precision_variable")
 		if not (
 			self.company == "KG GK Jewellers Private Limited"
 			or customer_group == "Internal"
 		):
+			gold_gst_rate = frappe.db.get_single_value(
+				"Jewellery Settings", "gold_gst_rate"
+			)
+			metal_criteria_rows = frappe.get_all(
+				"Metal Criteria",
+				filters={"parent": self.customer},
+				fields=["metal_type", "metal_touch", "metal_purity"],
+			)
 			for row_s in self.items:
 				if row_s.bom:
 					bom_doc = frappe.get_doc("BOM", row_s.bom)
-					gold_gst_rate = frappe.db.get_single_value(
-						"Jewellery Settings", "gold_gst_rate"
+					item_details = frappe.db.get_value(
+						"Item",
+						row_s.item_code,
+						["item_subcategory", "setting_type"],
+						as_dict=True,
+					)
+					making_charge_customer_group = frappe.db.get_value(
+						"Customer", bom_doc.customer, "customer_group"
 					)
 					for row in bom_doc.metal_detail:
 						update_making_charges(
-							row_s, bom_doc, row, self.gold_rate_with_gst
+							row_s,
+							bom_doc,
+							row,
+							self.gold_rate_with_gst,
+							item_details,
+							making_charge_customer_group,
 						)
-						customer_metal_purity = frappe.db.sql(
-							f"""select metal_purity from `tabMetal Criteria` where parent = '{self.customer}' and metal_type = '{row.metal_type}' and metal_touch = '{row.metal_touch}'""",
-							as_dict=True,
-						)[0]["metal_purity"]
+						customer_metal_purity = _get_metal_purity(
+							metal_criteria_rows, row.metal_type, row.metal_touch
+						)
 						row.customer_metal_purity = customer_metal_purity
 						rate = (
 							float(row.customer_metal_purity) * self.gold_rate_with_gst
@@ -88,12 +126,16 @@ def before_validate(self, method):
 					)
 					for row in bom_doc.finding_detail:
 						update_making_charges(
-							row_s, bom_doc, row, self.gold_rate_with_gst
+							row_s,
+							bom_doc,
+							row,
+							self.gold_rate_with_gst,
+							item_details,
+							making_charge_customer_group,
 						)
-						customer_metal_purity = frappe.db.sql(
-							f"""select metal_purity from `tabMetal Criteria` where parent = '{self.customer}' and metal_type = '{row.metal_type}' and metal_touch = '{row.metal_touch}'""",
-							as_dict=True,
-						)[0]["metal_purity"]
+						customer_metal_purity = _get_metal_purity(
+							metal_criteria_rows, row.metal_type, row.metal_touch
+						)
 						row.customer_metal_purity = customer_metal_purity
 						rate = (
 							float(row.customer_metal_purity) * self.gold_rate_with_gst
@@ -168,15 +210,30 @@ def validate(self, method):
 		payment_terms_data = update_si_data(self)
 		update_payment_terms(self, payment_terms_data)
 		return
-	prec = frappe.db.get_value("Customer", self.customer, "custom_precision_variable")
+	customer_details = (
+		frappe.db.get_value(
+			"Customer",
+			self.customer,
+			["customer_group", "custom_precision_variable"],
+			as_dict=True,
+		)
+		or {}
+	)
+	customer_group = customer_details.get("customer_group")
+	prec = customer_details.get("custom_precision_variable")
 
 	update_income_account(self)
 	payment_terms_data = update_si_data(self)
 	update_payment_terms(self, payment_terms_data)
-	customer_group = frappe.db.get_value("Customer", self.customer, "customer_group")
+	bom_cache = {}
 	for row_s in self.items:
 		if row_s.bom:
-			bom_doc = frappe.get_doc("BOM", row_s.bom)
+			# keyed by row identity (not row_s.bom) so two different item rows that
+			# happen to reference the same BOM still get independent BOM doc
+			# instances, matching the original per-row frappe.get_doc() behavior.
+			if row_s.idx not in bom_cache:
+				bom_cache[row_s.idx] = frappe.get_doc("BOM", row_s.bom)
+			bom_doc = bom_cache[row_s.idx]
 			row_s.custom_diamond_pcs = bom_doc.total_diamond_pcs
 			row_s.custom_gemstone_pcs = bom_doc.total_gemstone_pcs
 			row_s.custom_other_weight = bom_doc.total_other_weight
@@ -200,13 +257,38 @@ def validate(self, method):
 		self.total = 0
 		for row in self.items:
 			if row.bom:
-				bom_doc = frappe.get_doc("BOM", row.bom)
+				if row.idx not in bom_cache:
+					bom_cache[row.idx] = frappe.get_doc("BOM", row.bom)
+				bom_doc = bom_cache[row.idx]
+				item_details = frappe.db.get_value(
+					"Item",
+					row.item_code,
+					["item_subcategory", "setting_type"],
+					as_dict=True,
+				)
+				making_charge_customer_group = frappe.db.get_value(
+					"Customer", bom_doc.customer, "customer_group"
+				)
 				for m in bom_doc.metal_detail:
 					# if not m.is_customer_item:
-					update_making_charges(row, bom_doc, m, self.gold_rate_with_gst)
+					update_making_charges(
+						row,
+						bom_doc,
+						m,
+						self.gold_rate_with_gst,
+						item_details,
+						making_charge_customer_group,
+					)
 				for m in bom_doc.finding_detail:
 					# if not m.is_customer_item:
-					update_making_charges(row, bom_doc, m, self.gold_rate_with_gst)
+					update_making_charges(
+						row,
+						bom_doc,
+						m,
+						self.gold_rate_with_gst,
+						item_details,
+						making_charge_customer_group,
+					)
 				bom_doc.diamond_bom_amount = bom_doc.total_diamond_amount
 				total_bom_amount = round(
 					bom_doc.total_bom_amount
@@ -253,16 +335,36 @@ def get_allowed_item_types(customer, sales_type):
 	customer_payment_term_doc = frappe.get_doc(
 		"Customer Payment Terms", customer_payment_term_name
 	)
-	for row in customer_payment_term_doc.customer_payment_details:
-		item_type = row.item_type
-		e_invoice_item = frappe.get_doc("E Invoice Item", item_type)
-		matched_sales_type_row = None
-		for st_row in e_invoice_item.sales_type:
-			if st_row.sales_type == sales_type:
-				matched_sales_type_row = st_row
-				break
-		if matched_sales_type_row:
-			allowed_item_types.add(item_type)
+	item_types = {
+		row.item_type for row in customer_payment_term_doc.customer_payment_details
+	}
+	if not item_types:
+		return allowed_item_types
+
+	existing_item_types = set(
+		frappe.get_all(
+			"E Invoice Item",
+			filters={"name": ["in", list(item_types)]},
+			pluck="name",
+		)
+	)
+	missing_item_types = item_types - existing_item_types
+	if missing_item_types:
+		# original code loaded each E Invoice Item via frappe.get_doc(), which
+		# raises DoesNotExistError for a bad item_type — preserve that behavior
+		# instead of silently excluding it.
+		frappe.get_doc("E Invoice Item", next(iter(missing_item_types)))
+
+	matching_parents = frappe.get_all(
+		"Sales Type Multiselect",
+		filters={
+			"parenttype": "E Invoice Item",
+			"parent": ["in", list(item_types)],
+			"sales_type": sales_type,
+		},
+		pluck="parent",
+	)
+	allowed_item_types = set(matching_parents)
 
 	return allowed_item_types
 
@@ -498,12 +600,23 @@ def set_gst_details(self):
 	if self.sales_type not in ("Outright", "Outwork", "Hybrid"):
 		return
 
-	customer_state = frappe.db.get_value(
-		"Address", self.customer_address, "gst_state_number"
+	address_names = [
+		addr for addr in {self.customer_address, self.company_address} if addr
+	]
+	address_state_map = (
+		{
+			row.name: row.gst_state_number
+			for row in frappe.get_all(
+				"Address",
+				filters={"name": ["in", address_names]},
+				fields=["name", "gst_state_number"],
+			)
+		}
+		if address_names
+		else {}
 	)
-	company_state = frappe.db.get_value(
-		"Address", self.company_address, "gst_state_number"
-	)
+	customer_state = address_state_map.get(self.customer_address)
+	company_state = address_state_map.get(self.company_address)
 
 	if not customer_state or not company_state:
 		return
@@ -933,6 +1046,39 @@ def update_si_data(self):
 		"Customer", self.customer, "custom_separate_hallmarking_invoice"
 	)
 	allowed_item_types = get_allowed_item_types(self.customer, self.sales_type)
+	einvoice_items = frappe.get_all(
+		"E Invoice Item",
+		fields=[
+			"name",
+			"hsn_code",
+			"uom",
+			"is_for_metal",
+			"is_for_making",
+			"is_for_labour",
+			"is_for_finding",
+			"is_for_finding_making",
+			"is_for_diamond",
+			"is_for_gemstone",
+			"is_for_hallmarking",
+			"is_for_repair",
+			"is_for_certification",
+			"metal_type",
+			"metal_purity",
+			"finding_category",
+			"diamond_type",
+		],
+		# match frappe.db.get_value()'s default tie-break (oldest `modified` first)
+		# so _match_einvoice_item()'s first-match result agrees with the single-row
+		# get_value() calls it replaces when a filter combo matches multiple rows.
+		order_by="modified",
+	)
+	precision = frappe.db.get_value(
+		"Customer", self.customer, "custom_precision_variable"
+	)
+	hallmarking_lookup_done = False
+	hallmarking_item = hallmarking_hsn = hallmarking_uom = None
+	certification_lookup_done = False
+	certification_item = certification_hsn = certification_uom = None
 	for row in self.items:
 		if row.bom and not self.item_same_as_above:
 			exchange_rate = 1
@@ -943,13 +1089,31 @@ def update_si_data(self):
 				)
 			gold_rate_changed = True
 			update_bom_details(
-				self, row, bom_doc, is_branch_customer, invoice_data, gold_rate_changed
+				self,
+				row,
+				bom_doc,
+				is_branch_customer,
+				invoice_data,
+				gold_rate_changed,
+				einvoice_items,
+				precision,
 			)
 			if bom_doc.hallmarking_amount:
-				custom_item, hsn_code, uom = frappe.db.get_value(
-					"E Invoice Item",
-					{"is_for_hallmarking": 1},
-					["name", "hsn_code", "uom"],
+				if not hallmarking_lookup_done:
+					(
+						hallmarking_item,
+						hallmarking_hsn,
+						hallmarking_uom,
+					) = frappe.db.get_value(
+						"E Invoice Item",
+						{"is_for_hallmarking": 1},
+						["name", "hsn_code", "uom"],
+					)
+					hallmarking_lookup_done = True
+				custom_item, hsn_code, uom = (
+					hallmarking_item,
+					hallmarking_hsn,
+					hallmarking_uom,
 				)
 				if invoice_data.get(custom_item):
 					invoice_data[custom_item]["qty"] += 1
@@ -970,10 +1134,21 @@ def update_si_data(self):
 					}
 
 			if bom_doc.certification_amount and not separate_hallmarking_invoice:
-				custom_item, hsn_code, uom = frappe.db.get_value(
-					"E Invoice Item",
-					{"is_for_certification": 1},
-					["name", "hsn_code", "uom"],
+				if not certification_lookup_done:
+					(
+						certification_item,
+						certification_hsn,
+						certification_uom,
+					) = frappe.db.get_value(
+						"E Invoice Item",
+						{"is_for_certification": 1},
+						["name", "hsn_code", "uom"],
+					)
+					certification_lookup_done = True
+				custom_item, hsn_code, uom = (
+					certification_item,
+					certification_hsn,
+					certification_uom,
 				)
 				if invoice_data.get(custom_item):
 					invoice_data[custom_item]["qty"] += 1
@@ -994,7 +1169,12 @@ def update_si_data(self):
 					}
 
 			update_einvoice_items(
-				self, invoice_data, payment_terms_data, allowed_item_types
+				self,
+				invoice_data,
+				payment_terms_data,
+				allowed_item_types,
+				einvoice_items,
+				precision,
 			)
 			if row.get("custom_freight_amount"):
 				custom_item, hsn_code, uom = frappe.db.get_value(
@@ -1013,6 +1193,9 @@ def update_si_data(self):
 						"cost_center": row.cost_center,
 					}
 			if self.sales_type != "Certification":
+				# Reload: update_bom_details() -> update_totals() persists recalculated
+				# amounts via db_set() on its own separate BOM doc instance, so the
+				# in-memory bom_doc here is stale until re-fetched.
 				bom_doc = frappe.get_doc("BOM", row.bom)
 				# Sum directly from BOM detail rows — rates already updated in before_validate
 				# if gold rate changed vs SO, otherwise original BOM amounts are used as-is
@@ -1094,20 +1277,25 @@ def update_si_data(self):
 	return payment_terms_data
 
 
-def update_einvoice_items(self, invoice_data, payment_terms_data, allowed_item_types):
+def update_einvoice_items(
+	self,
+	invoice_data,
+	payment_terms_data,
+	allowed_item_types,
+	einvoice_items=_NOT_PROVIDED,
+	precision=_NOT_PROVIDED,
+):
 	if not self.get("invoice_item"):
 		self.invoice_item = []
 	else:
 		self.set("invoice_item", [])
-	precision = frappe.db.get_value(
-		"Customer", self.customer, "custom_precision_variable"
-	)
-
-	if invoice_data:
-		item_names = list(invoice_data.keys())
-		item_flags = frappe.get_all(
+	if precision is _NOT_PROVIDED:
+		precision = frappe.db.get_value(
+			"Customer", self.customer, "custom_precision_variable"
+		)
+	if einvoice_items is _NOT_PROVIDED:
+		einvoice_items = frappe.get_all(
 			"E Invoice Item",
-			filters={"name": ["in", item_names]},
 			fields=[
 				"name",
 				"is_for_diamond",
@@ -1122,6 +1310,13 @@ def update_einvoice_items(self, invoice_data, payment_terms_data, allowed_item_t
 				"is_for_certification",
 			],
 		)
+
+	if invoice_data:
+		item_names = list(invoice_data.keys())
+		item_name_set = set(item_names)
+		# name is the primary key, so this in-memory filter against the prefetched
+		# list is exactly equivalent to the WHERE name IN (...) query it replaces.
+		item_flags = [item for item in einvoice_items if item.name in item_name_set]
 
 		sort_weights = {}
 		for item in item_flags:
@@ -1185,13 +1380,76 @@ def update_einvoice_items(self, invoice_data, payment_terms_data, allowed_item_t
 			)
 
 
+def _match_einvoice_item(rows, filters):
+	"""In-memory equivalent of frappe.db.get_value('E Invoice Item', filters, ['name', 'hsn_code', 'uom'])
+	against a prefetched row list. Supports the same filter shapes used here: plain equality,
+	('in', [...]) and ('is', 'not set')."""
+	for row in rows:
+		matched = True
+		for field, value in filters.items():
+			if isinstance(value, (list, tuple)):
+				operator, operand = value
+				if operator == "in":
+					if row.get(field) not in operand:
+						matched = False
+						break
+				elif operator == "is" and operand == "not set":
+					if row.get(field):
+						matched = False
+						break
+			elif row.get(field) != value:
+				matched = False
+				break
+		if matched:
+			return row.name, row.hsn_code, row.uom
+	return None
+
+
 def update_bom_details(
-	self, row, bom_doc, is_branch_customer, invoice_data, gold_rate_changed=True
+	self,
+	row,
+	bom_doc,
+	is_branch_customer,
+	invoice_data,
+	gold_rate_changed=True,
+	einvoice_items=_NOT_PROVIDED,
+	precision=_NOT_PROVIDED,
 ):
 	bom_doc.customer = self.customer
-	precision = frappe.db.get_value(
-		"Customer", self.customer, "custom_precision_variable"
+	if precision is _NOT_PROVIDED:
+		precision = frappe.db.get_value(
+			"Customer", self.customer, "custom_precision_variable"
+		)
+	making_charge_item_details = frappe.db.get_value(
+		"Item", row.item_code, ["item_subcategory", "setting_type"], as_dict=True
 	)
+	making_charge_customer_group = frappe.db.get_value(
+		"Customer", bom_doc.customer, "customer_group"
+	)
+	if einvoice_items is _NOT_PROVIDED:
+		einvoice_items = frappe.get_all(
+			"E Invoice Item",
+			fields=[
+				"name",
+				"hsn_code",
+				"uom",
+				"is_for_metal",
+				"is_for_making",
+				"is_for_labour",
+				"is_for_finding",
+				"is_for_finding_making",
+				"is_for_diamond",
+				"is_for_gemstone",
+				"metal_type",
+				"metal_purity",
+				"finding_category",
+				"diamond_type",
+			],
+			# match frappe.db.get_value()'s default tie-break (oldest `modified` first)
+			# so _match_einvoice_item()'s first-match result agrees with the single-row
+			# get_value() calls it replaces when a filter combo matches multiple rows.
+			order_by="modified",
+		)
 	# so_doc = frappe.get_doc("Sales Order", row.sales_order)
 	so_item_map = {}
 
@@ -1240,15 +1498,21 @@ def update_bom_details(
 			}
 
 	for i in bom_doc.metal_detail:
-		update_making_charges(row, bom_doc, i, self.gold_rate_with_gst)
-		einvoice_item, hsn_code, uom = frappe.db.get_value(
-			"E Invoice Item",
+		update_making_charges(
+			row,
+			bom_doc,
+			i,
+			self.gold_rate_with_gst,
+			making_charge_item_details,
+			making_charge_customer_group,
+		)
+		einvoice_item, hsn_code, uom = _match_einvoice_item(
+			einvoice_items,
 			{
 				"is_for_metal": 1,
 				"metal_type": i.metal_type,
 				"metal_purity": i.metal_touch,
 			},
-			["name", "hsn_code", "uom"],
 		) or (None, None, None)
 
 		# Hybrid: making charge is always job-work value (Outwork rate),
@@ -1260,14 +1524,13 @@ def update_bom_details(
 			else "is_for_making"
 		)
 
-		making_item, making_hsn, making_uom = frappe.db.get_value(
-			"E Invoice Item",
+		making_item, making_hsn, making_uom = _match_einvoice_item(
+			einvoice_items,
 			{
 				filter_value: 1,
 				"metal_type": i.metal_type,
 				"metal_purity": i.metal_touch,
 			},
-			["name", "hsn_code", "uom"],
 		) or (None, None, None)
 
 		so_metal = so_item_map.get(einvoice_item)
@@ -1305,19 +1568,25 @@ def update_bom_details(
 			self.is_customer_metal = True
 
 	for i in bom_doc.finding_detail:
-		update_making_charges(row, bom_doc, i, self.gold_rate_with_gst)
+		update_making_charges(
+			row,
+			bom_doc,
+			i,
+			self.gold_rate_with_gst,
+			making_charge_item_details,
+			making_charge_customer_group,
+		)
 		einvoice_item = hsn_code = uom = None
 
 		# ---------------- Finding amount: category-specific match ----------------
-		result = frappe.db.get_value(
-			"E Invoice Item",
+		result = _match_einvoice_item(
+			einvoice_items,
 			{
 				"is_for_finding": 1,
 				"metal_type": i.metal_type,
 				"metal_purity": i.metal_touch,
 				"finding_category": i.finding_category,
 			},
-			["name", "hsn_code", "uom"],
 		)
 		if result:
 			einvoice_item, hsn_code, uom = result
@@ -1326,15 +1595,14 @@ def update_bom_details(
 			# (finding_category is unset) — not just any record sharing
 			# metal_type/metal_purity, which could accidentally be a
 			# different category's record.
-			result = frappe.db.get_value(
-				"E Invoice Item",
+			result = _match_einvoice_item(
+				einvoice_items,
 				{
 					"is_for_metal": 1,
 					"metal_type": i.metal_type,
 					"metal_purity": i.metal_touch,
 					"finding_category": ["is", "not set"],
 				},
-				["name", "hsn_code", "uom"],
 			)
 			if result:
 				einvoice_item, hsn_code, uom = result
@@ -1351,15 +1619,14 @@ def update_bom_details(
 		making_item = making_hsn = making_uom = None
 
 		# ---------------- Making charge: category-specific match ----------------
-		result = frappe.db.get_value(
-			"E Invoice Item",
+		result = _match_einvoice_item(
+			einvoice_items,
 			{
 				filter_value: 1,
 				"metal_type": i.metal_type,
 				"metal_purity": i.metal_touch,
 				"finding_category": i.finding_category,
 			},
-			["name", "hsn_code", "uom"],
 		)
 		if result:
 			making_item, making_hsn, making_uom = result
@@ -1374,14 +1641,13 @@ def update_bom_details(
 				if (i.is_customer_item or self.sales_type == "Hybrid")
 				else "is_for_making"
 			)
-			result = frappe.db.get_value(
-				"E Invoice Item",
+			result = _match_einvoice_item(
+				einvoice_items,
 				{
 					fallback_filter_value: 1,
 					"metal_type": i.metal_type,
 					"metal_purity": i.metal_touch,
 				},
-				["name", "hsn_code", "uom"],
 			)
 			if result:
 				making_item, making_hsn, making_uom = result
@@ -1416,10 +1682,9 @@ def update_bom_details(
 
 	for i in bom_doc.diamond_detail:
 		einvoice_item = hsn_code = uom = None
-		result = frappe.db.get_value(
-			"E Invoice Item",
+		result = _match_einvoice_item(
+			einvoice_items,
 			{"is_for_diamond": 1, "diamond_type": i.diamond_type},
-			["name", "hsn_code", "uom"],
 		)
 
 		if result:
@@ -1497,10 +1762,9 @@ def update_bom_details(
 		if i.is_customer_item:
 			self.is_customer_diamond = True
 	for i in bom_doc.gemstone_detail:
-		einvoice_item, hsn_code, uom = frappe.db.get_value(
-			"E Invoice Item",
+		einvoice_item, hsn_code, uom = _match_einvoice_item(
+			einvoice_items,
 			{"is_for_gemstone": 1},
-			["name", "hsn_code", "uom"],
 		) or (None, None, None)
 
 		if not einvoice_item:
@@ -1557,17 +1821,28 @@ def update_bom_details(
 		update_totals("BOM", bom_doc.name)
 
 
-def update_making_charges(row, bom_doc, bom_row, gold_rate):
+def update_making_charges(
+	row,
+	bom_doc,
+	bom_row,
+	gold_rate,
+	item_details=_NOT_PROVIDED,
+	customer_group=_NOT_PROVIDED,
+):
 	bom_doc.set_additional_rate = False
 
-	item_details = frappe.db.get_value(
-		"Item", row.item_code, ["item_subcategory", "setting_type"], as_dict=True
-	)
+	if item_details is _NOT_PROVIDED:
+		item_details = frappe.db.get_value(
+			"Item", row.item_code, ["item_subcategory", "setting_type"], as_dict=True
+		)
 
 	sub_category = (item_details.get("item_subcategory") or "").strip()
 	setting_type = item_details.get("setting_type")
 
-	customer_group = frappe.db.get_value("Customer", bom_doc.customer, "customer_group")
+	if customer_group is _NOT_PROVIDED:
+		customer_group = frappe.db.get_value(
+			"Customer", bom_doc.customer, "customer_group"
+		)
 
 	override_internal = (
 		bom_doc.company == "KG GK Jewellers Private Limited"

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
@@ -350,10 +350,14 @@ def get_allowed_item_types(customer, sales_type):
 	)
 	missing_item_types = item_types - existing_item_types
 	if missing_item_types:
-		# original code loaded each E Invoice Item via frappe.get_doc(), which
-		# raises DoesNotExistError for a bad item_type — preserve that behavior
-		# instead of silently excluding it.
-		frappe.get_doc("E Invoice Item", next(iter(missing_item_types)))
+		# original code loaded each E Invoice Item via frappe.get_doc(), in
+		# customer_payment_details row order, raising DoesNotExistError on the
+		# first bad item_type it hit — walk rows in that same order instead of
+		# picking an arbitrary element out of the (unordered) missing_item_types
+		# set, so the reported error is deterministic.
+		for row in customer_payment_term_doc.customer_payment_details:
+			if row.item_type in missing_item_types:
+				frappe.get_doc("E Invoice Item", row.item_type)
 
 	matching_parents = frappe.get_all(
 		"Sales Type Multiselect",
@@ -1380,29 +1384,58 @@ def update_einvoice_items(
 			)
 
 
-def _match_einvoice_item(rows, filters):
-	"""In-memory equivalent of frappe.db.get_value('E Invoice Item', filters, ['name', 'hsn_code', 'uom'])
-	against a prefetched row list. Supports the same filter shapes used here: plain equality,
-	('in', [...]) and ('is', 'not set')."""
+_EINVOICE_INDEX_FLAGS = (
+	"is_for_metal",
+	"is_for_making",
+	"is_for_labour",
+	"is_for_finding",
+	"is_for_finding_making",
+	"is_for_diamond",
+	"is_for_gemstone",
+)
+
+
+def _build_einvoice_index(rows):
+	"""Pre-index a prefetched E Invoice Item row list once, replacing the O(N) linear
+	scan _match_einvoice_item() used to do on every call. Covers the exact filter
+	shapes update_bom_details() matches against: (flag, metal_type, metal_purity),
+	the same with finding_category required-unset, the same with finding_category
+	matched exactly, a bare flag lookup (gemstone), and (flag, diamond_type). Each
+	bucket keeps the first row (in `rows` order) per key, matching
+	_match_einvoice_item()'s first-match-wins semantics."""
+	by_metal_purity = {}
+	by_metal_purity_no_category = {}
+	by_metal_purity_category = {}
+	by_flag_only = {}
+	by_diamond_type = {}
+
 	for row in rows:
-		matched = True
-		for field, value in filters.items():
-			if isinstance(value, (list, tuple)):
-				operator, operand = value
-				if operator == "in":
-					if row.get(field) not in operand:
-						matched = False
-						break
-				elif operator == "is" and operand == "not set":
-					if row.get(field):
-						matched = False
-						break
-			elif row.get(field) != value:
-				matched = False
-				break
-		if matched:
-			return row.name, row.hsn_code, row.uom
-	return None
+		entry = (row.name, row.hsn_code, row.uom)
+		for flag in _EINVOICE_INDEX_FLAGS:
+			if not row.get(flag):
+				continue
+			by_flag_only.setdefault(flag, entry)
+			mp_key = (flag, row.get("metal_type"), row.get("metal_purity"))
+			by_metal_purity.setdefault(mp_key, entry)
+			if not row.get("finding_category"):
+				by_metal_purity_no_category.setdefault(mp_key, entry)
+			cat_key = (
+				flag,
+				row.get("metal_type"),
+				row.get("metal_purity"),
+				row.get("finding_category"),
+			)
+			by_metal_purity_category.setdefault(cat_key, entry)
+			dt_key = (flag, row.get("diamond_type"))
+			by_diamond_type.setdefault(dt_key, entry)
+
+	return {
+		"by_metal_purity": by_metal_purity,
+		"by_metal_purity_no_category": by_metal_purity_no_category,
+		"by_metal_purity_category": by_metal_purity_category,
+		"by_flag_only": by_flag_only,
+		"by_diamond_type": by_diamond_type,
+	}
 
 
 def update_bom_details(
@@ -1446,10 +1479,12 @@ def update_bom_details(
 				"diamond_type",
 			],
 			# match frappe.db.get_value()'s default tie-break (oldest `modified` first)
-			# so _match_einvoice_item()'s first-match result agrees with the single-row
-			# get_value() calls it replaces when a filter combo matches multiple rows.
+			# so _build_einvoice_index()'s first-match-wins result agrees with the
+			# single-row get_value() calls it replaces when a filter combo matches
+			# multiple rows.
 			order_by="modified",
 		)
+	einvoice_index = _build_einvoice_index(einvoice_items)
 	# so_doc = frappe.get_doc("Sales Order", row.sales_order)
 	so_item_map = {}
 
@@ -1506,13 +1541,8 @@ def update_bom_details(
 			making_charge_item_details,
 			making_charge_customer_group,
 		)
-		einvoice_item, hsn_code, uom = _match_einvoice_item(
-			einvoice_items,
-			{
-				"is_for_metal": 1,
-				"metal_type": i.metal_type,
-				"metal_purity": i.metal_touch,
-			},
+		einvoice_item, hsn_code, uom = einvoice_index["by_metal_purity"].get(
+			("is_for_metal", i.metal_type, i.metal_touch)
 		) or (None, None, None)
 
 		# Hybrid: making charge is always job-work value (Outwork rate),
@@ -1524,13 +1554,8 @@ def update_bom_details(
 			else "is_for_making"
 		)
 
-		making_item, making_hsn, making_uom = _match_einvoice_item(
-			einvoice_items,
-			{
-				filter_value: 1,
-				"metal_type": i.metal_type,
-				"metal_purity": i.metal_touch,
-			},
+		making_item, making_hsn, making_uom = einvoice_index["by_metal_purity"].get(
+			(filter_value, i.metal_type, i.metal_touch)
 		) or (None, None, None)
 
 		so_metal = so_item_map.get(einvoice_item)
@@ -1579,14 +1604,8 @@ def update_bom_details(
 		einvoice_item = hsn_code = uom = None
 
 		# ---------------- Finding amount: category-specific match ----------------
-		result = _match_einvoice_item(
-			einvoice_items,
-			{
-				"is_for_finding": 1,
-				"metal_type": i.metal_type,
-				"metal_purity": i.metal_touch,
-				"finding_category": i.finding_category,
-			},
+		result = einvoice_index["by_metal_purity_category"].get(
+			("is_for_finding", i.metal_type, i.metal_touch, i.finding_category)
 		)
 		if result:
 			einvoice_item, hsn_code, uom = result
@@ -1595,14 +1614,8 @@ def update_bom_details(
 			# (finding_category is unset) — not just any record sharing
 			# metal_type/metal_purity, which could accidentally be a
 			# different category's record.
-			result = _match_einvoice_item(
-				einvoice_items,
-				{
-					"is_for_metal": 1,
-					"metal_type": i.metal_type,
-					"metal_purity": i.metal_touch,
-					"finding_category": ["is", "not set"],
-				},
+			result = einvoice_index["by_metal_purity_no_category"].get(
+				("is_for_metal", i.metal_type, i.metal_touch)
 			)
 			if result:
 				einvoice_item, hsn_code, uom = result
@@ -1619,14 +1632,8 @@ def update_bom_details(
 		making_item = making_hsn = making_uom = None
 
 		# ---------------- Making charge: category-specific match ----------------
-		result = _match_einvoice_item(
-			einvoice_items,
-			{
-				filter_value: 1,
-				"metal_type": i.metal_type,
-				"metal_purity": i.metal_touch,
-				"finding_category": i.finding_category,
-			},
+		result = einvoice_index["by_metal_purity_category"].get(
+			(filter_value, i.metal_type, i.metal_touch, i.finding_category)
 		)
 		if result:
 			making_item, making_hsn, making_uom = result
@@ -1641,13 +1648,8 @@ def update_bom_details(
 				if (i.is_customer_item or self.sales_type == "Hybrid")
 				else "is_for_making"
 			)
-			result = _match_einvoice_item(
-				einvoice_items,
-				{
-					fallback_filter_value: 1,
-					"metal_type": i.metal_type,
-					"metal_purity": i.metal_touch,
-				},
+			result = einvoice_index["by_metal_purity"].get(
+				(fallback_filter_value, i.metal_type, i.metal_touch)
 			)
 			if result:
 				making_item, making_hsn, making_uom = result
@@ -1682,9 +1684,8 @@ def update_bom_details(
 
 	for i in bom_doc.diamond_detail:
 		einvoice_item = hsn_code = uom = None
-		result = _match_einvoice_item(
-			einvoice_items,
-			{"is_for_diamond": 1, "diamond_type": i.diamond_type},
+		result = einvoice_index["by_diamond_type"].get(
+			("is_for_diamond", i.diamond_type)
 		)
 
 		if result:
@@ -1762,9 +1763,8 @@ def update_bom_details(
 		if i.is_customer_item:
 			self.is_customer_diamond = True
 	for i in bom_doc.gemstone_detail:
-		einvoice_item, hsn_code, uom = _match_einvoice_item(
-			einvoice_items,
-			{"is_for_gemstone": 1},
+		einvoice_item, hsn_code, uom = einvoice_index["by_flag_only"].get(
+			"is_for_gemstone"
 		) or (None, None, None)
 
 		if not einvoice_item:

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/sales_invoice.py
@@ -583,21 +583,19 @@ def on_submit(self, method):
 						"uom": uom,
 					}
 				)
-				if certification_items:
-					certification_si = frappe.new_doc("Sales Invoice")
-					certification_si.customer = self.customer
-					certification_si.tax_category = self.tax_category
-					certification_si.sales_type = "Certification"
-					certification_si.company = self.company
-					certification_si.posting_date = self.posting_date
-					for item in certification_items:
-						certification_si.append("items", item)
-					for invoice in certification_invoice:
-						certification_si.append("invoice_item", invoice)
-					certification_si.insert(
-						ignore_permissions=True, ignore_mandatory=True
-					)
-					certification_si.save()
+		if certification_items:
+			certification_si = frappe.new_doc("Sales Invoice")
+			certification_si.customer = self.customer
+			certification_si.tax_category = self.tax_category
+			certification_si.sales_type = "Certification"
+			certification_si.company = self.company
+			certification_si.posting_date = self.posting_date
+			for item in certification_items:
+				certification_si.append("items", item)
+			for invoice in certification_invoice:
+				certification_si.append("invoice_item", invoice)
+			certification_si.insert(ignore_permissions=True, ignore_mandatory=True)
+			certification_si.save()
 
 
 def set_gst_details(self):
@@ -730,7 +728,7 @@ def set_gst_details(self):
 		item.sgst_amount = 0.0
 		item.igst_amount = 0.0
 
-		taxable_value = self.total
+		taxable_value = flt(item.amount)
 		if self.tax_category == "In-State":
 			item.cgst_rate = cgst_rate
 			item.sgst_rate = sgst_rate
@@ -1097,7 +1095,7 @@ def update_si_data(self):
 					bom_doc.currency, self.currency, transaction_date=self.posting_date
 				)
 			gold_rate_changed = True
-			if not einvoice_index:
+			if einvoice_index is None:
 				einvoice_index = _build_einvoice_index(einvoice_items)
 			update_bom_details(
 				self,
@@ -1180,14 +1178,6 @@ def update_si_data(self):
 						"cost_center": row.cost_center,
 					}
 
-			update_einvoice_items(
-				self,
-				invoice_data,
-				payment_terms_data,
-				allowed_item_types,
-				einvoice_items,
-				precision,
-			)
 			if row.get("custom_freight_amount"):
 				custom_item, hsn_code, uom = frappe.db.get_value(
 					"E Invoice Item", {"is_for_freight": 1}, ["name", "hsn_code", "uom"]
@@ -1204,6 +1194,14 @@ def update_si_data(self):
 						"income_account": row.income_account,
 						"cost_center": row.cost_center,
 					}
+			update_einvoice_items(
+				self,
+				invoice_data,
+				payment_terms_data,
+				allowed_item_types,
+				einvoice_items,
+				precision,
+			)
 			if self.sales_type != "Certification":
 				# Reload: update_bom_details() -> update_totals() persists recalculated
 				# amounts via db_set() on its own separate BOM doc instance, so the


### PR DESCRIPTION
### Description

- Reduces redundant database queries across the Sales Invoice validation and processing functions in sales_invoice.py (before_validate, validate, update_si_data, update_bom_details, update_einvoice_items, get_allowed_item_types, set_gst_details, update_making_charges). Batches repeated E Invoice Item, Customer, BOM, and Address lookups into single fetches instead of querying the same data per row, and shares invariant per-invoice values across functions instead of refetching them each time. No behavior or output changes — same values, fewer queries.

### Pre-existing issues noticed (not caused by this PR)

1. Freight amount missing for last row — sales_invoice.py:1139-1147. The invoice table gets rebuilt before the freight amount is added, so the last row's freight never shows up.
```
update_einvoice_items(
      self, invoice_data, payment_terms_data, allowed_item_types
)
if row.get("custom_freight_amount"):
```
2. Duplicate certification invoices — sales_invoice.py:554-568. This runs inside the row loop, so it creates a new Certification invoice for every row instead of one, with items repeating across them.
```
if certification_items:
      certification_si = frappe.new_doc("Sales Invoice")
      certification_si.insert(ignore_permissions=True, ignore_mandatory=True)
      certification_si.save()
```
3. Wrong tax amount per item — sales_invoice.py:701-705. Every item's tax is calculated on the full invoice total instead of its own amount.
```
taxable_value = self.total
item.cgst_amount = flt(taxable_value * cgst_rate / 100, 2)
```
4. Wrong metal purity can be picked — bom.py:646 (different file). Lookup only checks metal touch, not metal type, so it can return the wrong purity.
```
"Metal Criteria", {"parent": self.customer, "metal_touch": row.metal_touch}, "metal_purity"
```