### PR TITLE
Add FG Purchase Rate handling to Purchase Order and Manufacturing Plan

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doc_events/bom_utils.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/bom_utils.py
@@ -73,6 +73,104 @@ def set_bom_rate(self):
 	for row in self.gemstone_detail:
 		self.gemstone_fg_purchase += row.fg_purchase_amount if row.fg_purchase_amount else 0
 
+	warn_missing_fg_purchase_rate(self)
+
+
+# (child table fieldname, label, price master to check)
+FG_PURCHASE_RATE_SOURCES = (
+	("metal_detail", "Metal Detail", "Making Charge Price"),
+	("finding_detail", "Finding Detail", "Making Charge Price"),
+	("diamond_detail", "Diamond Detail", "Diamond Price List"),
+	("gemstone_detail", "Gemstone Detail", "Gemstone Price List"),
+)
+
+
+def warn_missing_fg_purchase_rate(self):
+	"""Report raw-material rows left without a supplier FG purchase rate.
+
+	The per-table lookups fail quietly: `_set_total_making_charges` assigns nothing at all when no
+	`Making Charge Price` row matches, and `get_gemstone_rate` bails out of its whole loop on the
+	first unpriced stone. Without this the only symptom is a zero rate on the Purchase Order, long
+	after the fact.
+
+	Limited to Manufacturing Process BOMs -- that is the `bom_type` the FG Purchase order reads
+	via `purchase_order.update_rate`, so warning on any other type would only be noise.
+	"""
+	if self.bom_type != "Manufacturing Process":
+		return
+
+	# The Purchase Order self-heal reports its own consolidated summary across every BOM on the
+	# order -- one msgprint per BOM there would be noise.
+	if frappe.flags.get("ignore_fg_rate_warning"):
+		return
+
+	missing = []
+	for fieldname, label, price_master in FG_PURCHASE_RATE_SOURCES:
+		for row in self.get(fieldname) or []:
+			if not flt(row.get("fg_purchase_rate")):
+				missing.append(
+					_("{0} Row #{1}: no FG Purchase Rate - check {2} for customer {3}").format(
+						label, row.idx, price_master, self.customer or _("(not set)")
+					)
+				)
+
+	if missing:
+		frappe.msgprint(
+			"<br>".join(missing),
+			title=_("FG Purchase Rate Missing"),
+			indicator="orange",
+		)
+
+
+def refetch_fg_purchase_rate(bom_names, quiet=False):
+	"""Re-run `BOM.validate` on each BOM so `set_bom_rate` fetches `fg_purchase_rate` from the
+	customer price lists for the metal, finding, diamond and gemstone rows, sets
+	`fg_purchase_amount = fg_purchase_rate * qty`, and rolls the totals up into the BOM Amount tab.
+
+	Needed because the Manufacturing BOM is the Sales Order BOM re-labelled in place with a raw
+	`frappe.db.set_value` (`ManufacturingPlan.validate_qty_with_bom_creation`,
+	`sales_order.create_new_bom`), so `BOM.validate` has never run against
+	`bom_type = "Manufacturing Process"` and the rates are still whatever the Quotation-time save
+	produced.
+
+	Pass `quiet=True` when the caller reports its own summary (the Purchase Order self-heal).
+
+	Returns a dict of `updated` / `skipped` / `failed` BOM names.
+	"""
+	updated, skipped, failed = [], [], []
+
+	for bom_name in sorted(set(bom_names)):
+		# A submitted BOM takes the update_after_submit path on save, which does not run validate --
+		# nothing would be fetched, so skip it rather than write for no reason.
+		if frappe.db.get_value("BOM", bom_name, "docstatus") == 1:
+			skipped.append(bom_name)
+			continue
+
+		# BOM.validate can throw (missing gemstone price list type, missing metal purity, and any
+		# schema drift on the site). Contain each BOM in a savepoint so one bad BOM neither leaves
+		# partial writes behind nor aborts the caller.
+		save_point = "sp" + frappe.generate_hash(length=8)
+		frappe.db.savepoint(save_point)
+		try:
+			frappe.get_doc("BOM", bom_name).save(ignore_permissions=True)
+			frappe.db.release_savepoint(save_point)
+			updated.append(bom_name)
+		except Exception:
+			frappe.db.rollback(save_point=save_point)
+			frappe.log_error(
+				title=f"FG Purchase Rate fetch failed: {bom_name}", message=frappe.get_traceback()
+			)
+			failed.append(bom_name)
+
+	if failed and not quiet:
+		frappe.msgprint(
+			_("Could not fetch FG Purchase Rate for BOM: {0}").format(", ".join(failed)),
+			title=_("FG Purchase Rate"),
+			indicator="orange",
+		)
+
+	return {"updated": updated, "skipped": skipped, "failed": failed}
+
 
 def get_gold_rate(self):
 	# Get the metal purity from the self object or default to 0

