### PR TITLE
fix: cancelling a Manufacturing Plan fails on Sales Order Item update

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_plan/manufacturing_plan.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_plan/manufacturing_plan.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
+from frappe.query_builder import CustomFunction
 from frappe.utils import cint
 
 from jewellery_erpnext.jewellery_erpnext.doc_events.bom_utils import refetch_fg_purchase_rate
@@ -15,6 +16,8 @@ from jewellery_erpnext.jewellery_erpnext.doctype.parent_manufacturing_order.pare
 	make_manufacturing_order,
 )
 from jewellery_erpnext.utils import update_existing
+
+Greatest = CustomFunction("GREATEST", ["value", "floor"])
 
 
 class ManufacturingPlan(Document):
@@ -58,12 +61,21 @@ class ManufacturingPlan(Document):
 		)
 
 	def on_cancel(self):
+		SalesOrderItem = frappe.qb.DocType("Sales Order Item")
 		for row in self.manufacturing_plan_table:
+			if not row.docname:
+				continue
+			# Clamped at zero: cancelling the Parent Manufacturing Orders raised from this plan
+			# already gives back their own qty, so reversing the plan on top of that can overshoot.
 			update_existing(
 				"Sales Order Item",
 				row.docname,
 				"manufacturing_order_qty",
-				f"greatest(manufacturing_order_qty - {cint(row.manufacturing_order_qty) + cint(row.subcontracting_qty)},0)",
+				Greatest(
+					SalesOrderItem.manufacturing_order_qty
+					- (cint(row.manufacturing_order_qty) + cint(row.subcontracting_qty)),
+					0,
+				),
 			)
 
 	def validate(self):

--- a/jewellery_erpnext/utils.py
+++ b/jewellery_erpnext/utils.py
@@ -153,6 +153,30 @@ def get_variant_of_item(item_code):
 	return frappe.db.get_value("Item", item_code, "variant_of")
 
 
+def _resolve_update_value(Doc, field, value):
+	"""Turn the `"<field> +/- <number>"` shorthand into a real arithmetic expression.
+
+	Everything else -- plain values and query builder terms -- is passed through untouched, so
+	callers needing more than a bare increment can hand over an expression of their own.
+	"""
+	if not isinstance(value, str):
+		return value
+
+	operation = value.split()
+	if len(operation) != 3 or operation[0] != field or operation[1] not in ("+", "-"):
+		return value
+
+	operand = operation[2]
+	if not operand.lstrip("-").replace(".", "", 1).isdigit():
+		return value
+
+	column = getattr(Doc, field)
+	if operation[1] == "-":
+		return column - float(operand)
+
+	return column + float(operand)
+
+
 def update_existing(doctype, name, field, value=None, debug=False):
 	modified = frappe.utils.now()
 	modified_by = frappe.session.user
@@ -168,32 +192,10 @@ def update_existing(doctype, name, field, value=None, debug=False):
 	if isinstance(field, dict):
 		# If field is a dictionary, prepare multiple field updates
 		for key, _value in field.items():
-			if isinstance(_value, str) and ("+" in _value or "-" in _value):
-				operation = _value.split()
-				if (
-					len(operation) == 3
-					and operation[0] == key
-					and operation[2].lstrip("-").replace(".", "", 1).isdigit()
-				):
-					query = query.set(getattr(Doc, key), getattr(Doc, key) + float(operation[2]))
-				else:
-					query = query.set(getattr(Doc, key), _value)
-			else:
-				query = query.set(getattr(Doc, key), _value)
+			query = query.set(getattr(Doc, key), _resolve_update_value(Doc, key, _value))
 	else:
 		# Single field update
-		if isinstance(value, str) and ("+" in value or "-" in value):
-			operation = value.split()
-			if (
-				len(operation) == 3
-				and operation[0] == field
-				and operation[2].lstrip("-").replace(".", "", 1).isdigit()
-			):
-				query = query.set(getattr(Doc, field), getattr(Doc, field) + float(operation[2]))
-			else:
-				query = query.set(getattr(Doc, field), value)
-		else:
-			query = query.set(getattr(Doc, field), value)
+		query = query.set(getattr(Doc, field), _resolve_update_value(Doc, field, value))
 
 	query.run(debug=debug)
 


### PR DESCRIPTION
on_cancel was handing update_existing the string
"greatest(manufacturing_order_qty - X,0)" as a value. That helper only knows the "<field> + <number>" shorthand, so the string didn't parse and got bound as a plain value, which MariaDB refused:

    (1366, "Incorrect decimal value: 'greatest(manufacturing_order_qty - 1,0)'
     for column 'manufacturing_order_qty' at row 1")

Build the GREATEST() with the query builder so it reaches SQL as an expression. Rows without a docname are skipped now as well, on_submit already did that.

Also fixed in update_existing: it always did "+ float(operand)" and never looked at the operator, so "manufacturing_order_qty - qty" was adding. Parent Manufacturing Order's on_cancel and the gke_customization override both use that form, so cancelling a PMO was pushing the ordered qty up on the Manufacturing Plan Table row and the Sales Order Item instead of releasing it. Now "-" subtracts, and the same parsing is no longer duplicated across the dict and single field branches. Anything that isn't the shorthand (plain values, query builder terms) is passed through as before.

Rows already skewed by the second bug are not repaired here, that needs a patch.