### PR TITLE
feat(unused-loose): repack returns onto the matching Unused/Loose material

### DIFF
--- a/jewellery_erpnext/create_test_data.py
+++ b/jewellery_erpnext/create_test_data.py
@@ -2695,14 +2695,26 @@ def create_test_data():
 			).insert(ignore_permissions=True)
 
 		# Unused/Loose Material targets for the seeded metal items. Receive Unused/Loose
-		# Material books returns onto the ML variant matching the source's Metal Purity +
+		# Material books returns onto the variant matching the source's Metal Purity +
 		# Metal Colour (see _resolve_unused_loose_item), and THROWS when none exists — so
-		# every seeded M variant that can be received needs its ML counterpart, and no two
-		# ML variants may share a purity+colour pair or the resolution is ambiguous.
+		# every seeded M variant that can be received needs its ML counterpart.
+		#
+		# The seed keeps every ML purity+colour pair UNIQUE on purpose, so the resolver's
+		# fast path (a single purity+colour match) is what the suite exercises. A collision
+		# is no longer fatal — _narrow_unused_candidates breaks the tie on the source's
+		# remaining attributes — but the tie-break is covered by tests that build their own
+		# colliding variants inline, not by this shared seed.
+		#
+		# Do NOT seed the descriptive templates ("Metal Unused/Loose Material" /
+		# "Finding Unused/Loose Material") here: they are PREFERRED over the short codes,
+		# so their presence would redirect every receive in the suite and break the ML-/FL-
+		# assertions. The two tests that need them create and delete them in their own scope.
+		#
 		# Deliberately NOT seeding ML-G-24KT-99.9-Y here: that code is PURE_LOSS_ITEM, and
 		# creating it flips RefiningEntry.get_dust_item() from the _get_pure_loss_item()
 		# fallback chain to the pure code for the WHOLE refining suite. No test receives
-		# 24KT metal as unused material, so this feature does not need it.
+		# 24KT metal as unused material, so this feature does not need it — and
+		# test_unused_loose_audit_classifies_the_seeded_item_master asserts the omission.
 		for _ml_code, _ml_touch, _ml_purity, _ml_colour, _ml_series in (
 			("ML-G-22KT-91.6-Y", "22KT", "91.6", "Yellow", "GE2D075-MGL22916Y0-.##."),
 			("ML-G-22KT-91.6-P", "22KT", "91.6", "Pink", "GE2D075-MGL22916P0-.##."),
@@ -2818,7 +2830,9 @@ def create_test_data():
 			).insert(ignore_permissions=True)
 
 		# One FL variant per seeded F variant, at the same purity+colour so the resolver