--- a/jewellery_erpnext/jewellery_erpnext/doc_events/purchase_order.py
+++ b/jewellery_erpnext/jewellery_erpnext/doc_events/purchase_order.py
@@ -2,8 +2,43 @@ import json
 
 import frappe
 from erpnext.setup.utils import get_exchange_rate
+from frappe import _
+from frappe.utils import flt
+
+from jewellery_erpnext.jewellery_erpnext.doc_events.bom_utils import refetch_fg_purchase_rate
 
 # from jewellery_erpnext.utils import update_existing
+
+BOM_AMOUNT_FIELDS = [
+	"making_fg_purchase",
+	"finding_bom_amount",
+	"diamond_fg_purchase",
+	"gemstone_fg_purchase",
+	"certification_amount",
+	"freight_amount",
+	"hallmarking_amount",
+	"custom_duty_amount",
+]
+
+# bom_type and docstatus decide whether an unpriced BOM can be repriced at all.
+BOM_STATE_FIELDS = BOM_AMOUNT_FIELDS + ["bom_type", "docstatus"]
+
+# The amounts the FG Purchase rate is actually built from. If every one is zero the BOM has never
+# been priced, as opposed to being legitimately worth nothing.
+FG_AMOUNT_FIELDS = (
+	"making_fg_purchase",
+	"finding_bom_amount",
+	"diamond_fg_purchase",
+	"gemstone_fg_purchase",
+)
+
+# bom.py only runs set_bom_rate for these types -- saving any other type (notably "Template")
+# is a no-op, so never spend a BOM save attempting it.
+PRICEABLE_BOM_TYPES = ("Quotation", "Sales Order", "Manufacturing Process")
+
+# One Purchase Order can carry 150 rows. Repricing every unpriced BOM inline would run 150 full
+# BOM validates in a single request, so heal this many per save and report the remainder.
+MAX_INLINE_BOM_REFETCH = 25
 
 
 def validate(self, method):
@@ -11,52 +46,160 @@ def validate(self, method):
 
 
 def update_rate(self):
-	if self.purchase_type == "FG Purchase":
-		bom_data = frappe._dict()
-		for row in self.items:
-			if row.manufacturing_bom:
-				# confirm with Rajnibhai on 8 Jan 2025
-				# bom_doc = frappe.get_doc("BOM", row.manufacturing_bom)
-				# bom_doc.gold_rate_with_gst = self.gold_rate_with_gst
-				# bom_doc.validate()
-				# bom_doc.save()
+	if self.purchase_type != "FG Purchase":
+		return
 
-				field = [
-					"making_fg_purchase",
-					"finding_bom_amount",
-					"diamond_fg_purchase",
-					"gemstone_fg_purchase",
-					"certification_amount",
-					"freight_amount",
-					"hallmarking_amount",
-					"custom_duty_amount",
-				]
+	bom_data = frappe._dict()
+	heal = frappe._dict(attempted=set(), repriced=set(), unpriced=set(), deferred=set())
+	updated = False
 
