### PR TITLE
feat: Implement MOP Log balance repair for MWO-wide sum inflation

### DIFF
--- a/.github/workflows/manufacturing-tests.yml
+++ b/.github/workflows/manufacturing-tests.yml
@@ -64,3 +64,5 @@ jobs:
           bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_manufacturing_operation_balance_details_report
           bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_process_loss_valuation
           bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.tests.test_mwo_photoshop_images
+          bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.doctype.mop_log.test_mop_log
+          bench --site test_site run-tests --module jewellery_erpnext.jewellery_erpnext.doctype.mop_log.test_mop_lineage_stock_entry_bridge

--- a/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/manufacturing_operation/manufacturing_operation.py
@@ -21,9 +21,6 @@ from frappe.utils import (
 )
 
 from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
-	create_mop_log_for_stock_transfer_to_mo as create_mop_log,
-)
-from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 	get_available_qty_pcs_for_mop_item,
 	get_current_mop_balance_rows,
 	get_employee_ir_loss_map,
@@ -5975,89 +5972,63 @@ def update_new_mop_wtg(
 				).format(log.item_code, log.batch_no, loss_pcs, baseline_pcs_batch)
 			)
 
-		log["qty_change"] = -loss_qty
-		log["pcs_change"] = -loss_pcs
-		log["from_warehouse"] = from_warehouse if from_warehouse else log.from_warehouse
-		log["to_warehouse"] = to_warehouse if to_warehouse else log.to_warehouse
-		log["manufacturing_operation"] = self.name
-		create_mop_log(doc=employee_ir_doc, row=log)
+		# Write the baseline ABSOLUTELY, do not recompute it from a running
+		# balance. This row IS the new operation's opening balance, and the
+		# operation has no rows yet -- a computed balance would open the
+		# operation at -loss_qty instead of baseline - loss_qty. Every other
+		# clone writer (create_mop_log_for_department_ir,
+		# creste_mop_log_for_employee_ir, create_mop_log_for_employee_ir_receive)
+		# copies balances verbatim for the same reason.
+		mop_log = frappe.new_doc("MOP Log")
+		mop_log.item_code = log.item_code
+		mop_log.batch_no = log.batch_no
 
-		# mop_log = frappe.new_doc("MOP Log")
-		# mop_log.item_code = log.item_code
-		# mop_log.batch_no = log.batch_no
+		# Reduce all three balance tiers by loss_qty. When loss_qty is 0
+		# (no loss matches this row) the baseline is cloned verbatim.
+		mop_log.qty_after_transaction = flt(
+			flt(log.qty_after_transaction) - loss_qty, 3
+		)
+		mop_log.qty_after_transaction_item_based = flt(
+			flt(log.qty_after_transaction_item_based) - loss_qty, 3
+		)
+		mop_log.qty_after_transaction_batch_based = new_qty_batch
 
-		# # Reduce all three balance tiers by loss_qty. When loss_qty is 0
-		# # (no loss matches this row) the baseline is cloned verbatim.
-		# mop_log.qty_after_transaction = flt(
-		# 	flt(log.qty_after_transaction) - loss_qty, 3
-		# )
-		# mop_log.qty_after_transaction_item_based = flt(
-		# 	flt(log.qty_after_transaction_item_based) - loss_qty, 3
-		# )
-		# mop_log.qty_after_transaction_batch_based = new_qty_batch
+		mop_log.pcs_after_transaction = cint(log.pcs_after_transaction) - loss_pcs
+		mop_log.pcs_after_transaction_item_based = (
+			cint(log.pcs_after_transaction_item_based) - loss_pcs
+		)
+		mop_log.pcs_after_transaction_batch_based = new_pcs_batch
 
-		# mop_log.pcs_after_transaction = cint(log.pcs_after_transaction) - loss_pcs
-		# mop_log.pcs_after_transaction_item_based = (
-		# 	cint(log.pcs_after_transaction_item_based) - loss_pcs
-		# )
-		# mop_log.pcs_after_transaction_batch_based = new_pcs_batch
+		mop_log.qty_change = -loss_qty
+		mop_log.pcs_change = -loss_pcs
+		mop_log.from_warehouse = (
+			from_warehouse if from_warehouse else log.from_warehouse
+		)
+		mop_log.to_warehouse = to_warehouse if to_warehouse else log.to_warehouse
+		mop_log.manufacturing_operation = self.name
+		mop_log.manufacturing_work_order = log.manufacturing_work_order
+		mop_log.serial_and_batch_bundle = log.serial_and_batch_bundle
+		mop_log.is_synced = 0
+		# flow_index = 0: baseline + loss are part of the new MOP's initial
+		# balance tier, not a downstream movement.
+		mop_log.flow_index = 0
 
-		# mop_log.from_warehouse = from_warehouse if loss_bucket else log.from_warehouse
-		# mop_log.to_warehouse = to_warehouse if loss_bucket else log.to_warehouse
-		# mop_log.manufacturing_operation = self.name
-		# mop_log.manufacturing_work_order = log.manufacturing_work_order
-		# mop_log.serial_and_batch_bundle = log.serial_and_batch_bundle
-		# mop_log.is_synced = 0
-		# # flow_index = 0: baseline + loss are part of the new MOP's
-		# # initial baseline tier, not a downstream movement.
-		# mop_log.flow_index = 0
+		if loss_bucket:
+			# Tie the row to the EIR voucher so the cancel cascade
+			# (UPDATE tabMOP Log WHERE voucher_type=... AND voucher_no=...)
+			# picks it up symmetrically with the other EIR logs.
+			mop_log.voucher_type = employee_ir_doc.doctype
+			mop_log.voucher_no = employee_ir_doc.name
+			mop_log.row_name = employee_ir_operation_row.name
+		else:
+			# Plain baseline clone -- keep the prior voucher tagging so
+			# downstream readers that care about source provenance can still
+			# find the originating Manufacturing Operation.
+			mop_log.voucher_type = "Manufacturing Operation"
+			mop_log.voucher_no = log.manufacturing_operation
+			mop_log.row_name = log.row_name
 