-		# finds exactly one candidate.
+		# finds exactly one candidate on the fast path. The two seeded twins differ only by
+		# Metal Colour; Finding Category / Sub-Category / Size are what
+		# _narrow_unused_candidates would break a tie on if they ever collided.
 		for _fl_code, _fl_colour, _fl_series in (
 			(
 				"FL-G-22KT-91.9-Y-CHA-KC-2.50 MM",

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -5102,34 +5102,102 @@ def create_scrap_wo_stock_entry(se_data, request_id=None):
 	reserved item code or the SRE cancel/recreate and the MOP Log deductions would no longer
 	line up with what was issued.
 
-	The receive and the repack run in one transaction: if the repack fails the whole
-	receive rolls back, so the material is never left un-tagged.
+	Every row's target is resolved BEFORE any stock moves, so an item-master gap makes this
+	a clean no-op instead of a submit-then-unwind. The receive and the repack then run under
+	one savepoint of their own: ``create_mr_wo_stock_entry`` releases its inner savepoint as
+	soon as the receive is submitted, so without this outer one a throw from the repack could
+	only be undone by the request handler's blanket rollback — leaving any non-HTTP caller
+	with a submitted receive whose material was never tagged.
 	"""
 	if isinstance(se_data, str):
 		se_data = json.loads(se_data)
-	result = create_mr_wo_stock_entry(se_data, request_id=request_id)
-	receive_se = result.get("docname") if isinstance(result, dict) else None
-	if receive_se:
-		# The receive SE creates MOP Log entries as a side effect of the on-submit hook.
-		# This material comes OUT of the metal issued to the operation, so those deductions
-		# MUST reduce the MOP/MWO balance exactly like a normal receive — the weight is no
-		# longer work-in-progress. So the MOP Log rows are KEPT.
-		_convert_received_scrap_to_scrap_batch(receive_se, request_id=request_id)
+
+	_preflight_unused_loose_targets(se_data)
+
+	frappe.db.savepoint("receive_unused_loose")
+	try:
+		result = create_mr_wo_stock_entry(se_data, request_id=request_id)
+		receive_se = result.get("docname") if isinstance(result, dict) else None
+		if receive_se:
+			# The receive SE creates MOP Log entries as a side effect of the on-submit hook.
+			# This material comes OUT of the metal issued to the operation, so those deductions
+			# MUST reduce the MOP/MWO balance exactly like a normal receive — the weight is no
+			# longer work-in-progress. So the MOP Log rows are KEPT.
+			#
+			# Called even when the receive was idempotent: a replay whose repack never landed
+			# self-heals here, and the repack has its own idempotency guard.
+			_convert_received_scrap_to_scrap_batch(receive_se, request_id=request_id)
+	except Exception:
+		frappe.db.rollback(save_point="receive_unused_loose")
+		raise
+	frappe.db.release_savepoint("receive_unused_loose")
 	return result
 
 
-#: Source item template -> the unused/loose material template its returns book onto.
-#: Metal and Finding only; every other template (D/G/O and the alloys) keeps its own
-#: item code, exactly as before.
+def _preflight_unused_loose_targets(se_data):
+	"""Resolve every requested row's unused/loose target before any stock moves.
+
+	Item codes are re-read from the Stock Reservation Entry rather than trusted from the
+	client, exactly as ``create_mr_wo_stock_entry`` does.
+
+	The row filter mirrors ``_convert_received_scrap_to_scrap_batch``: rows with no qty are
+	ignored, and a source item that is not batch-tracked is skipped rather than blocked —
+	the repack already msgprints those and they must not start hard-failing.
+	"""
+	sre_names = {
+		row.get("stock_reservation_entry")
+		for row in (se_data.get("receive_items") or [])
+		if row.get("stock_reservation_entry") and flt(row.get("qty")) > 0
+	}
+	if not sre_names:
+		return
+
+	item_codes = set(
+		frappe.db.get_all(
+			"Stock Reservation Entry",
+			filters={"name": ["in", list(sre_names)]},
+			pluck="item_code",
+		)
+	)
+	for item_code in sorted(item_codes):
+		if not frappe.db.get_value("Item", item_code, "has_batch_no"):
+			continue
+		probe = _probe_unused_loose_item(item_code)
+		if probe.status not in (UNUSED_OK, UNUSED_OUT_OF_SCOPE):
+			frappe.throw(probe.message, title=probe.title)
+
+
+#: Source item template -> the FAMILY whose unused/loose material template its returns
+#: book onto. Metal and Finding only; every other template (D/G/O and the alloys) keeps
+#: its own item code, exactly as before.
 #:
-#: Both item-code conventions in use are listed. Short codes (M/ML, F/FL) are what the
-#: live site carries; the descriptive codes are what newer sites create. A pair whose
-#: target template does not exist on this site is skipped, so listing both is safe.
-UNUSED_TARGET_TEMPLATE = {
-	"M": "ML",
-	"F": "FL",
-	"Metal": "Metal Unused/Loose Material",
-	"Finding": "Finding Unused/Loose Material",
+#: Both item-code conventions in use are listed as SOURCE keys, because a site can mix
+#: them: the live site's sources are ``M-``/``F-`` while its Unused/Loose Material items
+#: may already use the descriptive names.
+UNUSED_SOURCE_FAMILY = {
+	"M": "metal",
+	"Metal": "metal",
+	"F": "finding",
+	"Finding": "finding",
+}
+
+#: Family -> candidate target templates, most specific FIRST. The descriptive template is
+#: the one an operator creates deliberately for this purpose; the short code is the legacy
+#: LOSS template (Variant Loss Table maps M->ML, F->FL) that doubles as the unused/loose
+#: target on sites that never created a dedicated one. A candidate is skipped unless it is
+#: a real template WITH at least one live variant, so a half-provisioned descriptive
+#: template does not black-hole every receive.
+UNUSED_TARGET_TEMPLATES = {
+	"metal": ("Metal Unused/Loose Material", "ML"),
+	"finding": ("Finding Unused/Loose Material", "FL"),
+}
+
+#: Family -> the name the operator knows this material by. Derived from the FAMILY and not
+#: from the resolved template, so the message reads "Metal Unused/Loose Material item is
+#: not there" even on a site whose template is literally called "ML".
+UNUSED_FAMILY_LABEL = {
+	"metal": "Metal Unused/Loose Material",
+	"finding": "Finding Unused/Loose Material",
 }
 
 #: Attribute names carrying the purity. "Purity" is a legacy alias still present on some
@@ -5137,67 +5205,82 @@ UNUSED_TARGET_TEMPLATE = {
 _PURITY_ATTRIBUTES = ("Metal Purity", "Purity")
 _COLOUR_ATTRIBUTE = "Metal Colour"
 
+#: Probe outcomes. Only OK and OUT_OF_SCOPE let a receive proceed.
+UNUSED_OK = "OK"
+UNUSED_OUT_OF_SCOPE = "OUT_OF_SCOPE"
+UNUSED_NO_TEMPLATE = "NO_TEMPLATE"
+UNUSED_HALF_CONFIGURED = "HALF_CONFIGURED"
+UNUSED_NO_MATCH = "NO_MATCH"
+UNUSED_NARROWED_TO_NONE = "NARROWED_TO_NONE"
+UNUSED_AMBIGUOUS = "AMBIGUOUS"
+UNUSED_NOT_BATCH_TRACKED = "NOT_BATCH_TRACKED"
+UNUSED_UOM_MISMATCH = "UOM_MISMATCH"
+UNUSED_SERIAL_TRACKED = "SERIAL_TRACKED"
 
-def _item_metal_attributes(item_code):
-	"""``(purity, colour)`` off the item's Item Variant Attribute rows, or ``(None, None)``.
+
+#: How many candidate item codes to name before summarising. The legacy FL template can
+#: match 59 variants on purity+colour alone; a dialog listing all of them is unreadable.
+_UNUSED_MAX_LISTED = 8
+
+
+def _format_item_list(item_codes, limit=_UNUSED_MAX_LISTED):
+	"""``"a, b, c and 56 more"`` — enough to recognise, short enough to read."""
+	item_codes = list(item_codes)
+	if len(item_codes) <= limit:
+		return ", ".join(item_codes)
+	return _("{0} and {1} more").format(
+		", ".join(item_codes[:limit]), len(item_codes) - limit
+	)
+
+
+def _item_attributes(item_code):
+	"""``{attribute: value}`` for every Item Variant Attribute row of ``item_code``.
 
 	The metal attributes live ONLY in ``Item Variant Attribute`` — there are no
 	``custom_metal_*`` fields on Item anywhere in the bench."""
 	rows = frappe.db.get_all(
 		"Item Variant Attribute",
-		filters={
-			"parent": item_code,
-			"attribute": ["in", list(_PURITY_ATTRIBUTES) + [_COLOUR_ATTRIBUTE]],
-		},
+		filters={"parent": item_code},
 		fields=["attribute", "attribute_value"],
 	)
-	values = {r.attribute: r.attribute_value for r in rows}
+	return {r.attribute: r.attribute_value for r in rows if r.attribute_value}
+
+
+def _item_metal_attributes(item_code):
+	"""``(purity, colour)`` off the item's Item Variant Attribute rows, or ``(None, None)``."""
+	values = _item_attributes(item_code)
 	purity = next((values[a] for a in _PURITY_ATTRIBUTES if values.get(a)), None)
 	return purity, values.get(_COLOUR_ATTRIBUTE)
 
 
-def _resolve_unused_loose_item(item_code):
-	"""The unused/loose item ``item_code``'s returns should be booked onto, or ``None``.
+def _unused_target_template(family):
+	"""THE unused/loose template for ``family`` — descriptive convention preferred.
 
-	Material a karigar did not consume is received back onto a DEDICATED item — ``ML-`` for
-	metal, ``FL-`` for findings — carrying the SAME purity and colour as the item it came
-	from. The target is resolved from the template plus the source item's own attributes, so
-	nothing is hardcoded to a particular site's item master.
+	A candidate qualifies as soon as the Item exists, is a template (``has_variants``) and
+	is not disabled. The site's convention is decided by which template EXISTS, so the
+	descriptive one wins the moment it is created; the short code (``ML``/``FL``) serves
+	only sites that never created a dedicated one.
 
-	Returns ``None`` (meaning "leave this row on its own item code") when the row is out of
-	scope: a template with no mapping (D/G/O), a mapped template that does not exist on this
-	site, or an item carrying NEITHER purity nor colour — the alloys (``M-AL``, ``M-394``,
-	``M-Genia-221``). An alloy has nothing to match on by design; those receives work today
-	and must not start failing.
-
-	Throws when the row IS in scope but the target cannot be pinned down — a HALF-configured
-	source (one of purity/colour set, the other missing), a missing variant, or an ambiguous
-	one. All three are item-master problems a human has to resolve; guessing would silently
-	book the material onto the wrong purity."""
-	variant_of = frappe.db.get_value("Item", item_code, "variant_of")
-	target_template = UNUSED_TARGET_TEMPLATE.get(variant_of)
-	# Both naming conventions are listed in the map, so only the one this site actually
-	# uses resolves; the other is skipped rather than throwing "no such template".
-	if not target_template or not frappe.db.exists("Item", target_template):
-		return None
-
-	purity, colour = _item_metal_attributes(item_code)
-	if not purity and not colour:
-		# An alloy: no purity and no colour to match on at all. Out of scope, as before.
-		return None
-	if not purity or not colour:
-		frappe.throw(
-			_(
-				"{0} has {1} but no {2}, so its Unused/Loose Material item cannot be "
-				"resolved. Set both Metal Purity and Metal Colour on the item, or clear "
-				"both if it is an alloy that should keep its own item code."
-			).format(
-				frappe.bold(item_code),
-				_("Metal Purity") if purity else _("Metal Colour"),
-				_("Metal Colour") if purity else _("Metal Purity"),
-			)
+	Exactly ONE template is returned and resolution searches only that one — there is no
+	per-item fallthrough. If the chosen template has no variant at the source's purity and
+	colour, the receive is BLOCKED. Falling back to the other convention would silently
+	book the material onto the legacy loss item and hide a missing (or deliberately
+	disabled) item master entry, which is exactly what this feature exists to prevent."""
+	for template in UNUSED_TARGET_TEMPLATES.get(family) or ():
+		meta = frappe.db.get_value(
+			"Item", template, ["has_variants", "disabled"], as_dict=True
 		)
+		if meta and meta.has_variants and not meta.disabled:
+			return template
+	return None
 
+
+def _unused_candidates(target_template, purity, colour):
+	"""Live variants of ``target_template`` matching BOTH purity and colour.
+
+	Purity and colour are the whole match key, as specified. ``attribute_value`` is
+	free-text Data, so the comparison is left to SQL (collation-tolerant) rather than
+	being done in Python."""
 	ItemDoc = frappe.qb.DocType("Item")
 	Attr = frappe.qb.DocType("Item Variant Attribute")
 	purity_attr = (
@@ -5213,7 +5296,7 @@ def _resolve_unused_loose_item(item_code):
 		.select(Attr.parent)
 		.where((Attr.attribute == _COLOUR_ATTRIBUTE) & (Attr.attribute_value == colour))
 	)
-	candidates = (
+	return (
 		frappe.qb.from_(ItemDoc)
 		.select(ItemDoc.name)
 		.where(
@@ -5226,40 +5309,299 @@ def _resolve_unused_loose_item(item_code):
 		.run(pluck=True)
 	)
 
-	if len(candidates) == 1:
-		return candidates[0]
 
-	if not candidates:
-		frappe.throw(
-			_(
-				"No Unused/Loose Material item exists for {0}. Please create a variant of "
-				"template <b>{1}</b> with Metal Purity <b>{2}</b> and Metal Colour <b>{3}</b> "
-				"before receiving."
-			).format(frappe.bold(item_code), target_template, purity, colour)
-		)
-
-	frappe.throw(
-		_(
-			"{0} matches more than one Unused/Loose Material item of template <b>{1}</b> "
-			"with Metal Purity <b>{2}</b> and Metal Colour <b>{3}</b>: {4}. Please disable "
-			"the ones that should not be used."
-		).format(
-			frappe.bold(item_code),
-			target_template,
-			purity,
-			colour,
-			frappe.bold(", ".join(candidates)),
+def _template_attribute_names(template):
+	"""Attribute names the template DECLARES, so narrowing never asks for one it lacks."""
+	return set(
+		frappe.db.get_all(
+			"Item Variant Attribute", filters={"parent": template}, pluck="attribute"
 		)
 	)
 
 
-def _create_scrap_batch(item_code, employee=None):
+def _narrow_unused_candidates(candidates, source_attributes, target_template):
+	"""Candidates that ALSO match every other attribute BOTH sides carry.
+
+	Only ever called when purity+colour matched more than one variant — a state that is a
+	hard error otherwise, which is what makes this monotone: it can turn a throw into a
+	resolution or a better-worded throw, never change a match that already succeeds.
+
+	The legacy ``FL`` template carries the full finding attribute set (Finding Category /
+	Sub-Category / Size), so dozens of its variants share a purity+colour pair; narrowing
+	picks the one that is actually the same finding.
+
+	Only attributes the TARGET TEMPLATE declares are used. A template keyed on purity and
+	colour alone therefore has nothing to narrow with, and the caller reports a plain
+	ambiguity ("disable the duplicates") instead of a misleading "create the exact
+	counterpart" — the twin it would be asking for cannot exist under that template.
+
+	The test is EXACT, never a best-guess score: a surviving candidate carries the same
+	value for every narrowed attribute. Booking a clasp's gold onto a jump-ring code would
+	be invisible, so a near miss is dropped rather than preferred."""
+	shared = _template_attribute_names(target_template)
+	narrow_on = {
+		attribute: value
+		for attribute, value in source_attributes.items()
+		if attribute not in _PURITY_ATTRIBUTES
+		and attribute != _COLOUR_ATTRIBUTE
+		and attribute in shared
+	}
+	if not narrow_on:
+		return candidates, narrow_on
+
+	rows = frappe.db.get_all(
+		"Item Variant Attribute",
+		filters={"parent": ["in", candidates], "attribute": ["in", list(narrow_on)]},
+		fields=["parent", "attribute", "attribute_value"],
+	)
+	found = {}
+	for row in rows:
+		found.setdefault(row.parent, {})[row.attribute] = row.attribute_value
+
+	narrowed = [
+		candidate for candidate in candidates if found.get(candidate, {}) == narrow_on
+	]
+	return narrowed, narrow_on
+
+
+def _probe_unused_loose_item(item_code):
+	"""Classify ``item_code``'s unused/loose target WITHOUT throwing.
+
+	Returns a dict carrying ``status`` (one of the ``UNUSED_*`` constants), the resolved
+	``target`` when there is one, and a ready-to-show ``message``/``title``. The resolver,
+	the pre-flight and the audit report all go through here, so what the audit lists and
+	what the button blocks on can never drift apart."""
+	result = frappe._dict(
+		item_code=item_code,
+		status=UNUSED_OUT_OF_SCOPE,
+		target=None,
+		family=None,
+		template=None,
+		purity=None,
+		colour=None,
+		candidates=[],
+		narrowed_on={},
+		title=None,
+		message=None,
+	)
+
+	source = frappe.db.get_value(
+		"Item", item_code, ["variant_of", "stock_uom"], as_dict=True
+	)
+	family = UNUSED_SOURCE_FAMILY.get(source and source.variant_of)
+	if not family:
+		# Diamonds, gemstones, "other" — no unused/loose counterpart by design.
+		return result
+	result.family = family
+	label = UNUSED_FAMILY_LABEL[family]
+
+	purity, colour = _item_metal_attributes(item_code)
+	result.purity, result.colour = purity, colour
+	if not purity and not colour:
+		# An alloy (M-AL, M-394, M-Genia-221): nothing to match on at all, and those
+		# receives work today. Out of scope, as before.
+		return result
+
+	def block(status, message, title=None):
+		result.status = status
+		result.title = title or _("{0} item is not there").format(label)
+		result.message = message
+		return result
+
+	if not purity or not colour:
+		return block(
+			UNUSED_HALF_CONFIGURED,
+			_(
+				"{0} has {1} but no {2}, so its Unused/Loose Material item cannot be "
+				"resolved. Set both Metal Purity and Metal Colour on the item, or clear "
+				"both if it is an alloy that should keep its own item code."
+			).format(
+				frappe.bold(item_code),
+				_("Metal Purity") if purity else _("Metal Colour"),
+				_("Metal Colour") if purity else _("Metal Purity"),
+			),
+			title=_("{0} item cannot be resolved").format(label),
+		)
+
+	template = _unused_target_template(family)
+	result.template = template
+	if not template:
+		return block(
+			UNUSED_NO_TEMPLATE,
+			_(
+				"This site has no {0} item template. Expected one of: <b>{1}</b>. Create "
+				"the template and its variants before receiving."
+			).format(label, ", ".join(UNUSED_TARGET_TEMPLATES[family])),
+		)
+
+	# One template, no fallthrough. A missing or disabled variant under it BLOCKS rather
+	# than quietly resolving under the other convention.
+	candidates = _unused_candidates(template, purity, colour)
+	result.candidates = candidates
+
+	if len(candidates) > 1:
+		narrowed, narrow_on = _narrow_unused_candidates(
+			candidates, _item_attributes(item_code), template
+		)
+		result.narrowed_on = narrow_on
+		if not narrow_on:
+			return block(
+				UNUSED_AMBIGUOUS,
+				_(
+					"{0} matches more than one {1} item of template <b>{2}</b> with Metal "
+					"Purity <b>{3}</b> and Metal Colour <b>{4}</b>: {5}. Please disable the "
+					"ones that should not be used."
+				).format(
+					frappe.bold(item_code),
+					label,
+					template,
+					purity,
+					colour,
+					frappe.bold(_format_item_list(candidates)),
+				),
+				title=_("More than one {0} item matches").format(label),
+			)
+		if not narrowed:
+			return block(
+				UNUSED_NARROWED_TO_NONE,
+				_(
+					"{0} items of template <b>{1}</b> match {2} on Metal Purity <b>{3}</b> "
+					"and Metal Colour <b>{4}</b> ({5}), but none of them also match {6}. "
+					"Create the exact counterpart, or disable all but one of the near "
+					"matches."
+				).format(
+					len(candidates),
+					template,
+					frappe.bold(item_code),
+					purity,
+					colour,
+					_format_item_list(candidates),
+					", ".join(f"{k} {v}" for k, v in sorted(narrow_on.items())),
+				),
+			)
+		if len(narrowed) > 1:
+			return block(
+				UNUSED_AMBIGUOUS,
+				_(
+					"{0} matches more than one {1} item of template <b>{2}</b>, even after "
+					"matching {3}: {4}. Please disable the ones that should not be used."
+				).format(
+					frappe.bold(item_code),
+					label,
+					template,
+					", ".join(f"{k} {v}" for k, v in sorted(narrow_on.items())),
+					frappe.bold(_format_item_list(narrowed)),
+				),
+				title=_("More than one {0} item matches").format(label),
+			)
+		candidates = narrowed
+		result.candidates = narrowed
+
+	if not candidates:
+		return block(
+			UNUSED_NO_MATCH,
+			_(
+				"{0} (Metal Purity <b>{1}</b>, Metal Colour <b>{2}</b>) has no "
+				"Unused/Loose Material counterpart. Create an enabled variant of template "
+				"<b>{3}</b> with that purity and colour and <b>Has Batch No</b> enabled, "
+				"then receive again."
+			).format(frappe.bold(item_code), purity, colour, template),
+		)
+
+	target = candidates[0]
+	result.target = target
+	target_meta = frappe.db.get_value(
+		"Item", target, ["has_batch_no", "has_serial_no", "stock_uom"], as_dict=True
+	)
+
+	if not target_meta.has_batch_no:
+		# The material would be produced onto an untagged item and would never be
+		# fetchable for refining. Skipping would lose it silently.
+		return block(
+			UNUSED_NOT_BATCH_TRACKED,
+			_(
+				"{0} is the Unused/Loose Material item for {1} (Metal Purity <b>{2}</b>, "
+				"Metal Colour <b>{3}</b>), but <b>Has Batch No</b> is off, so the received "
+				"material cannot be tagged for refining. Enable Has Batch No on {0}, then "
+				"receive again."
+			).format(frappe.bold(target), frappe.bold(item_code), purity, colour),
+			title=_("{0} item is not usable").format(label),
+		)
+
+	if target_meta.has_serial_no:
+		# The repack rows carry a batch and no serials; a serial-tracked target would
+		# fail deep inside Stock Entry submit with an opaque message.
+		return block(
+			UNUSED_SERIAL_TRACKED,
+			_(
+				"{0} is the Unused/Loose Material item for {1}, but it is serial-tracked. "
+				"Unused/Loose Material is received by weight under a batch, so the target "
+				"item must not have Has Serial No enabled."
+			).format(frappe.bold(target), frappe.bold(item_code)),
+			title=_("{0} item is not usable").format(label),
+		)
+
+	if (target_meta.stock_uom or "") != (source.stock_uom or ""):
+		# The repack copies the received qty verbatim onto the produce row, so a
+		# different unit would silently book grams as something else.
+		return block(
+			UNUSED_UOM_MISMATCH,
+			_(
+				"{0} is stocked in <b>{1}</b> but its Unused/Loose Material item {2} is "
+				"stocked in <b>{3}</b>. The received quantity cannot be booked across two "
+				"units — set both items to the same Default Unit of Measure."
+			).format(
+				frappe.bold(item_code),
+				source.stock_uom,
+				frappe.bold(target),
+				target_meta.stock_uom,
+			),
+			title=_("{0} item is not usable").format(label),
+		)
+
+	result.status = UNUSED_OK
+	return result
+
+
+def _resolve_unused_loose_item(item_code):
+	"""The unused/loose item ``item_code``'s returns should be booked onto, or ``None``.
+
+	Material a karigar did not consume is received back onto a DEDICATED item carrying the
+	SAME purity and colour as the item it came from — a variant of the ``Metal Unused/Loose
+	Material`` / ``Finding Unused/Loose Material`` template, or of the legacy ``ML``/``FL``
+	template on a site that never created the descriptive one. The target is resolved from
+	the template plus the source item's own attributes, so nothing is hardcoded to a
+	particular site's item master.
+
+	Returns ``None`` (meaning "leave this row on its own item code") only when the row is
+	genuinely out of scope: a template with no mapping (D/G/O), or an item carrying NEITHER
+	purity nor colour — the alloys (``M-AL``, ``M-394``, ``M-Genia-221``). An alloy has
+	nothing to match on by design; those receives work today and must not start failing.
+
+	Throws when the row IS in scope but the target cannot be pinned down or cannot hold the
+	material. All of those are item-master problems a human has to resolve; guessing would
+	silently book the metal onto the wrong purity.
+
+	Note on gk.site: the pure loss item ``ML-G-24KT-99.9-Y`` is also the legitimate target
+	for unused 24KT-Yellow metal. That overlap is intentional — 24KT unused metal IS 24KT
+	metal, and ``Batch.custom_batch_type`` is what separates the two populations for
+	``RefiningEntry.get_scrap_items_balance``."""
+	probe = _probe_unused_loose_item(item_code)
+	if probe.status in (UNUSED_OK, UNUSED_OUT_OF_SCOPE):
+		return probe.target
+	frappe.throw(probe.message, title=probe.title)
+
+
+def _create_scrap_batch(
+	item_code, employee=None, company=None, inventory_type=None, customer=None
+):
 	"""Create a new batch of ``item_code`` tagged custom_batch_type = 'Unused/Loose Material'.
 
 	``employee`` stamps Batch.custom_employee so it can be fetched employee-wise in
 	Unused/Loose Material Refining. The batch is created directly (before any Stock Entry
 	links it), so the usual SE->batch employee copy never runs; stamp it explicitly here
-	from the operation's employee.
+	from the operation's employee. ``company`` and the ownership pair are stamped for the
+	same reason — nothing else will fill them in for an auto-created repack.
 
 	Returns None for non-batch items (they cannot carry the Scrap marker)."""
 	if not frappe.db.get_value("Item", item_code, "has_batch_no"):
@@ -5269,6 +5611,19 @@ def _create_scrap_batch(item_code, employee=None):
 	batch.custom_batch_type = BATCH_TYPE_UNUSED
 	if employee:
 		batch.custom_employee = employee
+	if company:
+		# get_batch_company_abbr falls back to the SESSION user's default company and
+		# throws when none resolves, so the batch id would carry the wrong abbreviation
+		# on a multi-company site (and fail outright in a background job). Stamp the
+		# operation's own company, as RefiningEntry._auto_create_batch does.
+		batch.custom_company = company
+	if inventory_type:
+		# Material issued from a customer's batch and returned unused is still that
+		# customer's. The repack is auto_created, so CustomStockEntry.update_batches
+		# skips the generic batch->row ownership backfill and doc_events/stock_entry
+		# would default the rows to "Regular Stock" — carry it explicitly.
+		batch.custom_inventory_type = inventory_type
+		batch.custom_customer = customer
 	# Set batch_type before insert so it persists whether the item auto-names the
 	# batch (batch_number_series) or we generate an id below.
 	if not frappe.db.get_value("Item", item_code, "batch_number_series"):
@@ -5278,14 +5633,46 @@ def _create_scrap_batch(item_code, employee=None):
 	return batch.name
 
 
+def _unused_row_ownership(row, target_item):
+	"""``(inventory_type, customer)`` the unused/loose output should carry.
+
+	Resolved from the SOURCE batch through the app's single source of truth
+	(``resolve_batch_ownership``), then downgraded to Regular Stock when the TARGET item
+	is not allowed to hold customer goods — the target is a different item from the source,
+	so the source carrying the flag guarantees nothing, and minting a Customer Goods batch
+	for an item without it hard-fails in ``Batch.update_inventory_dimentions``."""
+	from jewellery_erpnext.jewellery_erpnext.customization.utils.row_ownership import (
+		resolve_batch_ownership,
+	)
+
+	inventory_type, customer = resolve_batch_ownership(row)
+	if inventory_type not in ("Customer Goods", "Customer Stock"):
+		return None, None
+	if not frappe.db.get_value(
+		"Item", target_item, "custom_inventory_type_can_be_customer_goods"
+	):
+		frappe.msgprint(
+			_(
+				"{0} cannot hold customer goods, so the unused/loose material received "
+				"from {1} is booked as Regular Stock. Enable <b>Inventory Type Can Be "
+				"Customer Goods</b> on {0} to retain the customer's ownership."
+			).format(frappe.bold(target_item), frappe.bold(row.item_code)),
+			indicator="orange",
+			alert=True,
+		)
+		return None, None
+	return inventory_type, customer
+
+
 def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 	"""Repack the just-received material onto its unused/loose item and a tagged batch.
 
 	Same warehouse and same qty; the batch ALWAYS changes (to a fresh one tagged
 	``custom_batch_type = "Unused/Loose Material"``) and the item code changes too whenever
-	``_resolve_unused_loose_item`` maps it — ``M-`` metal becomes ``ML-`` and ``F-`` findings
-	become ``FL-`` at the same purity and colour. Rows with no mapping (D/G/O, alloys) keep
-	their own item code and are isolated by the batch tag alone, as before."""
+	``_resolve_unused_loose_item`` maps it — metal becomes the matching Metal Unused/Loose
+	Material variant and findings the matching Finding Unused/Loose Material variant, at the
+	same purity and colour. Rows with no mapping (D/G/O, alloys) keep their own item code and
+	are isolated by the batch tag alone, as before."""
 	se = frappe.get_doc("Stock Entry", receive_se_name)
 	if cint(se.docstatus) != 1:
 		return
@@ -5293,10 +5680,17 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 	base_id = (request_id or receive_se_name)[:30]
 	scrap_request_id = f"{base_id}-scrap"
 	# Idempotent: the receive is idempotent by request_id, so its scrap repack must
-	# be too — never double-convert the same received material.
+	# be too — never double-convert the same received material. Both keys are checked:
+	# the request-derived one is what a first pass writes, and the SE-derived one covers
+	# a replay that reached us with a different request_id for the same receive.
+	# custom_request_id is Data(36), so "-scrap" must stay within the 30-char prefix.
+	fallback_request_id = f"{receive_se_name[:30]}-scrap"
 	if frappe.db.exists(
 		"Stock Entry",
-		{"custom_request_id": scrap_request_id, "docstatus": ["!=", 2]},
+		{
+			"custom_request_id": ["in", list({scrap_request_id, fallback_request_id})],
+			"docstatus": ["!=", 2],
+		},
 	):
 		return
 
@@ -5342,12 +5736,19 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 
 	for item in rows:
 		target_item = _resolve_unused_loose_item(item.item_code) or item.item_code
-		new_batch = _create_scrap_batch(target_item, employee=op_employee)
+		inventory_type, customer = _unused_row_ownership(item, target_item)
+		new_batch = _create_scrap_batch(
+			target_item,
+			employee=op_employee,
+			company=se.company,
+			inventory_type=inventory_type,
+			customer=customer,
+		)
 		if not new_batch:
 			if target_item != item.item_code:
-				# The source was batch-tracked (rows filtered on that above) but its
-				# unused/loose counterpart is not, so the material would be produced onto
-				# an untagged, unfetchable item. Skipping would lose it silently.
+				# Unreachable: _probe_unused_loose_item blocks a non-batch-tracked target
+				# before any stock moves. Kept so a future edit cannot quietly start
+				# producing material onto an untagged, unfetchable item.
 				frappe.throw(
 					_(
 						"Unused/Loose Material item {0} is not batch-tracked, so the "
@@ -5375,9 +5776,13 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 				"is_finished_item": 0,
 				"set_basic_rate_manually": 1,
 				"basic_rate": val_rate,
+				"inventory_type": inventory_type,
+				"customer": customer,
 			},
 		)
 		# ...and produce the same qty onto the unused/loose item under the tagged batch.
+		# The target's stock_uom is pinned equal to the source's by the probe, so the
+		# received qty carries across without a unit conversion.
 		repack.append(
 			"items",
 			{
@@ -5392,6 +5797,8 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 				"is_finished_item": 1,
 				"set_basic_rate_manually": 1,
 				"basic_rate": val_rate,
+				"inventory_type": inventory_type,
+				"customer": customer,
 			},
 		)
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -5484,14 +5484,15 @@ def _probe_unused_loose_item(item_code):
 			return block(
 				UNUSED_NARROWED_TO_NONE,
 				_(
-					"{0} items of template <b>{1}</b> match {2} on Metal Purity <b>{3}</b> "
-					"and Metal Colour <b>{4}</b> ({5}), but none of them also match {6}. "
-					"Create the exact counterpart, or disable all but one of the near "
-					"matches."
+					"No {0} item matches {1} exactly. {2} item(s) of template <b>{3}</b> "
+					"share Metal Purity <b>{4}</b> and Metal Colour <b>{5}</b> ({6}), but "
+					"none of them also match {7}. Create the exact counterpart, or disable "
+					"all but one of the near matches."
 				).format(
+					label,
+					frappe.bold(item_code),
 					len(candidates),
 					template,
-					frappe.bold(item_code),
 					purity,
 					colour,
 					_format_item_list(candidates),
@@ -5520,11 +5521,10 @@ def _probe_unused_loose_item(item_code):
 		return block(
 			UNUSED_NO_MATCH,
 			_(
-				"{0} (Metal Purity <b>{1}</b>, Metal Colour <b>{2}</b>) has no "
-				"Unused/Loose Material counterpart. Create an enabled variant of template "
-				"<b>{3}</b> with that purity and colour and <b>Has Batch No</b> enabled, "
-				"then receive again."
-			).format(frappe.bold(item_code), purity, colour, template),
+				"{0} (Metal Purity <b>{1}</b>, Metal Colour <b>{2}</b>) has no {3} "
+				"counterpart. Create an enabled variant of template <b>{4}</b> with that "
+				"purity and colour and <b>Has Batch No</b> enabled, then receive again."
+			).format(frappe.bold(item_code), purity, colour, label, template),
 		)
 
 	target = candidates[0]

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -4605,6 +4605,28 @@ def _build_replacement_sre(original_sre, remaining_qty, sb_remaining=None):
 
 
 @frappe.whitelist()
+def _existing_receive_se(
+	mo_name, request_id, stock_entry_type="Material Receive (WORK ORDER)"
+):
+	"""The receive Stock Entry a previous call with this ``request_id`` already made.
+
+	The single definition of "this request has already been served", shared by
+	``create_mr_wo_stock_entry``'s idempotency guard and by the Receive Unused/Loose
+	Material pre-flight, so the two can never disagree about whether a call is a replay."""
+	if not (request_id and mo_name):
+		return None
+	return frappe.db.get_value(
+		"Stock Entry",
+		{
+			"custom_request_id": request_id,
+			"manufacturing_operation": mo_name,
+			"stock_entry_type": stock_entry_type,
+			"docstatus": ["!=", 2],
+		},
+		"name",
+	)
+
+
 def create_mr_wo_stock_entry(
 	se_data,
 	request_id=None,
@@ -4645,24 +4667,14 @@ def create_mr_wo_stock_entry(
 		)
 
 	# Idempotency: same request_id under same MOP + SE type returns the existing SE.
-	if request_id:
-		existing = frappe.db.get_value(
-			"Stock Entry",
-			{
-				"custom_request_id": request_id,
-				"manufacturing_operation": mo.name,
-				"stock_entry_type": stock_entry_type,
-				"docstatus": ["!=", 2],
-			},
-			"name",
-		)
-		if existing:
-			return {
-				"doctype": "Stock Entry",
-				"docname": existing,
-				"request_id": request_id,
-				"idempotent": True,
-			}
+	existing = _existing_receive_se(mo.name, request_id, stock_entry_type)
+	if existing:
+		return {
+			"doctype": "Stock Entry",
+			"docname": existing,
+			"request_id": request_id,
+			"idempotent": True,
+		}
 
 	if target_warehouse:
 		t_warehouse = target_warehouse
@@ -5112,7 +5124,14 @@ def create_scrap_wo_stock_entry(se_data, request_id=None):
 	if isinstance(se_data, str):
 		se_data = json.loads(se_data)
 
-	_preflight_unused_loose_targets(se_data)
+	# The pre-flight reads the CLIENT's rows, so it must only gate a genuinely new
+	# receive. On a replay (same request_id) create_mr_wo_stock_entry short-circuits to
+	# the existing SE without looking at the payload at all, and this call exists purely
+	# to re-run a repack that never landed. Validating a stale payload there could reject
+	# a retry over SREs the receive no longer depends on — the repack does its own
+	# resolution against the SE's ACTUAL rows and blocks there if a target is missing.
+	if not _existing_receive_se(se_data.get("manufacturing_operation"), request_id):
+		_preflight_unused_loose_targets(se_data)
 
 	frappe.db.savepoint("receive_unused_loose")
 	try:
@@ -5634,20 +5653,31 @@ def _create_scrap_batch(
 
 
 def _unused_row_ownership(row, target_item):
-	"""``(inventory_type, customer)`` the unused/loose output should carry.
+	"""``(source_ownership, target_ownership)``, each an ``(inventory_type, customer)``.
 
-	Resolved from the SOURCE batch through the app's single source of truth
-	(``resolve_batch_ownership``), then downgraded to Regular Stock when the TARGET item
-	is not allowed to hold customer goods — the target is a different item from the source,
-	so the source carrying the flag guarantees nothing, and minting a Customer Goods batch
-	for an item without it hard-fails in ``Batch.update_inventory_dimentions``."""
+	The two sides are resolved SEPARATELY and are not always equal.
+
+	The **source** side comes from the consumed batch through the app's single source of
+	truth (``resolve_batch_ownership``) and is what the consume row must carry. Stock is
+	deducted along the ``inventory_type`` dimension, and this Stock Entry is
+	``auto_created`` — so ``CustomStockEntry.update_batches`` skips the usual batch->row
+	backfill and whatever is stamped here is what reaches the Stock Ledger Entry. Consuming
+	a Customer Goods batch under "Regular Stock" would deduct the wrong dimension.
+
+	The **target** side is the same ownership, EXCEPT that it downgrades to Regular Stock
+	when the target item is not allowed to hold customer goods. The target is a different
+	item from the source, so the source carrying that flag guarantees nothing, and minting
+	a Customer Goods batch for an item without it hard-fails in
+	``Batch.update_inventory_dimentions``. That downgrade is a real change of ownership and
+	is announced, not silent."""
 	from jewellery_erpnext.jewellery_erpnext.customization.utils.row_ownership import (
 		resolve_batch_ownership,
 	)
 
 	inventory_type, customer = resolve_batch_ownership(row)
+	source = (inventory_type, customer)
 	if inventory_type not in ("Customer Goods", "Customer Stock"):
-		return None, None
+		return source, source
 	if not frappe.db.get_value(
 		"Item", target_item, "custom_inventory_type_can_be_customer_goods"
 	):
@@ -5660,8 +5690,8 @@ def _unused_row_ownership(row, target_item):
 			indicator="orange",
 			alert=True,
 		)
-		return None, None
-	return inventory_type, customer
+		return source, ("Regular Stock", None)
+	return source, source
 
 
 def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
@@ -5736,13 +5766,15 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 
 	for item in rows:
 		target_item = _resolve_unused_loose_item(item.item_code) or item.item_code
-		inventory_type, customer = _unused_row_ownership(item, target_item)
+		(src_type, src_customer), (out_type, out_customer) = _unused_row_ownership(
+			item, target_item
+		)
 		new_batch = _create_scrap_batch(
 			target_item,
 			employee=op_employee,
 			company=se.company,
-			inventory_type=inventory_type,
-			customer=customer,
+			inventory_type=out_type,
+			customer=out_customer,
 		)
 		if not new_batch:
 			if target_item != item.item_code:
@@ -5776,8 +5808,9 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 				"is_finished_item": 0,
 				"set_basic_rate_manually": 1,
 				"basic_rate": val_rate,
-				"inventory_type": inventory_type,
-				"customer": customer,
+				# The consumed batch's OWN dimension — stock is deducted along it.
+				"inventory_type": src_type,
+				"customer": src_customer,
 			},
 		)
 		# ...and produce the same qty onto the unused/loose item under the tagged batch.
@@ -5797,8 +5830,10 @@ def _convert_received_scrap_to_scrap_batch(receive_se_name, request_id=None):
 				"is_finished_item": 1,
 				"set_basic_rate_manually": 1,
 				"basic_rate": val_rate,
-				"inventory_type": inventory_type,
-				"customer": customer,
+				# Matches the minted batch: the source's ownership, downgraded to Regular
+				# Stock only when the target item cannot hold customer goods.
+				"inventory_type": out_type,
+				"customer": out_customer,
 			},
 		)
 

--- a/jewellery_erpnext/patches/add_batch_scrap_type_field.py
+++ b/jewellery_erpnext/patches/add_batch_scrap_type_field.py
@@ -1,9 +1,11 @@
 """Provision the ``Batch.custom_batch_type`` marker used by Unused/Loose Material Refining.
 
 Material left unused by production is received back into the department (the "Receive
-Unused/Loose Material" Manufacturing Operation action) under the SAME item code but on a
-freshly created batch tagged ``custom_batch_type = "Unused/Loose Material"`` — there is no
-dedicated item. Unused/Loose Material Refining then fetches ONLY those batches
+Unused/Loose Material" Manufacturing Operation action) and repacked onto a dedicated
+unused/loose item on a freshly created batch tagged
+``custom_batch_type = "Unused/Loose Material"``. Rows with no such target (diamonds,
+gemstones, alloys) keep their own item code and rely on the tag alone, which is why the tag
+— not the item code — is the marker. Unused/Loose Material Refining fetches ONLY those batches
 (``RefiningEntry.get_scrap_items_balance``), so ordinary department stock sharing the
 warehouse is never pulled into a refining entry.
 

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
@@ -3915,12 +3915,17 @@ class RefiningEntry(Document):
 	def get_scrap_items_balance(self):
 		"""Fetch available unused/loose material from the department warehouse(s).
 
-		Material returned from production comes back under the SAME item code (there is
-		no dedicated item) but on a batch tagged ``custom_batch_type =
+		Material returned from production is repacked onto a DEDICATED unused/loose item
+		(a variant of the Metal / Finding Unused/Loose Material template, or of the legacy
+		``ML``/``FL`` template) on a batch tagged ``custom_batch_type =
 		"Unused/Loose Material"`` by the Manufacturing Operation "Receive Unused/Loose
-		Material" action. Only those batches are fetched (optionally narrowed to the
-		selected item), so ordinary department stock sharing a warehouse is never pulled
-		in. Non-batch stock cannot carry the marker and is excluded.
+		Material" action. Rows with no such target — diamonds, gemstones, alloys — keep
+		their own item code and are isolated by the batch tag alone.
+
+		This fetch is item-agnostic: only the batch tag decides. Only those batches are
+		fetched (optionally narrowed to the selected item), so ordinary department stock
+		sharing a warehouse is never pulled in. Non-batch stock cannot carry the marker and
+		is excluded.
 		"""
 		if self.refining_type != "Unused/Loose Material Refining":
 			frappe.throw(

--- a/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
@@ -1000,6 +1000,95 @@ class TestRefiningEntry(IntegrationTestCase):
 				)
 			receive.assert_not_called()
 
+	def test_unused_loose_preflight_is_skipped_on_a_replay(self):
+		"""A replay (same request_id) must not be gated on the CLIENT's payload.
+
+		create_mr_wo_stock_entry short-circuits to the existing SE without reading
+		receive_items at all, and this call exists only to re-run a repack that never
+		landed. Validating a stale payload there would reject a retry over SREs the
+		receive no longer depends on. The repack still resolves against the SE's actual
+		rows, so a genuinely missing target is caught there."""
+		orphan = self._metal_variant(
+			"M-TEST-REPLAY",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "9KT"),
+				("Metal Purity", "37.5"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		frappe.db.set_value("Item", orphan.name, "has_batch_no", 1)
+		se_data = {
+			"manufacturing_operation": "MOP-REPLAY",
+			"receive_items": [{"stock_reservation_entry": "SRE-TEST", "qty": 1.0}],
+		}
+		with (
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation."
+				"manufacturing_operation._existing_receive_se",
+				return_value="SE-ALREADY-THERE",
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation."
+				"manufacturing_operation._preflight_unused_loose_targets"
+			) as preflight,
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation."
+				"manufacturing_operation.create_mr_wo_stock_entry",
+				return_value={"docname": None},
+			),
+		):
+			create_scrap_wo_stock_entry(se_data, request_id="R-REPLAY")
+			preflight.assert_not_called()
+
+	def test_unused_loose_repack_keeps_source_ownership_on_the_consume_row(self):
+		"""Consume and produce ownership are resolved separately.
+
+		Stock is deducted along the inventory_type dimension and this Stock Entry is
+		auto_created, so update_batches never backfills it — consuming a Customer Goods
+		batch under "Regular Stock" would deduct the wrong dimension. Only the PRODUCE
+		side downgrades, and only when the target item cannot hold customer goods."""
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			_unused_row_ownership,
+		)
+
+		row = frappe._dict(
+			item_code="M-G-22KT-91.9-Y",
+			batch_no=None,
+			inventory_type="Customer Goods",
+			customer=self.customer if hasattr(self, "customer") else None,
+		)
+		target = "ML-G-22KT-91.9-Y"
+		allowed = frappe.db.get_value(
+			"Item", target, "custom_inventory_type_can_be_customer_goods"
+		)
+		try:
+			frappe.db.set_value(
+				"Item", target, "custom_inventory_type_can_be_customer_goods", 0
+			)
+			source, produce = _unused_row_ownership(row, target)
+			self.assertEqual(
+				source[0],
+				"Customer Goods",
+				"the consume row must keep the source batch's dimension",
+			)
+			self.assertEqual(
+				produce[0],
+				"Regular Stock",
+				"the produce row downgrades when the target cannot hold customer goods",
+			)
+
+			frappe.db.set_value(
+				"Item", target, "custom_inventory_type_can_be_customer_goods", 1
+			)
+			source, produce = _unused_row_ownership(row, target)
+			self.assertEqual(source, produce, "no downgrade when the target allows it")
+			self.assertEqual(produce[0], "Customer Goods")
+		finally:
+			frappe.db.set_value(
+				"Item", target, "custom_inventory_type_can_be_customer_goods", allowed
+			)
+
 	def test_unused_loose_audit_classifies_the_seeded_item_master(self):
 		"""One cheap end-to-end call so an import or SQL break in the audit cannot ship
 		unnoticed, and so the deliberate 24KT omission stays asserted."""

--- a/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
@@ -747,6 +747,14 @@ class TestRefiningEntry(IntegrationTestCase):
 		self.addCleanup(
 			frappe.delete_doc, "Item", doc.name, force=1, ignore_permissions=True
 		)
+		if not has_batch_no:
+			# doc_events/item.before_insert force-sets has_batch_no = 1 for every "- V"
+			# item group, so it cannot be turned off through the document API. Write it
+			# after insert — the point of the fixture is a target that CANNOT be tagged.
+			frappe.db.set_value(
+				"Item", doc.name, {"has_batch_no": 0, "create_new_batch": 0}
+			)
+			doc.reload()
 		return doc
 
 	#: The colliding target the tie-break tests share: same purity + colour as
@@ -786,10 +794,10 @@ class TestRefiningEntry(IntegrationTestCase):
 		what turns "no item" into an actionable "create this one"."""
 		self._ml_variant("ML-TEST-AMBIGUOUS", self._AMBIGUOUS_ML_ATTRS)
 		odd = self._metal_variant(
-			"M-TEST-20KT",
+			"M-TEST-24KT-919-Y",
 			[
 				("Metal Type", "Gold"),
-				("Metal Touch", "20KT"),
+				("Metal Touch", "24KT"),
 				("Metal Purity", "91.9"),
 				("Metal Colour", "Yellow"),
 			],
@@ -806,10 +814,10 @@ class TestRefiningEntry(IntegrationTestCase):
 		otherwise be a hard error, so nothing that resolves today can change. The karat
 		mismatch is surfaced by run_unused_loose_audit as an advisory, not here."""
 		odd = self._metal_variant(
-			"M-TEST-20KT-UNIQUE",
+			"M-TEST-24KT-UNIQUE",
 			[
 				("Metal Type", "Gold"),
-				("Metal Touch", "20KT"),
+				("Metal Touch", "24KT"),
 				("Metal Purity", "91.9"),
 				("Metal Colour", "Yellow"),
 			],
@@ -819,57 +827,36 @@ class TestRefiningEntry(IntegrationTestCase):
 	def test_unused_loose_resolver_throws_when_the_target_is_not_batch_tracked(self):
 		"""A target that cannot carry the Unused/Loose Material batch marker would make
 		the material invisible to refining. Block, and say which switch to flip."""
-		source = self._metal_variant(
-			"M-TEST-58.6-W",
-			[
-				("Metal Type", "Gold"),
-				("Metal Touch", "14KT"),
-				("Metal Purity", "58.6"),
-				("Metal Colour", "White"),
-			],
-		)
-		self._ml_variant(
-			"ML-TEST-58.6-W",
-			[
-				("Metal Type", "Gold"),
-				("Metal Touch", "14KT"),
-				("Metal Purity", "58.6"),
-				("Metal Colour", "White"),
-			],
-			has_batch_no=0,
-		)
+		attrs = [
+			("Metal Type", "Gold"),
+			("Metal Touch", "24KT"),
+			("Metal Purity", "92.0"),
+			("Metal Colour", "Yellow"),
+		]
+		source = self._metal_variant("M-TEST-92-Y", attrs)
+		self._ml_variant("ML-TEST-92-Y", attrs, has_batch_no=0)
 		with self.assertRaises(frappe.ValidationError) as caught:
 			_resolve_unused_loose_item(source.name)
 		message = frappe.utils.strip_html(str(caught.exception))
-		self.assertIn("ML-TEST-58.6-W", message)
+		self.assertIn("ML-TEST-92-Y", message)
 		self.assertIn("Has Batch No", message)
 
 	def test_unused_loose_resolver_throws_on_a_uom_mismatch(self):
 		"""The repack copies the received qty verbatim, so two different units would
 		silently book grams as something else."""
-		source = self._metal_variant(
-			"M-TEST-58.6-Y",
-			[
-				("Metal Type", "Gold"),
-				("Metal Touch", "14KT"),
-				("Metal Purity", "58.6"),
-				("Metal Colour", "Yellow"),
-			],
-		)
-		target = self._ml_variant(
-			"ML-TEST-58.6-Y",
-			[
-				("Metal Type", "Gold"),
-				("Metal Touch", "14KT"),
-				("Metal Purity", "58.6"),
-				("Metal Colour", "Yellow"),
-			],
-		)
+		attrs = [
+			("Metal Type", "Gold"),
+			("Metal Touch", "24KT"),
+			("Metal Purity", "92.0"),
+			("Metal Colour", "Pink"),
+		]
+		source = self._metal_variant("M-TEST-92-P", attrs)
+		target = self._ml_variant("ML-TEST-92-P", attrs)
 		frappe.db.set_value("Item", target.name, "stock_uom", "Nos")
 		with self.assertRaises(frappe.ValidationError) as caught:
 			_resolve_unused_loose_item(source.name)
 		message = frappe.utils.strip_html(str(caught.exception))
-		self.assertIn("ML-TEST-58.6-Y", message)
+		self.assertIn("ML-TEST-92-P", message)
 		self.assertIn("Nos", message)
 
 	def test_unused_loose_message_names_the_family_not_the_template(self):
@@ -880,8 +867,8 @@ class TestRefiningEntry(IntegrationTestCase):
 			"M-TEST-NO-TARGET",
 			[
 				("Metal Type", "Gold"),
-				("Metal Touch", "9KT"),
-				("Metal Purity", "37.5"),
+				("Metal Touch", "24KT"),
+				("Metal Purity", "92.0"),
 				("Metal Colour", "Yellow"),
 			],
 		)
@@ -967,8 +954,8 @@ class TestRefiningEntry(IntegrationTestCase):
 			"M-TEST-BLOCKS-EARLY",
 			[
 				("Metal Type", "Gold"),
-				("Metal Touch", "9KT"),
-				("Metal Purity", "37.5"),
+				("Metal Touch", "24KT"),
+				("Metal Purity", "92.0"),
 				("Metal Colour", "Yellow"),
 			],
 		)
@@ -1012,8 +999,8 @@ class TestRefiningEntry(IntegrationTestCase):
 			"M-TEST-REPLAY",
 			[
 				("Metal Type", "Gold"),
-				("Metal Touch", "9KT"),
-				("Metal Purity", "37.5"),
+				("Metal Touch", "24KT"),
+				("Metal Purity", "92.0"),
 				("Metal Colour", "Yellow"),
 			],
 		)
@@ -1052,11 +1039,15 @@ class TestRefiningEntry(IntegrationTestCase):
 			_unused_row_ownership,
 		)
 
+		# A real customer is required: normalize_ownership rule 3 downgrades a customer
+		# TYPE carrying no customer to Regular Stock, so a bare row would prove nothing.
+		customer = frappe.db.get_value("Customer", {"disabled": 0}, "name")
+		self.assertTrue(customer, "test data must contain at least one Customer")
 		row = frappe._dict(
 			item_code="M-G-22KT-91.9-Y",
 			batch_no=None,
 			inventory_type="Customer Goods",
-			customer=self.customer if hasattr(self, "customer") else None,
+			customer=customer,
 		)
 		target = "ML-G-22KT-91.9-Y"
 		allowed = frappe.db.get_value(

--- a/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/test_refining_entry.py
@@ -8,6 +8,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.utils import flt, today
 
 from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+	UNUSED_TARGET_TEMPLATES,
 	_create_scrap_batch,
 	_resolve_unused_loose_item,
 	create_scrap_wo_stock_entry,
@@ -56,6 +57,7 @@ from jewellery_erpnext.refining.doctype.refinery_price_list.refinery_price_list 
 from jewellery_erpnext.refining.doctype.refining_entry.refining_entry import (
 	PURE_LOSS_ITEM,
 )
+from jewellery_erpnext.unused_loose_audit import run_unused_loose_audit
 
 #: Scrap Refining is the operator's weigh-in type: validate_quantities requires a
 #: Physical Quantity > 0. Tests that exercise something else (restrictions, the rename
@@ -437,16 +439,21 @@ class TestRefiningEntry(IntegrationTestCase):
 		minted = set(frappe.get_all("Batch", pluck="name")) - before
 
 		# The received material is booked onto the DEDICATED unused/loose item, not onto
-		# the production code it was issued as: M- becomes ML- and F- becomes FL-. Rows
-		# with no mapping (diamonds, gemstones) keep their own code, so assert the absence
-		# of M/F rather than the presence of only ML/FL.
+		# the production code it was issued as. Rows with no mapping (diamonds, gemstones)
+		# keep their own code, so assert the absence of M/F rather than the presence of
+		# only the targets. The metal target is named per convention — "ML" on this site,
+		# "Metal Unused/Loose Material" on one that created the descriptive template —
+		# so accept either rather than pinning the suite to one item master.
 		minted_templates = {
 			frappe.db.get_value("Item", item, "variant_of")
 			for item in frappe.get_all(
 				"Batch", {"name": ["in", list(minted)]}, pluck="item"
 			)
 		}
-		self.assertIn("ML", minted_templates)
+		self.assertTrue(
+			minted_templates & set(UNUSED_TARGET_TEMPLATES["metal"]),
+			f"no metal unused/loose batch was minted: {minted_templates}",
+		)
 		self.assertFalse(
 			minted_templates & {"M", "F"},
 			f"unused/loose batches must not stay on the production item: {minted_templates}",
@@ -710,56 +717,298 @@ class TestRefiningEntry(IntegrationTestCase):
 			with self.assertRaises(frappe.ValidationError) as caught:
 				_resolve_unused_loose_item("M-G-22KT-91.9-Y")
 			message = str(caught.exception)
+			self.assertIn("M-G-22KT-91.9-Y", message)
 			self.assertIn("91.9", message)
 			self.assertIn("Yellow", message)
 		finally:
 			frappe.db.set_value("Item", "ML-G-22KT-91.9-Y", "disabled", 0)
 
-	def test_unused_loose_resolver_throws_when_more_than_one_target_matches(self):
-		"""Purity + colour alone can match several variants. That is a hard error naming
-		the candidates — never a guess, which would book the metal at the wrong purity."""
-		ambiguous = frappe.get_doc(
+	def _ml_variant(self, item_code, attributes, has_batch_no=1, template="ML"):
+		"""An unused/loose target variant, cleaned up with the test."""
+		doc = frappe.get_doc(
 			{
 				"doctype": "Item",
-				"item_code": "ML-TEST-AMBIGUOUS",
-				"item_name": "ML-TEST-AMBIGUOUS",
+				"item_code": item_code,
+				"item_name": item_code,
 				"gst_hsn_code": "010121",
 				"item_group": "Metal - V",
 				"stock_uom": "Gram",
 				"is_stock_item": 1,
-				"has_batch_no": 1,
-				"create_new_batch": 1,
-				"variant_of": "ML",
+				"has_batch_no": has_batch_no,
+				"create_new_batch": has_batch_no,
+				"variant_of": template,
 				"variant_based_on": "Item Attribute",
-				# Deliberately no Metal Touch: a DIFFERENT attribute set, so ERPNext does
-				# not reject it as a duplicate variant, that still collides on purity+colour.
 				"attributes": [
-					{
-						"variant_of": "ML",
-						"attribute": "Metal Type",
-						"attribute_value": "Gold",
-					},
-					{
-						"variant_of": "ML",
-						"attribute": "Metal Purity",
-						"attribute_value": "91.9",
-					},
-					{
-						"variant_of": "ML",
-						"attribute": "Metal Colour",
-						"attribute_value": "Yellow",
-					},
+					dict(variant_of=template, attribute=a, attribute_value=v)
+					for a, v in attributes
 				],
 			}
 		).insert(ignore_permissions=True)
-		try:
-			with self.assertRaises(frappe.ValidationError) as caught:
-				_resolve_unused_loose_item("M-G-22KT-91.9-Y")
-			message = str(caught.exception)
-			self.assertIn("ML-G-22KT-91.9-Y", message)
-			self.assertIn(ambiguous.name, message)
-		finally:
-			frappe.delete_doc("Item", ambiguous.name, force=1, ignore_permissions=True)
+		self.addCleanup(
+			frappe.delete_doc, "Item", doc.name, force=1, ignore_permissions=True
+		)
+		return doc
+
+	#: The colliding target the tie-break tests share: same purity + colour as
+	#: ML-G-22KT-91.9-Y but a DIFFERENT attribute set (no Metal Touch), so ERPNext does not
+	#: reject it as a duplicate variant while it still collides on the match key.
+	_AMBIGUOUS_ML_ATTRS = (
+		("Metal Type", "Gold"),
+		("Metal Purity", "91.9"),
+		("Metal Colour", "Yellow"),
+	)
+
+	def test_unused_loose_resolver_breaks_a_tie_on_the_remaining_attributes(self):
+		"""Purity + colour alone can match several variants. When it does, the source's
+		OTHER attributes decide — an exact test, never a guess. Here only
+		ML-G-22KT-91.9-Y also carries the source's Metal Touch."""
+		self._ml_variant("ML-TEST-AMBIGUOUS", self._AMBIGUOUS_ML_ATTRS)
+		self.assertEqual(
+			_resolve_unused_loose_item("M-G-22KT-91.9-Y"), "ML-G-22KT-91.9-Y"
+		)
+
+	def test_unused_loose_resolver_throws_when_there_is_nothing_to_narrow_on(self):
+		"""A source carrying ONLY purity and colour has nothing left to break the tie
+		with, so the ambiguity is a hard error naming the candidates."""
+		self._ml_variant("ML-TEST-AMBIGUOUS", self._AMBIGUOUS_ML_ATTRS)
+		bare = self._metal_variant(
+			"M-TEST-BARE",
+			[("Metal Purity", "91.9"), ("Metal Colour", "Yellow")],
+		)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			_resolve_unused_loose_item(bare.name)
+		message = str(caught.exception)
+		self.assertIn("ML-G-22KT-91.9-Y", message)
+		self.assertIn("ML-TEST-AMBIGUOUS", message)
+
+	def test_unused_loose_resolver_throws_when_narrowing_leaves_nothing(self):
+		"""Near matches on purity+colour, none of them the same metal. Naming them is
+		what turns "no item" into an actionable "create this one"."""
+		self._ml_variant("ML-TEST-AMBIGUOUS", self._AMBIGUOUS_ML_ATTRS)
+		odd = self._metal_variant(
+			"M-TEST-20KT",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "20KT"),
+				("Metal Purity", "91.9"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			_resolve_unused_loose_item(odd.name)
+		message = frappe.utils.strip_html(str(caught.exception))
+		self.assertIn("Metal Unused/Loose Material", message)
+		self.assertIn("ML-G-22KT-91.9-Y", message)
+
+	def test_unused_loose_resolver_never_narrows_a_unique_match(self):
+		"""The match key is purity + colour, full stop. A unique match is returned even
+		when Metal Touch disagrees — the tie-break only ever runs on a set that would
+		otherwise be a hard error, so nothing that resolves today can change. The karat
+		mismatch is surfaced by run_unused_loose_audit as an advisory, not here."""
+		odd = self._metal_variant(
+			"M-TEST-20KT-UNIQUE",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "20KT"),
+				("Metal Purity", "91.9"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		self.assertEqual(_resolve_unused_loose_item(odd.name), "ML-G-22KT-91.9-Y")
+
+	def test_unused_loose_resolver_throws_when_the_target_is_not_batch_tracked(self):
+		"""A target that cannot carry the Unused/Loose Material batch marker would make
+		the material invisible to refining. Block, and say which switch to flip."""
+		source = self._metal_variant(
+			"M-TEST-58.6-W",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "14KT"),
+				("Metal Purity", "58.6"),
+				("Metal Colour", "White"),
+			],
+		)
+		self._ml_variant(
+			"ML-TEST-58.6-W",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "14KT"),
+				("Metal Purity", "58.6"),
+				("Metal Colour", "White"),
+			],
+			has_batch_no=0,
+		)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			_resolve_unused_loose_item(source.name)
+		message = frappe.utils.strip_html(str(caught.exception))
+		self.assertIn("ML-TEST-58.6-W", message)
+		self.assertIn("Has Batch No", message)
+
+	def test_unused_loose_resolver_throws_on_a_uom_mismatch(self):
+		"""The repack copies the received qty verbatim, so two different units would
+		silently book grams as something else."""
+		source = self._metal_variant(
+			"M-TEST-58.6-Y",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "14KT"),
+				("Metal Purity", "58.6"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		target = self._ml_variant(
+			"ML-TEST-58.6-Y",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "14KT"),
+				("Metal Purity", "58.6"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		frappe.db.set_value("Item", target.name, "stock_uom", "Nos")
+		with self.assertRaises(frappe.ValidationError) as caught:
+			_resolve_unused_loose_item(source.name)
+		message = frappe.utils.strip_html(str(caught.exception))
+		self.assertIn("ML-TEST-58.6-Y", message)
+		self.assertIn("Nos", message)
+
+	def test_unused_loose_message_names_the_family_not_the_template(self):
+		"""On this site the templates are literally called ML and FL. The operator knows
+		this material as "Metal/Finding Unused/Loose Material", so the message must lead
+		with the FAMILY label — deriving it from the template would say "ML item"."""
+		orphan = self._metal_variant(
+			"M-TEST-NO-TARGET",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "9KT"),
+				("Metal Purity", "37.5"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			_resolve_unused_loose_item(orphan.name)
+		message = frappe.utils.strip_html(str(caught.exception))
+		self.assertIn("Metal Unused/Loose Material", message)
+		self.assertNotIn("ML item is not there", message)
+
+	def test_unused_loose_target_prefers_the_descriptive_template(self):
+		"""A site that has created the dedicated "Metal Unused/Loose Material" template
+		must book onto it, not onto the legacy ML loss template."""
+		template = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": "Metal Unused/Loose Material",
+				"item_name": "Metal Unused/Loose Material",
+				"gst_hsn_code": "010121",
+				"item_group": "Metal - T",
+				"stock_uom": "Gram",
+				"is_stock_item": 0,
+				"has_variants": 1,
+				"variant_based_on": "Item Attribute",
+				"attributes": [
+					{"attribute": "Metal Type"},
+					{"attribute": "Metal Touch"},
+					{"attribute": "Metal Purity"},
+					{"attribute": "Metal Colour"},
+				],
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(
+			frappe.delete_doc, "Item", template.name, force=1, ignore_permissions=True
+		)
+		# Deliberately keyed on purity + colour only, exactly as the live sites create
+		# them — no Finding/size attributes, so the match is unambiguous.
+		self._ml_variant(
+			"Metal Unused/Loose Material-G-22KT-91.9-Y",
+			[("Metal Purity", "91.9"), ("Metal Colour", "Yellow")],
+			template=template.name,
+		)
+		self.assertEqual(
+			_resolve_unused_loose_item("M-G-22KT-91.9-Y"),
+			"Metal Unused/Loose Material-G-22KT-91.9-Y",
+		)
+
+	def test_unused_loose_never_falls_back_once_the_template_exists(self):
+		"""Creating the descriptive template COMMITS the site to it. A purity+colour with
+		no variant under it — or whose variant has been disabled — must BLOCK, never
+		resolve quietly onto the legacy ML/FL loss item. Silently booking the metal onto
+		the old code is exactly what this feature exists to prevent, and it is how a
+		disabled item master entry would go unnoticed."""
+		template = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": "Metal Unused/Loose Material",
+				"item_name": "Metal Unused/Loose Material",
+				"gst_hsn_code": "010121",
+				"item_group": "Metal - T",
+				"stock_uom": "Gram",
+				"is_stock_item": 0,
+				"has_variants": 1,
+				"variant_based_on": "Item Attribute",
+				"attributes": [
+					{"attribute": "Metal Purity"},
+					{"attribute": "Metal Colour"},
+				],
+			}
+		).insert(ignore_permissions=True)
+		self.addCleanup(
+			frappe.delete_doc, "Item", template.name, force=1, ignore_permissions=True
+		)
+		with self.assertRaises(frappe.ValidationError) as caught:
+			_resolve_unused_loose_item("M-G-22KT-91.9-Y")
+		message = frappe.utils.strip_html(str(caught.exception))
+		self.assertIn("Metal Unused/Loose Material", message)
+		self.assertNotIn("ML-G-22KT-91.9-Y", message)
+
+	def test_unused_loose_receive_blocks_before_any_stock_moves(self):
+		"""The whole point of the pre-flight: an item-master gap makes the action a
+		no-op, not a submit-then-unwind that leaves an error-log trail."""
+		orphan = self._metal_variant(
+			"M-TEST-BLOCKS-EARLY",
+			[
+				("Metal Type", "Gold"),
+				("Metal Touch", "9KT"),
+				("Metal Purity", "37.5"),
+				("Metal Colour", "Yellow"),
+			],
+		)
+		frappe.db.set_value("Item", orphan.name, "has_batch_no", 1)
+
+		real_get_all = frappe.db.get_all
+
+		def only_sre_lookup_is_faked(doctype, *args, **kwargs):
+			"""Stand in for the SRE re-read, leave every other query real."""
+			if doctype == "Stock Reservation Entry":
+				return [orphan.name]
+			return real_get_all(doctype, *args, **kwargs)
+
+		with (
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation."
+				"manufacturing_operation.create_mr_wo_stock_entry"
+			) as receive,
+			patch.object(frappe.db, "get_all", side_effect=only_sre_lookup_is_faked),
+		):
+			with self.assertRaises(frappe.ValidationError):
+				create_scrap_wo_stock_entry(
+					{
+						"manufacturing_operation": "MOP-TEST",
+						"receive_items": [
+							{"stock_reservation_entry": "SRE-TEST", "qty": 1.0}
+						],
+					}
+				)
+			receive.assert_not_called()
+
+	def test_unused_loose_audit_classifies_the_seeded_item_master(self):
+		"""One cheap end-to-end call so an import or SQL break in the audit cannot ship
+		unnoticed, and so the deliberate 24KT omission stays asserted."""
+		rows = run_unused_loose_audit(family="metal", scope="all", as_dict=True)
+		by_item = {row.item_code: row for row in rows}
+		self.assertIn("M-G-24KT-99.9-Y", by_item)
+		self.assertEqual(by_item["M-G-24KT-99.9-Y"].status, "NO_MATCH")
+		# Alloys are out of scope by design and must never appear as a gap.
+		self.assertNotIn("M-TEST-ALLOY", by_item)
 
 	def test_scrap_batch_is_not_minted_for_a_non_batch_item(self):
 		"""_create_scrap_batch returns None for a non-batch item — the signal the repack

--- a/jewellery_erpnext/unused_loose_audit.py
+++ b/jewellery_erpnext/unused_loose_audit.py
@@ -1,0 +1,178 @@
+"""Which source items have no usable Unused/Loose Material target — read-only.
+
+The "Receive Unused/Loose Material" action on Manufacturing Operation books returned
+material onto a dedicated item carrying the same Metal Purity and Metal Colour as the
+item it came from, and BLOCKS the whole receive when no such item exists. This report
+lists the gaps up front so the item master can be filled in before an operator hits them.
+
+It shares ``_probe_unused_loose_item`` with the resolver, so what this lists and what the
+button blocks on can never drift apart.
+
+NEVER WRITES. There is deliberately no repair mode: creating an item master entry is a
+decision about how material is classified, not a mechanical fix.
+"""
+
+
+import frappe
+
+from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+	UNUSED_OK,
+	UNUSED_OUT_OF_SCOPE,
+	UNUSED_SOURCE_FAMILY,
+	UNUSED_TARGET_TEMPLATES,
+	_format_item_list,
+	_item_attributes,
+	_probe_unused_loose_item,
+	_unused_target_template,
+)
+
+#: Reported alongside a resolved target rather than as a failure: the source and its
+#: target disagree on karat. The match key is purity + colour by design, so this does not
+#: block anything — but a 18KT source landing on a 22KT-labelled item is worth a look.
+TOUCH_MISMATCH = "TOUCH_MISMATCH"
+
+_TOUCH_ATTRIBUTE = "Metal Touch"
+
+
+def _source_templates(family=None):
+	"""Source item templates in scope, optionally narrowed to one family."""
+	return sorted(
+		template
+		for template, fam in UNUSED_SOURCE_FAMILY.items()
+		if (not family or fam == family) and frappe.db.exists("Item", template)
+	)
+
+
+def _source_items(templates, scope):
+	"""Active variants of ``templates``, narrowed by ``scope``."""
+	items = set(
+		frappe.db.get_all(
+			"Item",
+			filters={"variant_of": ["in", templates], "disabled": 0},
+			pluck="name",
+		)
+	)
+	if not items or scope == "all":
+		return sorted(items)
+
+	if scope == "sre":
+		reserved = frappe.db.get_all(
+			"Stock Reservation Entry",
+			filters={"docstatus": 1, "item_code": ["in", list(items)]},
+			pluck="item_code",
+			distinct=True,
+		)
+		return sorted(set(reserved))
+
+	if scope == "stock":
+		warehouses = frappe.db.get_all(
+			"Warehouse",
+			filters={
+				"warehouse_type": ["in", ["Raw Material", "Scrap"]],
+				"is_group": 0,
+			},
+			pluck="name",
+		)
+		if not warehouses:
+			return []
+		in_stock = frappe.db.get_all(
+			"Bin",
+			filters={
+				"item_code": ["in", list(items)],
+				"warehouse": ["in", warehouses],
+				"actual_qty": [">", 0],
+			},
+			pluck="item_code",
+			distinct=True,
+		)
+		return sorted(set(in_stock))
+
+	frappe.throw(f"Unknown scope {scope!r}. Use 'sre', 'stock' or 'all'.")
+
+
+def run_unused_loose_audit(family=None, scope="sre", limit=None, as_dict=False):
+	"""Every source variant whose Unused/Loose Material target is missing or unusable.
+
+	``family``  "metal" | "finding" | None (both).
+	``scope``   "sre"   (default) only items reserved by a submitted Stock Reservation
+	                    Entry — i.e. exactly what can actually be received today.
+	            "stock" items with stock in a Raw Material / Scrap warehouse.
+	            "all"   every non-disabled variant of every mapped source template.
+	``limit``   cap the number of reported rows (the summary still counts everything).
+	"""
+	if family and family not in UNUSED_TARGET_TEMPLATES:
+		frappe.throw(
+			f"Unknown family {family!r}. Use {' or '.join(sorted(UNUSED_TARGET_TEMPLATES))}."
+		)
+
+	print(f"Scope: {scope}" + (f"   Family: {family}" if family else ""))
+	for fam in sorted(UNUSED_TARGET_TEMPLATES):
+		if family and fam != family:
+			continue
+		resolved = _unused_target_template(fam)
+		print(
+			f"  {fam:8s} target template: {resolved or '(none usable)'}"
+			f"   [candidates: {', '.join(UNUSED_TARGET_TEMPLATES[fam])}]"
+		)
+
+	templates = _source_templates(family)
+	if not templates:
+		print("No source item templates on this site — nothing to audit.")
+		return [] if as_dict else None
+
+	rows = []
+	counts = {}
+	for item_code in _source_items(templates, scope):
+		probe = _probe_unused_loose_item(item_code)
+		status = probe.status
+		if status == UNUSED_OUT_OF_SCOPE:
+			continue
+		if status == UNUSED_OK:
+			source_touch = _item_attributes(item_code).get(_TOUCH_ATTRIBUTE)
+			target_touch = _item_attributes(probe.target).get(_TOUCH_ATTRIBUTE)
+			if not (source_touch and target_touch and source_touch != target_touch):
+				continue
+			status = TOUCH_MISMATCH
+
+		counts[status] = counts.get(status, 0) + 1
+		rows.append(
+			frappe._dict(
+				status=status,
+				item_code=item_code,
+				family=probe.family,
+				purity=probe.purity,
+				colour=probe.colour,
+				template=probe.template,
+				target=probe.target,
+				candidates=probe.candidates,
+			)
+		)
+
+	rows.sort(key=lambda r: (r.status, r.item_code))
+	shown = rows[: int(limit)] if limit else rows
+
+	print()
+	if not rows:
+		print("No gaps: every source item in scope resolves to a usable target.")
+	else:
+		width = max(len(r.item_code) for r in shown) if shown else 12
+		for row in shown:
+			detail = row.target or (
+				_format_item_list(row.candidates, limit=3) if row.candidates else "-"
+			)
+			print(
+				f"  {row.status:18s} {row.item_code:{width}s} "
+				f"purity={str(row.purity):8s} colour={str(row.colour):14s} -> {detail}"
+			)
+		if len(rows) > len(shown):
+			print(
+				f"  ... {len(rows) - len(shown)} more row(s) not shown (limit={limit})"
+			)
+
+	print()
+	print(f"Summary ({len(rows)} row(s)):")
+	for status, count in sorted(counts.items()):
+		print(f"  {status:18s} {count}")
+
+	if as_dict:
+		return rows


### PR DESCRIPTION


Resolves the target by Metal Purity + Metal Colour, prefers the descriptive template over the legacy ML/FL, and blocks the receive when no enabled target exists instead of silently falling back.