-				if not bom_data.get(row.manufacturing_bom):
-					bom_data[row.manufacturing_bom] = frappe.db.get_value(
-						"BOM", row.manufacturing_bom, field, as_dict=1
-					)
-				bom_doc = bom_data.get(row.manufacturing_bom)
-				row.making_amount = bom_doc.making_fg_purchase
-				row.finding_amount = bom_doc.finding_bom_amount
-				row.diamond_amount = bom_doc.diamond_fg_purchase
-				row.gemstone_amount = bom_doc.gemstone_fg_purchase
-				row.custom_certification_amount = bom_doc.certification_amount
-				row.custom_freight_amount = bom_doc.freight_amount
-				row.custom_hallmarking_amount = bom_doc.hallmarking_amount
-				row.custom_custom_duty_amount = bom_doc.custom_duty_amount
+	for row in self.items:
+		if not row.manufacturing_bom:
+			continue
 
-				row.rate = (
-					row.metal_amount
-					+ row.making_amount
-					+ row.finding_amount
-					+ row.diamond_amount
-					+ row.gemstone_amount
-					+ row.custom_certification_amount
-					+ row.custom_freight_amount
-					+ row.custom_hallmarking_amount
-					+ row.custom_custom_duty_amount
+		# confirm with Rajnibhai on 8 Jan 2025
+		# bom_doc = frappe.get_doc("BOM", row.manufacturing_bom)
+		# bom_doc.gold_rate_with_gst = self.gold_rate_with_gst
+		# bom_doc.validate()
+		# bom_doc.save()
+
+		if row.manufacturing_bom not in bom_data:
+			bom_data[row.manufacturing_bom] = _get_bom_state(row.manufacturing_bom)
+
+		bom_doc = bom_data.get(row.manufacturing_bom)
+		if not bom_doc:
+			frappe.throw(
+				_("Row #{0}: Manufacturing BOM {1} does not exist.").format(
+					row.idx, row.manufacturing_bom
 				)
+			)
+
+		# A BOM with no FG amounts at all was never priced -- Manufacturing Plan adopts the Sales
+		# Order BOM with a raw db.set_value, so BOM.validate (and set_bom_rate with it) never ran.
+		# Fetch the rates once, here, at the point of use.
+		if _needs_fg_rate(bom_doc):
+			bom_doc = _fetch_fg_rate(row.manufacturing_bom, bom_data, heal)
+
+		row.making_amount = flt(bom_doc.making_fg_purchase)
+		row.finding_amount = flt(bom_doc.finding_bom_amount)
+		row.diamond_amount = flt(bom_doc.diamond_fg_purchase)
+		row.gemstone_amount = flt(bom_doc.gemstone_fg_purchase)
+		row.custom_certification_amount = flt(bom_doc.certification_amount)
+		row.custom_freight_amount = flt(bom_doc.freight_amount)
+		row.custom_hallmarking_amount = flt(bom_doc.hallmarking_amount)
+		row.custom_custom_duty_amount = flt(bom_doc.custom_duty_amount)
+
+		row.rate = flt(
+			flt(row.metal_amount)
+			+ row.making_amount
+			+ row.finding_amount
+			+ row.diamond_amount
+			+ row.gemstone_amount
+			+ row.custom_certification_amount
+			+ row.custom_freight_amount
+			+ row.custom_hallmarking_amount
+			+ row.custom_custom_duty_amount,
+			row.precision("rate"),
+		)
+		updated = True
+
+	_report_unpriced(heal)
+
+	if updated:
+		# doc_events `validate` handlers run AFTER the controller's own validate (frappe's
+		# Document.hook compose()), so calculate_taxes_and_totals() has already run against the
+		# pre-update rates -- amount, net_amount and the document totals would otherwise stay one
+		# save behind. Called directly rather than via run_method so the hooks do not re-enter.
+		self.calculate_taxes_and_totals()
+		# set_total_in_words() is a separate call in AccountsController.validate (line ~309), so
+		# it also ran against the old total and would still print "INR Zero only".
+		self.set_total_in_words()
+
+
+def _get_bom_state(bom_name):
+	return frappe.db.get_value("BOM", bom_name, BOM_STATE_FIELDS, as_dict=1)
+
+
+def _needs_fg_rate(bom_doc):
+	"""True when nothing the Purchase Order reads from this BOM has ever been priced."""
+	return not any(flt(bom_doc.get(field)) for field in FG_AMOUNT_FIELDS)
+
+
+def _fetch_fg_rate(bom_name, bom_data, heal):
+	"""Reprice one unpriced BOM in place, at most once per Purchase Order save.
+
+	Returns the BOM state to use for this row -- refreshed when the fetch ran, otherwise the
+	original. Never raises: `refetch_fg_purchase_rate` contains each BOM in a savepoint, so a BOM
+	that throws during validate rolls back on its own and the Purchase Order still saves.
+	"""
+	if bom_name in heal.attempted:
+		return bom_data[bom_name]
+
+	heal.attempted.add(bom_name)
+	bom_doc = bom_data[bom_name]
+
+	# Saving a type bom.py excludes, or a submitted BOM, fetches nothing -- do not spend the save.
+	if bom_doc.docstatus != 0 or bom_doc.bom_type not in PRICEABLE_BOM_TYPES:
+		heal.unpriced.add(bom_name)
+		return bom_doc
+
+	# Budget the BOM *saves*, not the rows looked at -- an order full of Template BOMs must not
+	# exhaust the cap and defer the handful of BOMs that could actually have been repriced.
+	if len(heal.repriced) >= MAX_INLINE_BOM_REFETCH:
+		heal.deferred.add(bom_name)
+		return bom_doc
+
+	heal.repriced.add(bom_name)
+
+	# Each BOM warns about its own unpriced rows; this function reports one consolidated message.
+	frappe.flags.ignore_fg_rate_warning = True
+	try:
+		refetch_fg_purchase_rate([bom_name], quiet=True)
+	finally:
+		frappe.flags.ignore_fg_rate_warning = False
+
+	bom_data[bom_name] = _get_bom_state(bom_name) or bom_doc
+	if _needs_fg_rate(bom_data[bom_name]):
+		heal.unpriced.add(bom_name)
+
+	return bom_data[bom_name]
+
+
+def _report_unpriced(heal):
+	"""One message for the whole order rather than one per BOM."""
+	if heal.unpriced:
+		frappe.msgprint(
+			_("No FG Purchase Rate found for BOM: {0}<br>Check Making Charge Price and Diamond "
+			  "Price List for this customer.").format(", ".join(sorted(heal.unpriced))),
+			title=_("FG Purchase Rate"),
+			indicator="orange",
+		)
+
+	if heal.deferred:
+		frappe.msgprint(
+			_("{0} more BOM(s) still need pricing. Save again, or use 'Fetch FG Purchase "
+			  "Rate'.").format(len(heal.deferred)),
+			title=_("FG Purchase Rate"),
+			indicator="orange",
+		)
+
+
+@frappe.whitelist()
+def fetch_fg_purchase_rate(purchase_order):
+	"""Re-fetch supplier FG purchase rates into the BOMs this Purchase Order reads.
+
+	Manufacturing Plan does this at submit time (`ManufacturingPlan.fetch_fg_purchase_rate`), but
+	BOMs adopted before that existed -- or priced before the customer price masters were filled in
+	-- still hold stale rates. Saving the BOM runs `BOM.validate` -> `set_bom_rate`, which fetches
+	`fg_purchase_rate` for the metal, finding, diamond and gemstone rows and rolls the amounts up
+	into the BOM Amount tab.
+	"""
+	doc = frappe.get_doc("Purchase Order", purchase_order)
+	doc.check_permission("write")
+
+	return refetch_fg_purchase_rate(
+		row.manufacturing_bom for row in doc.items if row.manufacturing_bom
+	)
 
 
 def make_subcontracting_order(doc):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_plan/manufacturing_plan.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_plan/manufacturing_plan.py
@@ -9,6 +9,7 @@ from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint
 
+from jewellery_erpnext.jewellery_erpnext.doc_events.bom_utils import refetch_fg_purchase_rate
 from jewellery_erpnext.jewellery_erpnext.doc_events.purchase_order import make_subcontracting_order
 from jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.parent_manufacturing_order import (
 	make_manufacturing_order,
@@ -36,7 +37,25 @@ class ManufacturingPlan(Document):
 				frappe.throw(f"Row:{row.idx} Manufacturing Bom Missing")
 
 		if is_subcontracting:
+			self.fetch_fg_purchase_rate()
 			create_subcontracting_order(self)
+
+	def fetch_fg_purchase_rate(self):
+		"""Fetch supplier FG purchase rates into the Manufacturing BOMs before the Purchase Order
+		reads them.
+
+		The Manufacturing BOM is the Sales Order BOM re-labelled in place by
+		`validate_qty_with_bom_creation`, using a raw `frappe.db.set_value`. So `BOM.validate` has
+		never run against `bom_type = "Manufacturing Process"`, and `set_bom_rate` has never fetched
+		`fg_purchase_rate` from the customer price lists for it -- the rates are still whatever the
+		Quotation-time save produced. `refetch_fg_purchase_rate` runs that fetch, containing each
+		BOM in a savepoint so one unpriceable BOM cannot block the whole Manufacturing Plan submit.
+		"""
+		refetch_fg_purchase_rate(
+			row.manufacturing_bom
+			for row in self.manufacturing_plan_table
+			if row.subcontracting and row.manufacturing_bom
+		)
 
 	def on_cancel(self):
 		for row in self.manufacturing_plan_table:

--- a/jewellery_erpnext/public/js/doctype_js/purchase_order.js
+++ b/jewellery_erpnext/public/js/doctype_js/purchase_order.js
@@ -24,6 +24,7 @@ frappe.ui.form.on("Purchase Order", {
 	refresh(frm) {
 		set_si_reference_field_filter(frm);
 		get_items(frm);
+		add_fetch_fg_purchase_rate_button(frm);
 	},
 	purchase_type(frm) {
 		filter_supplier(frm);
@@ -1535,6 +1536,46 @@ let set_si_reference_field_filter = (frm) => {
 				sales_type: "Branch Sales",
 			},
 		};
+	});
+};
+
+let add_fetch_fg_purchase_rate_button = (frm) => {
+	// Re-fetches supplier FG purchase rates into the Manufacturing BOMs this order reads.
+	// Manufacturing Plan does this at submit; this covers BOMs priced before the customer
+	// price masters were filled in.
+	if (frm.doc.purchase_type !== "FG Purchase" || frm.doc.docstatus !== 0) return;
+	if (!(frm.doc.items || []).some((row) => row.manufacturing_bom)) return;
+
+	frm.add_custom_button(__("Fetch FG Purchase Rate"), function () {
+		frappe.call({
+			method: "jewellery_erpnext.jewellery_erpnext.doc_events.purchase_order.fetch_fg_purchase_rate",
+			args: { purchase_order: frm.doc.name },
+			freeze: true,
+			freeze_message: __("Fetching FG Purchase Rate from customer price lists..."),
+			callback: function (r) {
+				if (!r.message) return;
+				let updated = r.message.updated || [];
+				let skipped = r.message.skipped || [];
+				let failed = r.message.failed || [];
+
+				let lines = [];
+				if (updated.length) lines.push(__("Updated: {0}", [updated.join(", ")]));
+				if (skipped.length)
+					lines.push(__("Skipped (submitted BOM): {0}", [skipped.join(", ")]));
+				if (failed.length) lines.push(__("Failed: {0}", [failed.join(", ")]));
+
+				frappe.msgprint({
+					title: __("FG Purchase Rate"),
+					message: lines.join("<br>") || __("No Manufacturing BOM to update."),
+					indicator: failed.length ? "orange" : "green",
+				});
+
+				// Force a save so the server-side validate hook re-reads the BOM amounts onto
+				// the rows -- reload_doc alone would not re-run update_rate.
+				frm.dirty();
+				frm.save();
+			},
+		});
 	});
 };
 


### PR DESCRIPTION
- Implemented `fetch_fg_purchase_rate` method in Manufacturing Plan to update FG purchase rates for Manufacturing BOMs.
- Enhanced `update_rate` method in Purchase Order to re-fetch FG purchase rates for unpriced BOMs.
- Added a custom button in the Purchase Order form to trigger FG purchase rate fetching.
- Introduced warning messages for unpriced BOMs and deferred pricing updates.