-		# if loss_bucket:
-		# 	# Tie the row to the EIR voucher so the cancel cascade
-		# 	# (`UPDATE tabMOP Log WHERE voucher_type=… AND voucher_no=…`)
-		# 	# picks it up symmetrically with the other EIR logs.
-		# 	mop_log.voucher_type = "Employee IR"
-		# 	mop_log.voucher_no = employee_ir_doc.name
-		# 	mop_log.row_name = employee_ir_operation_row.name
-		# 	mop_log.qty_change = -loss_qty
-		# 	mop_log.pcs_change = -loss_pcs
-
-		# 	mop_log.loss_weight = flt(loss_bucket.get("loss_weight_grams"), 3)
-		# 	loss_types = loss_bucket.get("loss_types") or []
-		# 	mop_log.loss_type = ", ".join(loss_types) if loss_types else None
-		# 	source_rows_list = loss_bucket.get("source_rows") or []
-		# 	joined = ",".join(source_rows_list)
-		# 	mop_log.loss_source_row = joined[:140] if len(joined) > 140 else joined
-
-		# 	processed_loss_keys.add(key)
-		# else:
-		# 	# Plain baseline clone — keep the prior voucher tagging so
-		# 	# downstream readers that care about source provenance can
-		# 	# still find the originating Manufacturing Operation.
-		# 	mop_log.voucher_type = "Manufacturing Operation"
-		# 	mop_log.voucher_no = log.manufacturing_operation
-		# 	mop_log.row_name = log.row_name
-
-		# mop_log.save()
-
-	# Loss keys that didn't find a baseline row aren't valid: a loss can
-	# only reduce a balance the new operation actually starts with.
-	# unprocessed = set(loss_map.keys()) - processed_loss_keys
-	# if unprocessed:
-	# 	details = ", ".join(
-	# 		f"{item}/{batch or 'no-batch'}"
-	# 		for item, batch in sorted(
-	# 			unprocessed, key=lambda k: (k[0] or "", k[1] or "")
-	# 		)
-	# 	)
-	# 	frappe.throw(
-	# 		_(
-	# 			"Employee IR loss is booked against item(s)/batch(es) that "
-	# 			"are not present in the previous Manufacturing Operation's "
-	# 			"baseline: {0}. Loss can only be applied to balances the "
-	# 			"new operation actually inherits."
-	# # 		).format(details)
-	# 	)
+		mop_log.save()
 
 
 def get_warehouse_from_previous_stock_entry(

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
@@ -7,7 +7,7 @@ from frappe.query_builder import DocType
 from frappe.query_builder.functions import Max
 from frappe.utils import cint, cstr, flt, get_datetime
 
-from jewellery_erpnext.utils import get_mwo_refining_cutoff, is_mwo_refined
+from jewellery_erpnext.utils import get_mwo_refining_cutoff
 
 FIELD_MAP = {"M": "net", "F": "finding", "D": "diamond", "G": "gemstone", "O": "other"}
 select_fields = [
@@ -279,6 +279,32 @@ def get_mop_opening_balances(manufacturing_operation, item_code, batch_no, mwo=N
 	totals["qty_item"] = flt(totals["qty_item"], 3)
 	totals["qty_batch"] = flt(totals["qty_batch"], 3)
 	return totals
+
+
+def drop_pre_refining_rows(rows, manufacturing_work_order):
+	"""Drop source rows that pre-date the MWO's Work Order Refining cutoff.
+
+	Refining zeroes the MWO, so a pre-refining row describes metal that no longer
+	exists and must never be cloned into a downstream operation. Rows written AFTER
+	the cutoff describe a recast -- an expected manual flow, since
+	``complete_refining`` only advises the Work Order action -- and must be.
+
+	The clone writers used to answer this with a blanket ``is_mwo_refined`` early
+	return, which threw away the post-refining balance too: a Department IR handoff
+	after a recast wrote no ledger rows at all, so the receiving operation opened at
+	0 while the metal stayed stranded on the source operation. Filtering by the
+	cutoff keeps the guard's intent (no stale pre-refining figures) without deleting
+	the live balance.
+
+	Callers must include ``creation`` in the fields they fetch.
+	"""
+	if not rows:
+		return rows
+	cutoff = get_mwo_refining_cutoff(manufacturing_work_order)
+	if not cutoff:
+		return rows
+	cutoff = get_datetime(cutoff)
+	return [r for r in rows if get_datetime(r.get("creation")) > cutoff]
 
 
 def create_mop_log_for_stock_transfer_to_mo(doc, row, is_synced=False):
@@ -653,14 +679,12 @@ def get_available_qty_pcs_for_mop_item(
 def create_mop_log_for_department_ir(
 	self, row, to_warehouse, from_warehouse, operation
 ):
-	# A refined MWO's metal is gone (the Refining Entry zeroed the balance). Cloning
-	# the source operation's log history into the post-refining operation would carry
-	# stale pre-refining qty_after_transaction values forward — the cloned rows'
-	# validate would recompute the new operation's weight buckets back to the
-	# pre-refining figures, and EOD sync would see phantom stock to move.
-	if is_mwo_refined(row.manufacturing_work_order):
-		return
-
+	# A refined MWO's PRE-refining rows are gone (the Refining Entry zeroed the
+	# balance); cloning them forward would recompute the new operation's weight
+	# buckets back to the pre-refining figures and give EOD sync phantom stock to
+	# move. Post-refining rows are a recast and must still be carried -- see
+	# drop_pre_refining_rows. This used to early-return on is_mwo_refined, which
+	# dropped the recast balance too and opened the receiving operation at 0.
 	mop_logs = []
 	is_receive = getattr(self, "type", None) == "Receive" and getattr(
 		self, "receive_against", None
@@ -675,7 +699,7 @@ def create_mop_log_for_department_ir(
 				"voucher_type": "Department IR",
 				"voucher_no": self.receive_against,
 			},
-			fields=select_fields,
+			fields=select_fields + ["creation"],
 			order_by="creation asc",
 		)
 
@@ -689,6 +713,10 @@ def create_mop_log_for_department_ir(
 			row.manufacturing_operation,
 			include_fields=select_fields,
 		)
+
+	# Dedup first, then drop by cutoff: a key whose latest row is post-refining
+	# carries forward; a key with only pre-refining rows drops out entirely.
+	mop_logs = drop_pre_refining_rows(mop_logs, row.manufacturing_work_order)
 
 	for log in mop_logs:
 		mop_log = frappe.new_doc("MOP Log")
@@ -730,17 +758,17 @@ def _get_mop_logs_for_employee_ir_issue(row, department_receive_id):
 
 
 def creste_mop_log_for_employee_ir(self, row, from_warehouse, to_warehouse):
-	# Same guard as the Department IR clone above: a refined MWO has no metal left,
-	# so no balance may be issued to an employee from it. On healthy data the
-	# balance snapshot is already 0; on pre-fix data it can still hold phantom
-	# pre-refining rows that must not be propagated.
-	if is_mwo_refined(row.manufacturing_work_order):
-		return
-
+	# Same treatment as the Department IR clone above: a refined MWO's pre-refining
+	# balance must not be issued to an employee, but its post-refining recast
+	# balance must be. A blanket refusal here stranded the metal on the source
+	# operation.
 	department_receive_id = frappe.db.get_value(
 		"Manufacturing Operation", row.manufacturing_operation, "department_receive_id"
 	)
-	mop_logs = _get_mop_logs_for_employee_ir_issue(row, department_receive_id)
+	mop_logs = drop_pre_refining_rows(
+		_get_mop_logs_for_employee_ir_issue(row, department_receive_id),
+		row.manufacturing_work_order,
+	)
 	for log in mop_logs:
 		mop_log = frappe.new_doc("MOP Log")
 		mop_log.item_code = log.item_code

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/mop_log.py
@@ -5,9 +5,9 @@ import frappe
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Max
-from frappe.utils import cint, cstr, flt
+from frappe.utils import cint, cstr, flt, get_datetime
 
-from jewellery_erpnext.utils import is_mwo_refined
+from jewellery_erpnext.utils import get_mwo_refining_cutoff, is_mwo_refined
 
 FIELD_MAP = {"M": "net", "F": "finding", "D": "diamond", "G": "gemstone", "O": "other"}
 select_fields = [
@@ -197,6 +197,90 @@ def recalculate_manufacturing_operation_weights(mop_name, pending=None):
 	update_wt_detail(mop_name)
 
 
+def get_mop_opening_balances(manufacturing_operation, item_code, batch_no, mwo=None):
+	"""Opening balance of ONE operation, for the three tiers MOP Log tracks.
+
+	The ``qty_after_transaction*`` / ``pcs_after_transaction*`` tiers are per-OPERATION
+	running balances -- that is how every reader treats them:
+	:func:`get_current_mop_balance_rows`,
+	:func:`recalculate_manufacturing_operation_weights`, :func:`update_wt_detail`, the
+	Make Receive Entry availability popup and the balance-details report. So the opening
+	balance is derived here from the operation's OWN latest row per
+	``(item_code, batch_no)``.
+
+	It is deliberately NOT ``SUM(qty_change)`` over the Manufacturing Work Order. A MWO
+	routinely carries residue stranded on a finished operation -- metal returned short of
+	the balance, a refined MWO, a rework loop -- and a MWO-wide sum folds that residue
+	into the next operation's opening balance, inflating it. That produced gross weights
+	0.01g above the received weight on re-cast operations.
+
+	Scoping the sum to the operation instead is NOT a fix on its own: baseline clone rows
+	carry ``qty_change = 0`` while carrying a non-zero balance, so summing changes within
+	one operation reads 0 for an operation that legitimately inherited a balance. The
+	inherited balance is written explicitly by the clone writers
+	(:func:`update_new_mop_wtg`, :func:`create_mop_log_for_department_ir`,
+	:func:`creste_mop_log_for_employee_ir`), and read back from here as an absolute value.
+
+	Rows at or before the MWO's Work Order Refining submit time are ignored: refining
+	zeroes the MWO, so a surviving pre-refining row must not resurrect a dead balance.
+	Recasting a refined MWO is an expected manual flow, so this only clamps the opening
+	balance -- the movement itself is still ledgered. See
+	:func:`~jewellery_erpnext.utils.get_mwo_refining_cutoff`.
+
+	A fresh operation has no rows and opens at zero, which is exactly right.
+	"""
+	empty = {
+		"qty_prefix": 0.0,
+		"qty_item": 0.0,
+		"qty_batch": 0.0,
+		"pcs_prefix": 0,
+		"pcs_item": 0,
+		"pcs_batch": 0,
+	}
+	if not (manufacturing_operation and item_code):
+		return empty
+
+	rows = get_current_mop_balance_rows(
+		manufacturing_operation,
+		include_fields=[
+			"item_code",
+			"batch_no",
+			"qty_after_transaction_batch_based",
+			"pcs_after_transaction_batch_based",
+		],
+	)
+	if not rows:
+		return empty
+
+	# Only pay for the refining lookup when there is actually a balance to clamp.
+	cutoff = get_mwo_refining_cutoff(mwo)
+
+	first_char = item_code[0]
+	totals = dict(empty)
+	for log in rows:
+		row_item = log.get("item_code") or ""
+		if not row_item.startswith(first_char):
+			continue
+		if cutoff and get_datetime(log.get("creation")) <= get_datetime(cutoff):
+			continue
+		qty = flt(log.get("qty_after_transaction_batch_based"))
+		pcs = cint(log.get("pcs_after_transaction_batch_based"))
+		totals["qty_prefix"] += qty
+		totals["pcs_prefix"] += pcs
+		if row_item != item_code:
+			continue
+		totals["qty_item"] += qty
+		totals["pcs_item"] += pcs
+		if log.get("batch_no") == batch_no:
+			totals["qty_batch"] += qty
+			totals["pcs_batch"] += pcs
+
+	totals["qty_prefix"] = flt(totals["qty_prefix"], 3)
+	totals["qty_item"] = flt(totals["qty_item"], 3)
+	totals["qty_batch"] = flt(totals["qty_batch"], 3)
+	return totals
+
+
 def create_mop_log_for_stock_transfer_to_mo(doc, row, is_synced=False):
 	item_code = row.get("item_code") or ""
 	if not item_code:
@@ -225,69 +309,19 @@ def create_mop_log_for_stock_transfer_to_mo(doc, row, is_synced=False):
 		if doc.doctype == "Employee IR"
 		else doc.get("manufacturing_work_order")
 	)
-	# mop_op = row.get("manufacturing_operation")
-
-	# prepare prefix pattern e.g. 'D%' or 'G%'
-	prefix_like = f"{first_char}%"
-	sql = """
-	SELECT
-		COALESCE(SUM(CASE WHEN item_code LIKE %s THEN pcs_change END), 0) AS sum_pcs_prefix,
-		COALESCE(SUM(CASE WHEN item_code = %s THEN pcs_change END), 0) AS sum_pcs_item,
-		COALESCE(SUM(CASE WHEN item_code = %s AND batch_no = %s THEN pcs_change END), 0) AS sum_pcs_batch,
-		COALESCE(SUM(CASE WHEN item_code LIKE %s THEN qty_change END), 0) AS sum_qty_prefix,
-		COALESCE(SUM(CASE WHEN item_code = %s THEN qty_change END), 0) AS sum_qty_item,
-		COALESCE(SUM(CASE WHEN item_code = %s AND batch_no = %s THEN qty_change END), 0) AS sum_qty_batch
-	FROM `tabMOP Log`
-	WHERE manufacturing_work_order = %s
-	  AND is_cancelled = 0
-	"""
-	sql_params = [
-		prefix_like,
-		item_code,
-		item_code,
-		batch_no,
-		prefix_like,
-		item_code,
-		item_code,
-		batch_no,
-		mwo,
-	]
-
-	# if mop_op:
-	# 	previous_mop = frappe.db.get_value(
-	# 		"Manufacturing Operation", mop_op, "previous_mop"
-	# 	)
-	# 	if previous_mop:
-	# 		sql += " AND manufacturing_operation IN (%s, %s)"
-	# 		sql_params.extend([mop_op, previous_mop])
-	# 	else:
-	# 		sql += " AND manufacturing_operation = %s"
-	# 		sql_params.append(mop_op)
-
-	row_vals = frappe.db.sql(sql, tuple(sql_params), as_dict=True)
-
-	stats = (
-		row_vals[0]
-		if row_vals
-		else {
-			"sum_pcs_prefix": 0,
-			"sum_pcs_item": 0,
-			"sum_pcs_batch": 0,
-			"sum_qty_prefix": 0.0,
-			"sum_qty_item": 0.0,
-			"sum_qty_batch": 0.0,
-			"sum_qty_mop_total": 0.0,
-		}
+	opening = get_mop_opening_balances(
+		row.get("manufacturing_operation"), item_code, batch_no, mwo
 	)
+
 	last_mop_index = get_last_mop_index(row.manufacturing_operation)
 	# compute fields
-	pcs_after_prefix = pcs + cint(stats["sum_pcs_prefix"])
-	pcs_after_item = pcs + cint(stats["sum_pcs_item"])
-	pcs_after_batch = pcs + cint(stats["sum_pcs_batch"])
+	pcs_after_prefix = pcs + cint(opening["pcs_prefix"])
+	pcs_after_item = pcs + cint(opening["pcs_item"])
+	pcs_after_batch = pcs + cint(opening["pcs_batch"])
 
-	qty_after_prefix = qty + flt(stats["sum_qty_prefix"])
-	qty_after_item = qty + flt(stats["sum_qty_item"])
-	qty_after_batch = qty + flt(stats["sum_qty_batch"])
+	qty_after_prefix = flt(qty + flt(opening["qty_prefix"]), 3)
+	qty_after_item = flt(qty + flt(opening["qty_item"]), 3)
+	qty_after_batch = flt(qty + flt(opening["qty_batch"]), 3)
 	# create doc
 	mop_log = frappe.new_doc("MOP Log")
 	mop_log.item_code = item_code
@@ -646,16 +680,14 @@ def create_mop_log_for_department_ir(
 		)
 
 	else:
-		filters = {
-			"manufacturing_operation": row.manufacturing_operation,
-			"is_cancelled": 0,
-		}
-
-		mop_logs = frappe.db.get_all(
-			"MOP Log",
-			filters,
-			select_fields,
-			order_by="creation asc",
+		# Latest row per (item, batch), NOT every historical row. Cloning the whole
+		# history doubled the row count at every Department IR hop (2 -> 4 -> 8 ...)
+		# and left stale pre-loss balances interleaved with the true one, so which
+		# figure a reader saw depended on how it happened to dedup. Mirrors
+		# creste_mop_log_for_employee_ir, which already sources the same snapshot.
+		mop_logs = get_current_mop_balance_rows(
+			row.manufacturing_operation,
+			include_fields=select_fields,
 		)
 
 	for log in mop_logs:
@@ -1003,22 +1035,14 @@ def create_mop_log_for_employee_ir_receive(
 		mop_log.batch_no = log.batch_no
 		mop_log.flow_index = log.flow_index + 1
 
-		# Carry loss audit metadata on the combined row (joined when more
-		# than one loss-detail row contributes). We deliberately do NOT set
-		# log_category="Loss Attribution" — that label is reserved for
-		# pre-existing legacy audit rows and would cause downstream
-		# consumers to mis-classify this real movement row.
+		# Loss is applied to the NEW operation by update_new_mop_wtg; nothing to
+		# carry here beyond marking the bucket consumed so a second source log
+		# matching the same (item, batch) does not absorb it again.
+		# NOTE: MOP Log has no loss_weight / loss_type / loss_source_row /
+		# log_category fields (neither in mop_log.json nor on the live site), so
+		# the assignments that used to sit here were silent no-ops.
 		if loss:
 			consumed_loss_keys.add(loss_key)
-			mop_log.loss_weight = flt(loss.get("loss_weight_grams"), 3)
-			loss_types = loss.get("loss_types") or []
-			mop_log.loss_type = ", ".join(loss_types) if loss_types else None
-			source_rows = loss.get("source_rows") or []
-			# loss_source_row is a Data field — guard against length blow-up
-			# by capping at 140 chars (Frappe Data default). Truncated
-			# entries still carry the first N references.
-			joined = ",".join(source_rows)
-			mop_log.loss_source_row = joined[:140] if len(joined) > 140 else joined
 
 		mop_log.save()
 

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_lineage_stock_entry_bridge.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_lineage_stock_entry_bridge.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 try:
 	from jewellery_erpnext.jewellery_erpnext.doc_events.stock_entry import (
@@ -26,7 +26,7 @@ import unittest
 	update_balance_table is None,
 	"update_balance_table was removed; MOP Log is now the source of truth.",
 )
-class TestStockEntryLegacyBalanceTable(FrappeTestCase):
+class TestStockEntryLegacyBalanceTable(UnitTestCase):
 	def test_update_balance_table_appends_rows_per_legacy_key(self):
 		mop_doc = MagicMock()
 		mop_doc.append = MagicMock()
@@ -55,30 +55,44 @@ class TestStockEntryLegacyBalanceTable(FrappeTestCase):
 		self.assertEqual(first_table, "department_source_table")
 
 
-class TestMopLogStockEntryWriter(FrappeTestCase):
-	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.sql")
+class TestMopLogStockEntryWriter(UnitTestCase):
+	# Patch the two seams the writer actually reads, NOT frappe.db.sql wholesale:
+	# a module-wide sql patch also answers Frappe's lazy Meta load (property
+	# setters), which then chokes on the stub payload.
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.get_last_mop_index"
+	)
+	@patch(
+		"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.get_mop_opening_balances"
+	)
 	@patch("jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.new_doc")
 	def test_create_mop_log_for_stock_transfer_sets_stock_entry_voucher(
-		self, mock_new_doc, mock_sql
+		self, mock_new_doc, mock_opening, mock_last_index
 	):
 		from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 			create_mop_log_for_stock_transfer_to_mo,
 		)
 
-		mock_sql.return_value = [
-			{
-				"sum_pcs_prefix": 0,
-				"sum_pcs_item": 0,
-				"sum_pcs_batch": 0,
-				"sum_qty_prefix": 0.0,
-				"sum_qty_item": 0.0,
-				"sum_qty_batch": 0.0,
-			}
-		]
+		# a fresh operation opens at zero on every tier
+		mock_opening.return_value = {
+			"qty_prefix": 0.0,
+			"qty_item": 0.0,
+			"qty_batch": 0.0,
+			"pcs_prefix": 0,
+			"pcs_item": 0,
+			"pcs_batch": 0,
+		}
+		mock_last_index.return_value = None
 		mock_log = MagicMock()
 		mock_new_doc.return_value = mock_log
 
-		se = frappe._dict(name="SE-TEST-001", manufacturing_work_order="MWO-1")
+		# `doctype` is what the writer stamps onto voucher_type -- without it the
+		# assertion below can only ever see None.
+		se = frappe._dict(
+			doctype="Stock Entry",
+			name="SE-TEST-001",
+			manufacturing_work_order="MWO-1",
+		)
 		row = frappe._dict(
 			name="sed-1",
 			item_code="M-G-22KT-TEST",
@@ -98,7 +112,7 @@ class TestMopLogStockEntryWriter(FrappeTestCase):
 		mock_log.save.assert_called_once()
 
 
-class TestMopLineageAuditProofPack(FrappeTestCase):
+class TestMopLineageAuditProofPack(UnitTestCase):
 	def test_get_sql_proof_templates_keys(self):
 		from jewellery_erpnext.mop_lineage_audit import get_sql_proof_templates
 
@@ -116,7 +130,7 @@ class TestMopLineageAuditProofPack(FrappeTestCase):
 		self.assertIn("department_source_table", trace["legacy_keys_in_mop_data"])
 
 
-class TestStockEntryMopLogBridge(FrappeTestCase):
+class TestStockEntryMopLogBridge(UnitTestCase):
 	"""Cover the Stock Entry -> MOP Log bridge that fixes diamond visibility
 	on Employee IR Receive after MR-driven bagging transfers."""
 
@@ -241,7 +255,7 @@ class TestStockEntryMopLogBridge(FrappeTestCase):
 		self.assertEqual(params, ("SE-BRIDGE-001",))
 
 
-class TestEmployeeIrReceiveDiamondParity(FrappeTestCase):
+class TestEmployeeIrReceiveDiamondParity(UnitTestCase):
 	"""Server-side row builder for Employee IR must surface diamond / gemstone
 	header weights so Receive does not render blank diamond columns."""
 
@@ -274,7 +288,7 @@ class TestEmployeeIrReceiveDiamondParity(FrappeTestCase):
 		self.assertEqual(payload["gemstone_pcs"], 1)
 
 
-class TestEmployeeIrDiamondLineageAudit(FrappeTestCase):
+class TestEmployeeIrDiamondLineageAudit(UnitTestCase):
 	"""Audit helper used during staging verification of the failing chain."""
 
 	def test_diagnoses_missing_mop_log_when_se_exists(self):

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_log.py
@@ -17,9 +17,12 @@ from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_work_order.test_m
 )
 from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 	_get_mop_logs_for_employee_ir_issue,
+	create_mop_log_for_department_ir,
 	create_mop_log_for_employee_ir_receive,
+	create_mop_log_for_stock_transfer_to_mo,
 	creste_mop_log_for_employee_ir,
 	get_current_mop_balance_rows,
+	get_mop_opening_balances,
 	get_mwo_balance_rows,
 	resolve_employee_ir_issue_voucher_for_receive,
 )
@@ -111,11 +114,11 @@ class TestCurrentMOPBalanceRows(IntegrationTestCase):
 class TestMwoBalanceRows(IntegrationTestCase):
 	"""``get_mwo_balance_rows`` — the work-order-scoped balance reader.
 
-	``qty_after_transaction_batch_based`` is written as an MWO-wide running sum
-	and then stamped with whichever operation wrote it, so reading it per
-	operation returns a snapshot frozen at that operation's last write. This
-	reader is the scope that stays correct as work hands off between
-	operations.
+	``qty_after_transaction_batch_based`` is a PER-OPERATION running balance
+	(see ``get_mop_opening_balances``); it used to be an MWO-wide running sum,
+	which folded residue stranded on one operation into the next operation's
+	opening balance. This reader deliberately spans the work order for callers
+	that want the whole MWO's picture rather than one operation's.
 	"""
 
 	@classmethod
@@ -314,15 +317,19 @@ class TestResolveEmployeeIRIssueVoucher(IntegrationTestCase):
 		doc = MagicMock()
 		doc.emp_ir_id = "EMP-IR-ISSUE-01"
 		row = MockRow()
-		with patch(
-			"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
-			return_value=FrappeDict({"docstatus": 1, "type": "Issue"}),
-		), patch(
-			"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
-			return_value=True,
-		), patch(
-			"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.sql",
-		) as mock_sql:
+		with (
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.get_value",
+				return_value=FrappeDict({"docstatus": 1, "type": "Issue"}),
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.exists",
+				return_value=True,
+			),
+			patch(
+				"jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log.frappe.db.sql",
+			) as mock_sql,
+		):
 			out = resolve_employee_ir_issue_voucher_for_receive(doc, row)
 		self.assertEqual(out, "EMP-IR-ISSUE-01")
 		mock_sql.assert_not_called()
@@ -751,3 +758,392 @@ def create_test_manufacturing_operation():
 	mo.save()
 
 	return mo
+
+
+MOP_LOG = "jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log"
+MFG_OP = (
+	"jewellery_erpnext.jewellery_erpnext.doctype."
+	"manufacturing_operation.manufacturing_operation"
+)
+
+
+class MockStockEntry:
+	doctype = "Stock Entry"
+	stock_entry_type = "Material Transfer (WORK ORDER)"
+	name = "MAT-STE-TEST-001"
+
+	def __init__(self, mwo="MWO-TEST-001"):
+		self._mwo = mwo
+
+	def get(self, key, default=None):
+		if key == "manufacturing_work_order":
+			return self._mwo
+		return default
+
+
+def _se_row(**overrides):
+	base = {
+		"name": "se-child-1",
+		"item_code": "M-G-22KT-91.75-Y",
+		"batch_no": "BATCH-A",
+		"qty": 3.21,
+		"pcs": 0,
+		"s_warehouse": "WH-Employee",
+		"t_warehouse": "WH-Dept",
+		"manufacturing_operation": "MOP-FRESH",
+		"serial_and_batch_bundle": None,
+	}
+	base.update(overrides)
+	return FrappeDict(base)
+
+
+class TestMopOpeningBalances(IntegrationTestCase):
+	"""``get_mop_opening_balances`` — the per-operation opening balance.
+
+	Regression cover for the MWO-wide sum: residue stranded on an earlier
+	operation of the same work order must not become the next operation's
+	opening balance.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_fresh_operation_opens_at_zero(self):
+		with patch(f"{MOP_LOG}.frappe.db.get_all", return_value=[]):
+			out = get_mop_opening_balances(
+				"MOP-FRESH", "M-G-22KT-91.75-Y", "BATCH-A", "MWO-TEST-001"
+			)
+		self.assertEqual(out["qty_batch"], 0.0)
+		self.assertEqual(out["qty_item"], 0.0)
+		self.assertEqual(out["qty_prefix"], 0.0)
+
+	def test_scopes_by_operation_never_by_work_order(self):
+		"""The bug in one assertion: the query must not span the work order."""
+		with patch(f"{MOP_LOG}.frappe.db.get_all", return_value=[]) as mock_get_all:
+			get_mop_opening_balances(
+				"MOP-FRESH", "M-G-22KT-91.75-Y", "BATCH-A", "MWO-TEST-001"
+			)
+		filters = mock_get_all.call_args.kwargs["filters"]
+		self.assertEqual(filters["manufacturing_operation"], "MOP-FRESH")
+		self.assertNotIn("manufacturing_work_order", filters)
+
+	def test_tiers_split_by_prefix_item_and_batch(self):
+		rows = [
+			_sample_log(
+				name="L1",
+				creation="2026-08-24 10:00:00",
+				item_code="M-G-22KT-91.75-Y",
+				batch_no="BATCH-A",
+				qty_after_transaction_batch_based=3.24,
+			),
+			_sample_log(
+				name="L2",
+				creation="2026-08-24 10:00:01",
+				item_code="M-G-22KT-91.75-Y",
+				batch_no="BATCH-B",
+				qty_after_transaction_batch_based=0.01,
+			),
+			_sample_log(
+				name="L3",
+				creation="2026-08-24 10:00:02",
+				item_code="F-FINDING",
+				batch_no="BATCH-C",
+				qty_after_transaction_batch_based=9.0,
+			),
+		]
+		with (
+			patch(f"{MOP_LOG}.frappe.db.get_all", return_value=rows),
+			patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=None),
+		):
+			out = get_mop_opening_balances(
+				"MOP-X", "M-G-22KT-91.75-Y", "BATCH-A", "MWO-TEST-001"
+			)
+		# batch tier: only BATCH-A. item tier: both batches of that item.
+		# prefix tier: every M- item. The F- row belongs to none of them.
+		self.assertEqual(out["qty_batch"], 3.24)
+		self.assertEqual(out["qty_item"], 3.25)
+		self.assertEqual(out["qty_prefix"], 3.25)
+
+	def test_pre_refining_rows_are_ignored(self):
+		"""Refining kills the MWO; a surviving pre-refining row must not revive it."""
+		rows = [
+			_sample_log(
+				name="L-PRE",
+				creation="2026-08-24 10:01:46",
+				item_code="M-G-22KT-91.75-Y",
+				batch_no="BATCH-A",
+				qty_after_transaction_batch_based=0.01,
+			)
+		]
+		with (
+			patch(f"{MOP_LOG}.frappe.db.get_all", return_value=rows),
+			patch(
+				f"{MOP_LOG}.get_mwo_refining_cutoff",
+				return_value="2026-08-24 10:03:18",
+			),
+		):
+			out = get_mop_opening_balances(
+				"MOP-I5D24", "M-G-22KT-91.75-Y", "BATCH-A", "MWO-TEST-001"
+			)
+		self.assertEqual(out["qty_batch"], 0.0)
+
+
+class TestStockTransferBalanceIsPerOperation(IntegrationTestCase):
+	"""The reported defect, end to end through the writer.
+
+	`MWO-KGJPL-RI02163-054-1-91.75-Y-01`: 3.26 issued, 0.02 booked as loss,
+	3.23 returned, leaving 0.01 stranded. The next casting issued 3.21 and the
+	operation opened at 3.22 because the balance was summed across the work
+	order. It must open at 3.21.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def _write(self, opening_rows):
+		created = MagicMock()
+		with (
+			patch(f"{MOP_LOG}.frappe.db.get_all", return_value=opening_rows),
+			patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=None),
+			patch(f"{MOP_LOG}.get_last_mop_index", return_value=None),
+			patch(f"{MOP_LOG}.frappe.new_doc", return_value=created),
+		):
+			create_mop_log_for_stock_transfer_to_mo(MockStockEntry(), _se_row())
+		return created
+
+	def test_fresh_operation_records_only_what_was_issued(self):
+		created = self._write([])
+		self.assertEqual(created.qty_change, 3.21)
+		self.assertEqual(created.qty_after_transaction_batch_based, 3.21)
+		self.assertEqual(created.qty_after_transaction_item_based, 3.21)
+		self.assertEqual(created.qty_after_transaction, 3.21)
+		created.save.assert_called_once()
+
+	def test_operation_with_own_balance_adds_to_it(self):
+		"""Per-operation carry-forward still works — only the MWO-wide leak is gone."""
+		created = self._write(
+			[
+				_sample_log(
+					name="L-OWN",
+					creation="2026-08-24 10:00:00",
+					item_code="M-G-22KT-91.75-Y",
+					batch_no="BATCH-A",
+					qty_after_transaction_batch_based=1.0,
+				)
+			]
+		)
+		self.assertEqual(created.qty_after_transaction_batch_based, 4.21)
+
+
+class TestNewMopBaselineWrite(IntegrationTestCase):
+	"""``update_new_mop_wtg`` must write the inherited baseline as an absolute value.
+
+	The new operation has no rows of its own, so a computed running balance
+	would open it at ``-loss_qty`` instead of ``baseline - loss_qty``.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def _run(self, loss_qty):
+		from jewellery_erpnext.jewellery_erpnext.doctype.manufacturing_operation.manufacturing_operation import (
+			update_new_mop_wtg,
+		)
+
+		new_mop = FrappeDict(
+			{"name": "MOP-NEW", "previous_mop": "MOP-SRC", "gross_wt": 0}
+		)
+		eir = FrappeDict({"name": "EIR-1", "doctype": "Employee IR"})
+		eir_row = FrappeDict(
+			{
+				"name": "eir-row-1",
+				"manufacturing_operation": "MOP-SRC",
+				"manufacturing_work_order": "MWO-TEST-001",
+			}
+		)
+		baseline = _sample_log(
+			name="L-BASE",
+			creation="2026-08-24 10:00:00",
+			item_code="M-G-22KT-91.75-Y",
+			batch_no="BATCH-A",
+			qty_after_transaction=3.24,
+			qty_after_transaction_item_based=3.24,
+			qty_after_transaction_batch_based=3.24,
+			pcs_after_transaction=0,
+			pcs_after_transaction_item_based=0,
+			pcs_after_transaction_batch_based=0,
+			manufacturing_operation="MOP-SRC",
+			manufacturing_work_order="MWO-TEST-001",
+			row_name="src-row",
+			from_warehouse="WH-A",
+			to_warehouse="WH-B",
+		)
+		loss_map = {}
+		if loss_qty:
+			loss_map[("MOP-SRC", "MWO-TEST-001", "M-G-22KT-91.75-Y", "BATCH-A")] = {
+				"loss_qty": loss_qty,
+				"loss_pcs": 0,
+			}
+
+		created = MagicMock()
+		with (
+			patch(f"{MFG_OP}.get_last_mop_index", return_value=None),
+			patch(f"{MFG_OP}.get_employee_ir_loss_map", return_value=loss_map),
+			patch(f"{MFG_OP}.get_current_mop_balance_rows", return_value=[baseline]),
+			patch(f"{MFG_OP}._float_tolerance", return_value=0.001),
+			patch(f"{MFG_OP}.frappe.new_doc", return_value=created),
+		):
+			update_new_mop_wtg(
+				new_mop,
+				employee_ir_doc=eir,
+				employee_ir_operation_row=eir_row,
+				from_warehouse="WH-Emp",
+				to_warehouse="WH-Dept",
+			)
+		return created
+
+	def test_baseline_cloned_verbatim_when_no_loss(self):
+		created = self._run(0)
+		self.assertEqual(created.qty_after_transaction_batch_based, 3.24)
+		self.assertEqual(created.qty_change, 0)
+		self.assertEqual(created.flow_index, 0)
+		self.assertEqual(created.manufacturing_operation, "MOP-NEW")
+
+	def test_baseline_reduced_by_loss_not_replaced_by_it(self):
+		created = self._run(0.01)
+		self.assertEqual(created.qty_after_transaction_batch_based, 3.23)
+		self.assertEqual(created.qty_change, -0.01)
+
+
+class TestDepartmentIRCloneDedupes(IntegrationTestCase):
+	"""Cloning every historical row doubled the ledger at each Department IR hop.
+
+	Observed on the reported MWO: 2 rows -> 4 -> 8, with stale pre-loss
+	balances interleaved with the true one.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	def test_issue_clones_latest_snapshot_only(self):
+		row = FrappeDict(
+			{
+				"name": "dir-row-1",
+				"manufacturing_operation": "MOP-SRC",
+				"manufacturing_work_order": "MWO-TEST-001",
+			}
+		)
+		dir_doc = FrappeDict(
+			{"name": "DIR-1", "type": "Issue", "receive_against": None}
+		)
+		snapshot = [
+			_sample_log(
+				name="L-LATEST",
+				creation="2026-08-24 10:00:02",
+				item_code="M-G-22KT-91.75-Y",
+				batch_no="BATCH-A",
+				qty_after_transaction_batch_based=0.01,
+				flow_index=5,
+			)
+		]
+		created = MagicMock()
+		with (
+			patch(f"{MOP_LOG}.is_mwo_refined", return_value=False),
+			patch(
+				f"{MOP_LOG}.get_current_mop_balance_rows", return_value=snapshot
+			) as mock_snapshot,
+			patch(f"{MOP_LOG}.frappe.new_doc", return_value=created),
+		):
+			create_mop_log_for_department_ir(
+				dir_doc, row, "WH-Dept", "WH-Transit", "MOP-DEST"
+			)
+
+		mock_snapshot.assert_called_once()
+		self.assertEqual(mock_snapshot.call_args.args[0], "MOP-SRC")
+		self.assertEqual(created.save.call_count, 1)
+		self.assertEqual(created.qty_after_transaction_batch_based, 0.01)
+		self.assertEqual(created.manufacturing_operation, "MOP-DEST")
+		self.assertEqual(created.flow_index, 6)
+
+
+class TestRepairPatchClassification(IntegrationTestCase):
+	"""The repair script must never guess, and never invent metal.
+
+	Only findings it can prove are written; a shortfall (positive delta) points at a
+	different cause than this defect and would mean adding gold to the ledger, so it is
+	gated behind an explicit opt-in.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	@staticmethod
+	def _finding(**overrides):
+		base = {
+			"manufacturing_work_order": "MWO-TEST-001",
+			"manufacturing_operation": "MOP-A",
+			"item_code": "M-G-22KT-91.75-Y",
+			"batch_no": "BATCH-A",
+			"expected": 3.21,
+			"actual": 3.22,
+			"delta": -0.01,
+			"straddles": False,
+			"already_repaired": False,
+			"latest_row": "row-1",
+			"latest_voucher": "Employee IR EIR-1",
+			"refined_on": "2026-08-24 10:03:18",
+		}
+		base.update(overrides)
+		return base
+
+	def _execute(self, findings, **kwargs):
+		from jewellery_erpnext.patches import (
+			repair_mwo_wide_mop_log_balances as patch_mod,
+		)
+
+		with (
+			patch.object(
+				patch_mod, "audit_post_refining_contamination", return_value=findings
+			),
+			patch.object(patch_mod, "recalculate_manufacturing_operation_weights"),
+			patch.object(patch_mod.frappe.db, "commit"),
+			patch.object(patch_mod, "_append_correction") as appended,
+		):
+			out = patch_mod.execute(**kwargs)
+		return out, appended
+
+	def test_dry_run_writes_nothing(self):
+		out, appended = self._execute([self._finding()])
+		self.assertEqual(len(out["corrections"]), 1)
+		appended.assert_not_called()
+
+	def test_inflation_is_repaired(self):
+		out, appended = self._execute([self._finding()], dry_run=False)
+		self.assertEqual(len(out["written"]), 1)
+		self.assertEqual(appended.call_count, 1)
+
+	def test_shortfall_needs_explicit_opt_in(self):
+		shortfall = self._finding(expected=2.36, actual=0.0, delta=2.36)
+		out, appended = self._execute([shortfall], dry_run=False)
+		self.assertEqual(out["corrections"], [])
+		self.assertEqual(len(out["review"]), 1)
+		appended.assert_not_called()
+
+		out, appended = self._execute([shortfall], dry_run=False, allow_increase=True)
+		self.assertEqual(len(out["corrections"]), 1)
+		self.assertEqual(appended.call_count, 1)
+
+	def test_straddling_and_already_repaired_are_never_written(self):
+		findings = [
+			self._finding(manufacturing_operation="MOP-STRADDLE", straddles=True),
+			self._finding(manufacturing_operation="MOP-DONE", already_repaired=True),
+		]
+		out, appended = self._execute(findings, dry_run=False)
+		self.assertEqual(out["corrections"], [])
+		self.assertEqual(len(out["review"]), 2)
+		appended.assert_not_called()

--- a/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_log.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/mop_log/test_mop_log.py
@@ -21,6 +21,7 @@ from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
 	create_mop_log_for_employee_ir_receive,
 	create_mop_log_for_stock_transfer_to_mo,
 	creste_mop_log_for_employee_ir,
+	drop_pre_refining_rows,
 	get_current_mop_balance_rows,
 	get_mop_opening_balances,
 	get_mwo_balance_rows,
@@ -1052,7 +1053,7 @@ class TestDepartmentIRCloneDedupes(IntegrationTestCase):
 		]
 		created = MagicMock()
 		with (
-			patch(f"{MOP_LOG}.is_mwo_refined", return_value=False),
+			patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=None),
 			patch(
 				f"{MOP_LOG}.get_current_mop_balance_rows", return_value=snapshot
 			) as mock_snapshot,
@@ -1147,3 +1148,81 @@ class TestRepairPatchClassification(IntegrationTestCase):
 		self.assertEqual(out["corrections"], [])
 		self.assertEqual(len(out["review"]), 2)
 		appended.assert_not_called()
+
+
+class TestRefinedMwoCloneKeepsRecastBalance(IntegrationTestCase):
+	"""Refining must drop the PRE-refining balance, not the recast that follows it.
+
+	The clone writers used to early-return on ``is_mwo_refined``, so a Department IR
+	handoff after a recast wrote no ledger rows at all: the receiving operation opened
+	at 0 while the metal stayed stranded on the source. Observed on kg-gk as
+	``MOP-N632Z`` at 0.000 against 2.34 held on ``MOP-5W4B8``.
+	"""
+
+	CUTOFF = "2026-08-24 12:40:47"
+
+	@classmethod
+	def setUpClass(cls):
+		pass
+
+	@staticmethod
+	def _rows():
+		return [
+			_sample_log(
+				name="L-PRE",
+				creation="2026-08-24 12:30:00",
+				item_code="M-G-22KT-91.75-Y",
+				batch_no="BATCH-OLD",
+				qty_after_transaction_batch_based=3.25,
+			),
+			_sample_log(
+				name="L-POST",
+				creation="2026-08-24 12:58:18",
+				item_code="M-G-22KT-91.75-Y",
+				batch_no="BATCH-A",
+				qty_after_transaction_batch_based=2.34,
+			),
+		]
+
+	def test_unrefined_mwo_keeps_every_row(self):
+		with patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=None):
+			out = drop_pre_refining_rows(self._rows(), "MWO-TEST-001")
+		self.assertEqual(len(out), 2)
+
+	def test_pre_refining_row_dropped_recast_kept(self):
+		with patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=self.CUTOFF):
+			out = drop_pre_refining_rows(self._rows(), "MWO-TEST-001")
+		self.assertEqual([r.name for r in out], ["L-POST"])
+		self.assertEqual(out[0].qty_after_transaction_batch_based, 2.34)
+
+	def test_only_pre_refining_rows_drops_everything(self):
+		rows = [r for r in self._rows() if r.name == "L-PRE"]
+		with patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=self.CUTOFF):
+			out = drop_pre_refining_rows(rows, "MWO-TEST-001")
+		self.assertEqual(out, [])
+
+	def test_department_ir_clones_the_recast_balance(self):
+		"""The end of the reported chain: the handoff must carry 2.34, not nothing."""
+		row = FrappeDict(
+			{
+				"name": "dir-row-1",
+				"manufacturing_operation": "MOP-5W4B8",
+				"manufacturing_work_order": "MWO-KGJPL-NP00004-003-5-91.75-Y-01",
+			}
+		)
+		dir_doc = FrappeDict(
+			{"name": "DIR-658", "type": "Issue", "receive_against": None}
+		)
+		created = MagicMock()
+		with (
+			patch(f"{MOP_LOG}.get_mwo_refining_cutoff", return_value=self.CUTOFF),
+			patch(f"{MOP_LOG}.get_current_mop_balance_rows", return_value=self._rows()),
+			patch(f"{MOP_LOG}.frappe.new_doc", return_value=created),
+		):
+			create_mop_log_for_department_ir(
+				dir_doc, row, "WH-Dept", "WH-Transit", "MOP-N632Z"
+			)
+		# exactly one clone -- the post-refining row -- onto the receiving operation
+		self.assertEqual(created.save.call_count, 1)
+		self.assertEqual(created.qty_after_transaction_batch_based, 2.34)
+		self.assertEqual(created.manufacturing_operation, "MOP-N632Z")

--- a/jewellery_erpnext/mop_lineage_audit.py
+++ b/jewellery_erpnext/mop_lineage_audit.py
@@ -33,6 +33,12 @@ import subprocess
 from pathlib import Path
 
 import frappe
+from frappe.utils import flt
+
+# row_name stamped on correcting rows appended by
+# patches/repair_mwo_wide_mop_log_balances.py, so they stay identifiable and
+# re-runs are no-ops.
+REPAIR_ROW_TAG = "repair-mwo-wide-balance"
 
 
 def _app_root() -> Path:
@@ -76,7 +82,8 @@ def get_deployment_parity_record() -> dict:
 			"has_receive_against_clone": '"voucher_no": self.receive_against' in text,
 			"has_max_issue_flow_slice": "max_issue_flow" in text,
 			"has_dir_receive_idempotency": (
-				'"voucher_type": "Department IR"' in text and '"voucher_no": self.name' in text
+				'"voucher_type": "Department IR"' in text
+				and '"voucher_no": self.name' in text
 			),
 			"has_validate_receive_lineage": "validate_receive_lineage" in text,
 		}
@@ -209,15 +216,18 @@ def _latest_submitted_receive() -> dict | None:
 
 
 def _mops_for_receive(receive_name: str) -> list[str]:
-	return frappe.db.sql(
-		"""
+	return (
+		frappe.db.sql(
+			"""
 		SELECT DISTINCT manufacturing_operation
 		FROM `tabDepartment IR Operation`
 		WHERE parent = %(p)s AND IFNULL(manufacturing_operation,'') != ''
 		""",
-		{"p": receive_name},
-		pluck="manufacturing_operation",
-	) or []
+			{"p": receive_name},
+			pluck="manufacturing_operation",
+		)
+		or []
+	)
 
 
 def get_sql_proof_templates() -> dict[str, str]:
@@ -326,7 +336,9 @@ def run_proof_query_pack(limit: int = 50) -> dict:
 		"stock_entry_multiple_mops_same_voucher": out["templates"][
 			"stock_entry_multiple_mops_same_voucher"
 		],
-		"snc_submitted_empty_source_table": out["templates"]["snc_submitted_empty_source_table"],
+		"snc_submitted_empty_source_table": out["templates"][
+			"snc_submitted_empty_source_table"
+		],
 		"pmo_submitted_recent_slice": out["templates"]["pmo_submitted_recent_slice"],
 		"submission_queue_department_ir_timeline": out["templates"][
 			"submission_queue_department_ir_timeline"
@@ -345,10 +357,12 @@ def run_proof_pack_audits(limit: int = 50) -> dict:
 	"""Bench entry: templates + executed proof queries + parity + DIR fallback errors."""
 	base = run_all_audits()
 	base["proof_pack"] = run_proof_query_pack(limit=limit)
-	base["stock_entry_legacy_balance_trace"] = get_stock_entry_legacy_balance_table_trace()
-	base["proof_pack"]["archive_hint"] = (
-		"Save this JSON from bench output to your ticket / evidence store; re-run after each deploy."
-	)
+	base[
+		"stock_entry_legacy_balance_trace"
+	] = get_stock_entry_legacy_balance_table_trace()
+	base["proof_pack"][
+		"archive_hint"
+	] = "Save this JSON from bench output to your ticket / evidence store; re-run after each deploy."
 	return base
 
 
@@ -527,7 +541,9 @@ def audit_employee_ir_diamond_lineage(
 		l for l in all_logs if l.get("item_code") and l["item_code"][0] in ("D", "G")
 	]
 	issue_logs = (
-		_mop_log_rows("AND voucher_type = 'Employee IR' AND voucher_no = %s", (issue_voucher,))
+		_mop_log_rows(
+			"AND voucher_type = 'Employee IR' AND voucher_no = %s", (issue_voucher,)
+		)
 		if issue_voucher
 		else []
 	)
@@ -600,16 +616,319 @@ def audit_employee_ir_diamond_lineage(
 		"key_set_diff": {
 			"in_stock_entry_only": sorted(se_keys - current_keys),
 			"in_current_balance_only": sorted(current_keys - se_keys),
-			"in_current_but_missing_from_issue_snapshot": sorted(current_keys - issue_keys),
+			"in_current_but_missing_from_issue_snapshot": sorted(
+				current_keys - issue_keys
+			),
 		},
 		"mop_log_diamond_rows": diamond_logs,
 		"issue_voucher_diamond_rows": issue_diamond_logs,
 		"stock_entry_diamond_lines": se_diamond_lines,
-		"diagnosis": diagnosis or [
+		"diagnosis": diagnosis
+		or [
 			"Diamond present uniformly in Stock Entry, MOP Log, Issue snapshot and header — "
 			"investigate UI / Receive form rendering instead of data lineage."
 		],
 	}
+
+
+def audit_mop_balance_drift(
+	mwos: list[str] | None = None, limit: int = 200
+) -> list[dict]:
+	"""Operations whose stored ``gross_wt`` disagrees with a per-operation ledger replay.
+
+	Read-only. This is the detector for the MWO-wide-balance bug: the MOP Log writer used
+	to derive ``qty_after_transaction*`` from ``SUM(qty_change)`` over the whole
+	Manufacturing Work Order, so residue stranded on a finished operation was folded into
+	the next operation's opening balance. A drifted operation shows a ``gross_wt`` above
+	the weight actually issued/received into it.
+
+	Compares three views of the same operation:
+
+	* ``ledger_gross`` -- sum of the latest MOP Log row per (item, batch), the value
+	  ``recalculate_manufacturing_operation_weights`` would write.
+	* ``stored_gross`` -- ``Manufacturing Operation.gross_wt``.
+	* ``received_gross_wt`` -- what the operator actually weighed in.
+
+	``mwos`` narrows the scan; omit it to sweep every MWO with active MOP Log rows.
+	"""
+	conditions = ""
+	params: dict = {}
+	if mwos:
+		conditions = "AND ml.manufacturing_work_order IN %(mwos)s"
+		params["mwos"] = tuple(mwos)
+
+	# Latest row per (operation, item, batch) -- same dedup as
+	# get_current_mop_balance_rows, expressed in SQL so the sweep stays one query.
+	rows = frappe.db.sql(
+		f"""
+		SELECT
+			ml.manufacturing_operation AS mop,
+			ml.manufacturing_work_order AS mwo,
+			ml.item_code,
+			ml.batch_no,
+			ml.qty_after_transaction_batch_based AS qty
+		FROM `tabMOP Log` ml
+		INNER JOIN (
+			SELECT manufacturing_operation, item_code, batch_no, MAX(creation) AS mx
+			FROM `tabMOP Log`
+			WHERE is_cancelled = 0 AND IFNULL(manufacturing_operation, '') != ''
+			GROUP BY manufacturing_operation, item_code, batch_no
+		) latest
+			ON latest.manufacturing_operation = ml.manufacturing_operation
+			AND latest.item_code <=> ml.item_code
+			AND latest.batch_no <=> ml.batch_no
+			AND latest.mx = ml.creation
+		WHERE ml.is_cancelled = 0
+		  {conditions}
+		""",
+		params,
+		as_dict=True,
+	)
+
+	ledger: dict[str, dict] = {}
+	for r in rows:
+		bucket = ledger.setdefault(r["mop"], {"mwo": r["mwo"], "ledger_gross": 0.0})
+		# Only metal-ish prefixes contribute to gross_wt in grams; D/G are carats and
+		# are converted by the recompute, so mirror FIELD_MAP's treatment.
+		first_char = (r.get("item_code") or "")[:1]
+		qty = flt(r.get("qty"))
+		if first_char in ("D", "G"):
+			bucket["ledger_gross"] += flt(qty * 0.2, 3)
+		elif first_char in ("M", "F", "O"):
+			bucket["ledger_gross"] += qty
+
+	if not ledger:
+		return []
+
+	stored = frappe.get_all(
+		"Manufacturing Operation",
+		filters={"name": ["in", list(ledger)]},
+		fields=[
+			"name",
+			"gross_wt",
+			"received_gross_wt",
+			"previous_mop",
+			"prev_gross_wt",
+			"status",
+			"department",
+			"manufacturing_work_order",
+		],
+		limit_page_length=0,
+	)
+
+	out: list[dict] = []
+	for mop in stored:
+		led = flt(ledger[mop["name"]]["ledger_gross"], 3)
+		stored_gross = flt(mop.get("gross_wt"), 3)
+		received = flt(mop.get("received_gross_wt"), 3)
+		ledger_vs_stored = flt(led - stored_gross, 3)
+		# A receive that weighed less than the operation carried is normal; what is not
+		# normal is the ledger holding MORE than was received into the operation.
+		received_vs_ledger = flt(led - received, 3) if received else 0.0
+		if not ledger_vs_stored and not received_vs_ledger:
+			continue
+		out.append(
+			{
+				"manufacturing_operation": mop["name"],
+				"manufacturing_work_order": mop.get("manufacturing_work_order"),
+				"department": mop.get("department"),
+				"status": mop.get("status"),
+				"ledger_gross": led,
+				"stored_gross": stored_gross,
+				"received_gross_wt": received,
+				"ledger_minus_stored": ledger_vs_stored,
+				"ledger_minus_received": received_vs_ledger,
+				"previous_mop": mop.get("previous_mop"),
+				"prev_gross_wt": flt(mop.get("prev_gross_wt"), 3),
+			}
+		)
+
+	out.sort(key=lambda r: abs(r["ledger_minus_received"]), reverse=True)
+	return out[:limit]
+
+
+def refining_cutoffs(mwos: list[str] | None = None) -> dict:
+	"""``{mwo: refined_on}`` for MWOs consumed by a submitted Work Order Refining Entry.
+
+	``refined_on`` is the entry's ``modified`` -- the moment the MWO's balances were
+	zeroed. Every MOP Log row at or before it describes metal that no longer exists.
+	"""
+	conditions = ""
+	params: dict = {}
+	if mwos:
+		conditions = "AND d.manufacturing_work_order IN %(mwos)s"
+		params["mwos"] = tuple(mwos)
+
+	rows = frappe.db.sql(
+		f"""
+		SELECT d.manufacturing_work_order AS mwo, MAX(re.modified) AS refined_on
+		FROM `tabManufacturing Work Order Refining Details` d
+		INNER JOIN `tabRefining Entry` re ON re.name = d.parent
+		WHERE d.parenttype = 'Refining Entry'
+		  AND re.docstatus = 1
+		  AND re.refining_type = 'Work Order Refining'
+		  {conditions}
+		GROUP BY d.manufacturing_work_order
+		""",
+		params,
+		as_dict=True,
+	)
+	return {r["mwo"]: r["refined_on"] for r in rows}
+
+
+def audit_post_refining_contamination(
+	mwos: list[str] | None = None, limit: int = 200
+) -> list[dict]:
+	"""Balances a refined MWO should not still be carrying.
+
+	Read-only, and the single source of truth the repair script consumes -- audit and
+	repair cannot disagree about what is wrong.
+
+	A Work Order Refining Entry zeroes the MWO, so the post-refining ledger can be
+	replayed from a known zero. For each ``(operation, item, batch)``::
+
+	    expected(op) = expected(op.previous_mop) + SUM(op's own qty_change)
+
+	with ``expected = 0`` where ``previous_mop`` is absent or itself pre-dates refining --
+	that operation starts a fresh chain and may only hold what was issued into it. A
+	handoff clone contributes ``qty_change = 0``, so carry-forward along a chain is
+	preserved; what the replay refuses to carry is residue from an operation the chain
+	*left behind*. That is the defect: 0.010g stranded on ``MOP-I5D24`` turned a 3.210g
+	re-cast issue on ``MOP-0K3Q4`` into a 3.220g balance.
+
+	An operation with any row at or before the cutoff **straddles** refining; its opening
+	balance is not derivable this way, and neither is that of anything downstream of it.
+	Those are reported with ``straddles = True`` and excluded from automatic repair.
+
+	Returns one entry per ``(operation, item, batch)`` that disagrees, each carrying
+	``expected`` (the replayed balance), ``actual`` (what the ledger holds) and ``delta``.
+	"""
+	cutoffs = refining_cutoffs(mwos)
+	if not cutoffs:
+		return []
+
+	rows = frappe.db.sql(
+		"""
+		SELECT
+			manufacturing_work_order AS mwo,
+			manufacturing_operation AS mop,
+			item_code,
+			batch_no,
+			qty_change,
+			qty_after_transaction_batch_based AS balance,
+			voucher_type,
+			voucher_no,
+			row_name,
+			name,
+			creation
+		FROM `tabMOP Log`
+		WHERE is_cancelled = 0
+		  AND IFNULL(manufacturing_operation, '') != ''
+		  AND manufacturing_work_order IN %(mwos)s
+		ORDER BY creation ASC
+		""",
+		{"mwos": tuple(cutoffs)},
+		as_dict=True,
+	)
+	if not rows:
+		return []
+
+	previous_mop = dict(
+		frappe.get_all(
+			"Manufacturing Operation",
+			filters={"name": ["in", sorted({r["mop"] for r in rows})]},
+			fields=["name", "previous_mop"],
+			as_list=True,
+			limit_page_length=0,
+		)
+	)
+
+	by_mwo: dict = {}
+	for r in rows:
+		by_mwo.setdefault(r["mwo"], []).append(r)
+
+	out: list[dict] = []
+	for mwo, mwo_rows in by_mwo.items():
+		refined_on = cutoffs[mwo]
+		# Three populations, and the distinction matters:
+		#   pre_only    -- every row pre-dates refining. The operation is dead; a
+		#                  successor of it starts a FRESH chain at 0. Derivable.
+		#   straddling  -- rows on both sides of the cutoff. Its own opening balance is
+		#                  not derivable, and neither is anything downstream of it.
+		#   post_only   -- entirely after refining. Replayable.
+		mops_pre = {r["mop"] for r in mwo_rows if r["creation"] <= refined_on}
+		mops_post = {r["mop"] for r in mwo_rows if r["creation"] > refined_on}
+		straddling = mops_pre & mops_post
+		pre_only = mops_pre - mops_post
+		underivable = set(straddling)
+
+		own_change: dict = {}
+		actual: dict = {}
+		latest: dict = {}
+		repaired: set = set()
+		order: list = []
+		for r in mwo_rows:
+			if r["creation"] <= refined_on:
+				continue
+			key = (r["mop"], r["item_code"], r["batch_no"])
+			if key not in own_change:
+				order.append(key)
+				own_change[key] = 0.0
+			if r["row_name"] == REPAIR_ROW_TAG:
+				# A correcting row is not a movement -- it restates the balance. Its
+				# effect is visible through `actual` only, so a repaired key reports
+				# delta 0 and drops out of the findings instead of re-reporting its
+				# own correction as fresh drift.
+				repaired.add(key)
+			else:
+				own_change[key] = flt(own_change[key] + flt(r["qty_change"]), 3)
+			actual[key] = flt(r["balance"], 3)
+			latest[key] = r
+
+		# `order` follows first-appearance in creation order, so a predecessor's
+		# closing balance is always resolved before its successor needs it.
+		expected: dict = {}
+		for key in order:
+			mop, item_code, batch_no = key
+			prev = previous_mop.get(mop)
+			if prev in underivable:
+				# Cannot trust the predecessor's closing balance, so cannot derive
+				# this one either.
+				underivable.add(mop)
+				opening = 0.0
+			elif not prev or prev in pre_only:
+				# Fresh chain: the predecessor's metal was consumed by refining, so
+				# this operation may hold only what was issued into it.
+				opening = 0.0
+			else:
+				opening = flt(expected.get((prev, item_code, batch_no), 0.0))
+			expected[key] = flt(opening + own_change[key], 3)
+
+		for key in order:
+			delta = flt(expected[key] - actual[key], 3)
+			if not delta:
+				continue
+			mop, item_code, batch_no = key
+			ref = latest[key]
+			out.append(
+				{
+					"manufacturing_work_order": mwo,
+					"manufacturing_operation": mop,
+					"item_code": item_code,
+					"batch_no": batch_no,
+					"expected": expected[key],
+					"actual": actual[key],
+					"delta": delta,
+					"straddles": mop in underivable,
+					"already_repaired": key in repaired,
+					"latest_row": ref["name"],
+					"latest_voucher": f"{ref['voucher_type']} {ref['voucher_no']}",
+					"refined_on": refined_on,
+				}
+			)
+
+	out.sort(key=lambda r: (r["straddles"], -abs(r["delta"])))
+	return out[:limit]
 
 
 def run_all_audits(receive_doc: str | None = None) -> dict:
@@ -661,6 +980,10 @@ def run_all_audits(receive_doc: str | None = None) -> dict:
 			)
 
 	out["server_scripts"] = audit_active_server_scripts()
-	out["submission_queue_duplicates"] = audit_submission_queue_department_ir_duplicates()
+	out[
+		"submission_queue_duplicates"
+	] = audit_submission_queue_department_ir_duplicates()
 	out["error_log_dir_fallback_recent"] = audit_error_log_dir_fallback(20)
+	out["mop_balance_drift"] = audit_mop_balance_drift()
+	out["post_refining_contamination"] = audit_post_refining_contamination()
 	return out

--- a/jewellery_erpnext/patches/repair_mwo_wide_mop_log_balances.py
+++ b/jewellery_erpnext/patches/repair_mwo_wide_mop_log_balances.py
@@ -1,0 +1,210 @@
+"""Repair MOP Log balances inflated by the old MWO-wide running-balance sum.
+
+``create_mop_log_for_stock_transfer_to_mo`` used to derive ``qty_after_transaction*``
+from ``SUM(qty_change)`` over the whole **Manufacturing Work Order** rather than the
+operation being written to. A MWO routinely strands residue on a finished operation --
+metal returned short of the balance, a rework loop, a Work Order Refining Entry -- and
+the MWO-wide sum folded that residue into the next operation's opening balance.
+
+Observed on ``MWO-KGJPL-RI02163-054-1-91.75-Y-01``: MOP Log row ``s1iefq86og`` posted a
+``qty_change`` of 3.210 (Stock Entry ``MAT-STE-05717``, the re-cast issue) and recorded a
+balance of 3.220, because 0.010 stranded before ``RFN-MWO-26-00003`` was still in the MWO
+sum. ``MOP-0K3Q4.gross_wt`` then read 3.220 against a received weight of 3.210.
+
+The writer is fixed (``get_mop_opening_balances``). This script repairs rows already
+written.
+
+**Append-only.** It never updates or deletes an existing MOP Log row. Each correction is
+a NEW row carrying the delta as ``qty_change`` and the corrected absolute balance, tagged
+``row_name = REPAIR_ROW_TAG``, so history stays intact, the change is reversible by
+cancelling the appended rows, and re-runs are no-ops. ``MOPLog.validate`` ->
+``update_wt_detail`` then recomputes ``gross_wt`` through the normal path.
+
+**It only repairs what it can prove.** The detector is
+``mop_lineage_audit.audit_post_refining_contamination`` -- the same function the audit
+reports, so audit and repair cannot disagree. Refining zeroes the MWO, so an operation
+created entirely after that moment provably opens at 0 and its correct closing balance is
+the sum of its own ``qty_change`` values. Operations that *straddle* the refining cutoff
+have no derivable opening balance and are reported for manual review, never guessed at.
+
+A genuinely stranded residue is left where it is, visible for write-off or return. This
+corrects the *contamination of other operations*, not the disposal decision -- where a
+stranded gram physically went is Central's call.
+
+NOT registered in patches.txt -- run it manually.
+
+Dry run (prints every proposed correction, writes nothing):
+
+    bench --site gk execute \\
+        jewellery_erpnext.patches.repair_mwo_wide_mop_log_balances.execute
+
+Apply, one MWO at a time:
+
+    bench --site gk execute \\
+        jewellery_erpnext.patches.repair_mwo_wide_mop_log_balances.execute \\
+        --kwargs "{'dry_run': False, 'mwos': ['MWO-KGJPL-RI02163-054-1-91.75-Y-01']}"
+
+Take a backup first (``bench --site <site> backup``), and do not run while an EOD sync is
+in flight: MOP Log carries the EOD lock validator on ``before_save``, so the inserts
+would be rejected mid-window.
+"""
+
+import frappe
+from frappe.utils import cint, flt
+
+from jewellery_erpnext.jewellery_erpnext.doctype.mop_log.mop_log import (
+	get_current_mop_balance_rows,
+	get_last_mop_index,
+	recalculate_manufacturing_operation_weights,
+)
+from jewellery_erpnext.mop_lineage_audit import (
+	REPAIR_ROW_TAG,
+	audit_post_refining_contamination,
+)
+
+
+def _current_pcs(mop, item_code, batch_no):
+	"""PCS on the operation's latest row for this key; carried through unchanged.
+
+	The defect was in the qty tiers only, so the correcting row must not disturb PCS --
+	it restates whatever the ledger already holds.
+	"""
+	for bal in get_current_mop_balance_rows(
+		mop,
+		include_fields=["item_code", "batch_no", "pcs_after_transaction_batch_based"],
+		keys=[(item_code, batch_no)],
+	):
+		if bal.get("item_code") == item_code and bal.get("batch_no") == batch_no:
+			return cint(bal.get("pcs_after_transaction_batch_based"))
+	return 0
+
+
+def _append_correction(fix):
+	"""Insert ONE correcting MOP Log row. Never mutates an existing row."""
+	mop = fix["manufacturing_operation"]
+	warehouses = frappe.db.get_value(
+		"MOP Log",
+		{
+			"manufacturing_operation": mop,
+			"item_code": fix["item_code"],
+			"batch_no": fix["batch_no"],
+			"is_cancelled": 0,
+		},
+		["from_warehouse", "to_warehouse"],
+	) or (None, None)
+
+	correct = flt(fix["expected"], 3)
+	pcs = _current_pcs(mop, fix["item_code"], fix["batch_no"])
+
+	ml = frappe.new_doc("MOP Log")
+	ml.item_code = fix["item_code"]
+	ml.batch_no = fix["batch_no"]
+	ml.manufacturing_operation = mop
+	ml.manufacturing_work_order = fix["manufacturing_work_order"]
+	ml.from_warehouse = warehouses[0]
+	ml.to_warehouse = warehouses[1]
+	ml.voucher_type = "Manufacturing Operation"
+	ml.voucher_no = mop
+	ml.row_name = REPAIR_ROW_TAG
+
+	ml.qty_change = flt(fix["delta"], 3)
+	ml.pcs_change = 0
+	# All three tiers land on the corrected absolute balance: they are per-operation
+	# views of the same figure and this row IS the operation's new balance.
+	ml.qty_after_transaction = correct
+	ml.qty_after_transaction_item_based = correct
+	ml.qty_after_transaction_batch_based = correct
+	ml.pcs_after_transaction = pcs
+	ml.pcs_after_transaction_item_based = pcs
+	ml.pcs_after_transaction_batch_based = pcs
+
+	ml.is_synced = 0
+	ml.is_cancelled = 0
+	ml.flow_index = (get_last_mop_index(mop) or 0) + 1
+	ml.flags.ignore_permissions = True
+	ml.insert(ignore_permissions=True)
+	return ml.name
+
+
+def execute(dry_run=True, mwos=None, limit=500, allow_increase=False):
+	"""Report, and optionally repair, MOP Log balances inflated by the MWO-wide sum.
+
+	``allow_increase`` gates corrections with a POSITIVE delta -- those raise a metal
+	balance rather than removing phantom stock. This defect inflates balances, so a
+	shortfall points at a different cause (a missed movement, a cancelled voucher), and
+	inventing gold in the ledger to close it would hide that. Those are routed to manual
+	review unless explicitly allowed.
+	"""
+	if isinstance(mwos, str):
+		mwos = [mwos]
+
+	findings = audit_post_refining_contamination(mwos=mwos, limit=cint(limit))
+	if not findings:
+		scope = ", ".join(mwos) if mwos else "all refined MWOs"
+		print(
+			f"[repair-mop-balance] No contamination found for {scope}. Nothing to do."
+		)
+		return {"corrections": [], "review": []}
+
+	def _repairable(f):
+		if f["straddles"] or f["already_repaired"]:
+			return False
+		return allow_increase or flt(f["delta"]) < 0
+
+	corrections = [f for f in findings if _repairable(f)]
+	review = [f for f in findings if not _repairable(f)]
+
+	print(
+		f"[repair-mop-balance] {len(corrections)} provable correction(s), "
+		f"{len(review)} needing manual review."
+	)
+	for c in corrections:
+		print(
+			"  {mop}  {item}/{batch}  {actual} -> {expected}  (delta {delta})".format(
+				mop=c["manufacturing_operation"],
+				item=c["item_code"],
+				batch=c["batch_no"] or "no-batch",
+				actual=c["actual"],
+				expected=c["expected"],
+				delta=c["delta"],
+			)
+		)
+	for r in review:
+		if r["already_repaired"]:
+			reason = "already repaired"
+		elif r["straddles"]:
+			reason = "straddles refining"
+		else:
+			reason = "would INCREASE balance; pass allow_increase=True"
+		print(
+			"  REVIEW ({reason}) {mop}  {item}/{batch}  ledger {actual}, "
+			"post-refining movements sum to {expected}".format(
+				reason=reason,
+				mop=r["manufacturing_operation"],
+				item=r["item_code"],
+				batch=r["batch_no"] or "no-batch",
+				actual=r["actual"],
+				expected=r["expected"],
+			)
+		)
+
+	if dry_run:
+		print(
+			"[repair-mop-balance] DRY RUN — nothing written. "
+			"Pass dry_run=False to apply."
+		)
+		return {"corrections": corrections, "review": review}
+
+	if not corrections:
+		print("[repair-mop-balance] Nothing provable to write.")
+		return {"corrections": [], "review": review}
+
+	written = []
+	for c in corrections:
+		written.append(_append_correction(c))
+	for mop in sorted({c["manufacturing_operation"] for c in corrections}):
+		recalculate_manufacturing_operation_weights(mop)
+	frappe.db.commit()
+
+	print(f"[repair-mop-balance] Wrote {len(written)} correcting MOP Log row(s).")
+	return {"corrections": corrections, "review": review, "written": written}

--- a/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
+++ b/jewellery_erpnext/refining/doctype/refining_entry/refining_entry.py
@@ -2307,18 +2307,53 @@ class RefiningEntry(Document):
 					(mwo.manufacturing_work_order,),
 				)
 
-				op = frappe.db.get_value(
+				# Zero the LEDGER for every operation of this MWO that still holds a
+				# balance -- not just MWO.manufacturing_operation. Metal strands on
+				# earlier operations routinely (a rework loop, a short return), and a
+				# balance left behind here survives refining: the next operation's
+				# opening balance picks it up and inflates a freshly issued weight.
+				# That is how a re-cast of 3.210g came out as 3.220g.
+				ops = frappe.get_all(
+					"MOP Log",
+					filters={
+						"manufacturing_work_order": mwo.manufacturing_work_order,
+						"is_cancelled": 0,
+						"manufacturing_operation": ["is", "set"],
+					},
+					pluck="manufacturing_operation",
+					distinct=True,
+				)
+				current_op = frappe.db.get_value(
 					"Manufacturing Work Order",
 					mwo.manufacturing_work_order,
 					"manufacturing_operation",
 				)
-				if not op:
+				if current_op:
+					ops.append(current_op)
+				ops = sorted({o for o in ops if o})
+
+				if not ops:
+					# Never silently skip: a refined MWO with no resolvable operation
+					# means the ledger cannot be zeroed, and the next issue against it
+					# will open on whatever balance survives.
+					frappe.log_error(
+						title="Refining: no operation to zero",
+						message=(
+							f"Refining Entry {self.name}: Manufacturing Work Order "
+							f"{mwo.manufacturing_work_order} has no Manufacturing "
+							"Operation and no active MOP Log rows, so its ledger could "
+							"not be zeroed. Any later issue against this MWO will not "
+							"start from a verified zero balance."
+						),
+					)
 					continue
 
-				# Create a 0-balance MOP Log for every active item in the current operation
+				# Create a 0-balance MOP Log for every active item in each operation
 				# so that future operations read a 0 balance from the ledger.
-				balance_rows = get_current_mop_balance_rows(op)
-				if balance_rows:
+				for op in ops:
+					balance_rows = get_current_mop_balance_rows(op)
+					if not balance_rows:
+						continue
 					last_idx = get_last_mop_index(op) or 0
 					for bal in balance_rows:
 						qty = flt(bal.get("qty_after_transaction_batch_based"))

--- a/jewellery_erpnext/utils.py
+++ b/jewellery_erpnext/utils.py
@@ -369,6 +369,38 @@ def is_mwo_refined(manufacturing_work_order):
 	)
 
 
+def get_mwo_refining_cutoff(manufacturing_work_order):
+	"""Submit time of the Work Order Refining Entry that consumed this MWO's metal, else None.
+
+	Companion to :func:`is_mwo_refined`. Refining zeroes the MWO's balances, so every MOP
+	Log row created at or before this moment describes metal that no longer exists. Readers
+	that rebuild an opening balance from the ledger must ignore those rows: on data written
+	before the refining zero-out was made reliable, a pre-refining row can still be the
+	latest one for its (item, batch) and would resurrect a dead balance.
+
+	Recasting a refined MWO is an expected manual flow (``complete_refining`` only
+	*advises* the Work Order action), so this is a cutoff, never a reason to drop a real
+	movement -- post-refining stock movements must still be ledgered, just against a zero
+	opening balance.
+	"""
+	if not manufacturing_work_order:
+		return None
+	rows = frappe.db.sql(
+		"""
+		SELECT MAX(re.modified) AS refined_on
+		FROM `tabManufacturing Work Order Refining Details` d
+		INNER JOIN `tabRefining Entry` re ON re.name = d.parent
+		WHERE d.manufacturing_work_order = %s
+		  AND d.parenttype = 'Refining Entry'
+		  AND re.docstatus = 1
+		  AND re.refining_type = 'Work Order Refining'
+		""",
+		(manufacturing_work_order,),
+		as_dict=True,
+	)
+	return rows[0].get("refined_on") if rows else None
+
+
 def set_values_in_bulk(doctype, doclist, values):
 	Doc = frappe.qb.DocType(doctype)
 	query = frappe.qb.update(Doc)


### PR DESCRIPTION
- Added a new patch script to repair MOP Log balances inflated by the old MWO-wide running-balance sum.
- Introduced `audit_mop_balance_drift` and `audit_post_refining_contamination` functions to detect discrepancies in MOP Log balances.
- Enhanced the `RefiningEntry` class to ensure all operations of a Manufacturing Work Order are zeroed during refining.
- Added utility function `get_mwo_refining_cutoff` to retrieve the refining cutoff time for a Manufacturing Work Order.
- Updated existing functions to improve readability and maintainability, including SQL queries and logic for handling MOP Log entries.