### PR TITLE
feat: Add tree batch reconciliation utility for assessing metal avail…

### DIFF
--- a/jewellery_erpnext/jewellery_erpnext/doctype/tree_number/doc_events/tree_stock_entry.py
+++ b/jewellery_erpnext/jewellery_erpnext/doctype/tree_number/doc_events/tree_stock_entry.py
@@ -31,14 +31,23 @@ Notes:
     ``before_validate`` metal branch resolves without a Main Slip link.
   * Warehouse resolution reuses existing app resolvers (``Warehouse`` custom fields
     ``employee`` / ``department``); MSL is the employee's Raw-Material warehouse.
-  * **Receive returns the batches the Issue put in.** The MSL warehouse is the *employee's*, so it
-    pools metal from every tree, main slip and EIR injection for that operator — warehouse-wide
-    FIFO would hand back whichever batch happens to be oldest, i.e. someone else's (a Customer
-    Goods batch in, company metal out). ``receive_material`` therefore resolves each batch itself
-    via ``_allocate_tree_batches`` and pre-stamps the rows, which makes
+  * **Receive returns the tree's own metal first, and never crosses ownership.** The MSL warehouse
+    is the *employee's*, so it pools metal from every tree for that operator — warehouse-wide FIFO
+    would hand back whichever batch happens to be oldest, i.e. someone else's (a Customer Goods
+    batch in, company metal out). ``receive_material`` therefore resolves each batch itself via
+    ``_allocate_tree_legs`` and pre-stamps the rows, which makes
     ``_apply_fifo_batches_to_stock_entry`` a no-op for them (``_expand_source_rows_for_fifo``
     early-returns on a row that already carries ``batch_no``). ``issue_material`` keeps plain FIFO
     — sourcing fresh metal from the department pool is exactly what it should do.
+
+    Batch identity is the mechanism, not the goal. Casting does not preserve it: every tree for the
+    operator issues into the same MSL warehouse and the untagged ``Material Transfer (WORK ORDER)``
+    draws consume it oldest-first, so an early tree's batch is routinely drained to zero by later
+    trees' operations while it still holds a real ledger claim. So the pool is the tree's own
+    batches (``_tree_owed_batches``) and then, only if those fall short, other batches at the same
+    warehouse in the same ``(inventory_type, customer)`` tier (``_tree_fallback_batches``), warned
+    on the voucher. Ownership — the thing the GEPL-TR-26-00150 regression actually violated — is
+    never relaxed; when no same-tier metal exists, ``_throw_tree_shortfall`` still refuses.
 """
 
 import json
@@ -358,20 +367,20 @@ def _batch_ownership(batch_nos):
 	return {b: (m.inventory_type, m.customer) for b, m in ranks.items()}
 
 
-def _tree_owed_batches(se, tree, item_code, msl_wh):
-	"""``[(batch_no, qty)]`` this tree still owes back at ``msl_wh``, in FIFO order.
+def _tree_netted_owed(tree, item_code, msl_wh):
+	"""``{batch_no: qty}`` this tree's own Stock Entries still owe back at ``msl_wh``, UNCAPPED.
 
 	The tree's own Stock Entries ARE the record — ``custom_tree_number`` is stamped on every leg
-	(``_new_transfer_se``) — so the pool is derived on the fly rather than cached in a field that
+	(``_new_transfer_se``) — so the claim is derived on the fly rather than cached in a field that
 	could drift: per batch, ``issued into MSL - already taken back out of MSL``. Only
 	``docstatus = 1`` counts, so a reversed tree (``cancel_tree_stock_entries``) drops out of the
 	netting for free.
 
-	The netted result is then capped at what is PHYSICALLY left of each batch at MSL. That cap is
-	load-bearing, not defensive: the MSL warehouse is the *employee's* (shared by every tree, main
-	slip and EIR injection for that operator), and the casting Employee IR's gain injection draws
-	this tree's own metal out of it without stamping ``custom_tree_number``. Casting mints no new
-	batch at MSL, so the leftover genuinely IS the issued batch — only its quantity moves.
+	This is a GROSS claim, not a balance, and must never be disbursed against directly. The untagged
+	``Material Transfer (WORK ORDER)`` draws that legitimately consume the tree's metal out of MSL
+	carry no ``custom_tree_number``, so they are invisible here — which is why the site-wide total of
+	this number runs far above the physical stock backing it. ``_tree_owed_batches`` is the caller
+	that caps it; the ledger's ``pending_qty`` is the caller-side bound on what may actually move.
 
 	The loss leg's produce row can never be double-counted: it carries no ``s_warehouse`` and its
 	item is the ML variant, so the warehouse and ``item_code`` predicates both exclude it.
@@ -400,7 +409,27 @@ def _tree_owed_batches(se, tree, item_code, msl_wh):
 			owed[r.batch_no] = flt(owed.get(r.batch_no)) - qty
 
 	eps = _pending_eps()
-	owed = {b: q for b, q in owed.items() if q > eps}
+	return {b: q for b, q in owed.items() if q > eps}
+
+
+def _tree_owed_batches(se, tree, item_code, msl_wh):
+	"""``[(batch_no, qty)]`` of the tree's OWN issued batches still available at ``msl_wh``.
+
+	``_tree_netted_owed`` capped at what is PHYSICALLY left of each batch at MSL. That cap is
+	load-bearing, not defensive: the MSL warehouse is the *employee's*, shared by every tree for that
+	operator, and the casting Employee IR's gain draws this tree's own metal out of it without
+	stamping ``custom_tree_number``. Without the cap the netting would hand back metal that has
+	already been consumed — site-wide it over-claims by kilograms.
+
+	What the cap CANNOT do is keep the tree solvent. Casting mints no new batch at MSL, but other
+	trees' Issue legs continuously bring NEWER batches into the same warehouse while the untagged
+	draws consume it oldest-first — so an early tree's batch is routinely consumed down to zero by
+	later trees' operations, each of which correctly drew its own share. When that happens this pool
+	goes empty while the tree still holds a real ledger claim, and ``_tree_fallback_batches`` takes
+	over within the same ownership tier.
+	"""
+	eps = _pending_eps()
+	owed = _tree_netted_owed(tree, item_code, msl_wh)
 	if not owed:
 		return []
 
@@ -435,6 +464,145 @@ def _tree_owed_batches(se, tree, item_code, msl_wh):
 	# see _allocate_tree_legs.
 	ranks = batch_priority_map([b for b, _q in out])
 	out.sort(key=lambda bq: batch_sort_key(bq[0], ranks.get(bq[0]), "consume"))
+	return out
+
+
+def _tree_issued_tiers(owed_batches):
+	"""``{(inventory_type, customer)}`` — the ownership tiers this tree issued into MSL.
+
+	Normalised through ``normalize_ownership`` so a blank ``inventory_type`` collapses to the company
+	default exactly as the row builders do. Without that, a tree that issued unlabelled metal would
+	match no candidate and the fallback would be silently dead.
+	"""
+	if not owed_batches:
+		return set()
+
+	ranks = batch_priority_map(list(owed_batches))
+	tiers = set()
+	for batch_no in owed_batches:
+		meta = ranks.get(batch_no)
+		tiers.add(
+			normalize_ownership(
+				meta.inventory_type if meta else None,
+				meta.customer if meta else None,
+				batch_no=batch_no,
+			)
+		)
+	return tiers
+
+
+def _tree_fallback_batches(se, tree, item_code, msl_wh, offered, limit):
+	"""``[(batch_no, qty)]`` of SAME-OWNERSHIP-TIER metal at ``msl_wh`` standing in for the tree's
+	own, already-consumed batches.
+
+	Batch identity does not survive casting. The MSL warehouse is the *employee's* shared pool: every
+	tree for that operator issues into it, and the untagged ``Material Transfer (WORK ORDER)`` draws
+	consume it oldest-first, so an early tree's batch is routinely drained by later trees' operations
+	while newer trees' issues sit alongside it. Observed in production: seventeen trees shared one
+	batch at a single casting warehouse, each correctly drawing back its own share, until the batch
+	hit zero — permanently blocking every tree that still held a claim on it, for Receive AND for the
+	write-off inside ``Tree Number.submit_tree``.
+
+	What DOES survive is ownership, and that is the invariant the batch restriction was written to
+	protect: GEPL-TR-26-00150 repaid a Customer-Goods issue with a company batch that merely happened
+	to be older, which the module docstring names as "a Customer Goods batch in, company metal out".
+	Batch identity was the mechanism; ownership was the goal. So substitution is confined to the same
+	``(inventory_type, customer)``: company metal only ever replaced by company metal, a customer's
+	only by that same customer's own. A tier with no candidate still throws.
+
+	``offered`` is ``{batch_no: qty}`` the tree's own pool already puts up, and is SUBTRACTED from
+	each candidate rather than used to skip it. A batch the tree issued 81 g of, sitting in a
+	warehouse that holds 327 g of it, must still be able to supply the other 246 g -- that metal is
+	no more and no less "someone else's" than a different batch of the same tier would be. Skipping
+	such a batch outright would strand a tree next to metal it is entitled to.
+
+	``limit`` is the caller's UNMET need — bounded by the ledger's ``pending_qty`` at the
+	``receive_material`` guard — never the netted owed. See ``_tree_netted_owed`` on why that number
+	must not be disbursed against.
+	"""
+	eps = _pending_eps()
+	prec = _se_precision()
+	limit = flt(limit, prec)
+	if limit <= eps:
+		return []
+
+	tiers = _tree_issued_tiers(_tree_netted_owed(tree, item_code, msl_wh))
+	if not tiers:
+		return []
+
+	# No `batch_no` filter — that restriction is exactly what this fallback exists to lift. `qty` is
+	# still withheld so a phantom batch cannot FIFO-truncate real ones before the tier filter runs.
+	_ensure_posting_datetime(se)
+	available = (
+		capped_auto_batch_nos(
+			frappe._dict(
+				posting_date=se.posting_date,
+				posting_time=se.posting_time,
+				item_code=item_code,
+				warehouse=msl_wh,
+				for_stock_levels=False,
+				consider_negative_batches=False,
+			)
+		)
+		or []
+	)
+	offered = offered or {}
+	candidates = []
+	for b in available:
+		if not b.batch_no:
+			continue
+		free = flt(flt(b.qty) - flt(offered.get(b.batch_no)), prec)
+		if free > eps:
+			candidates.append((b.batch_no, free))
+	if not candidates:
+		return []
+
+	ranks = batch_priority_map([b for b, _q in candidates])
+	same_tier = []
+	for batch_no, free in candidates:
+		meta = ranks.get(batch_no)
+		owner = normalize_ownership(
+			meta.inventory_type if meta else None,
+			meta.customer if meta else None,
+			batch_no=batch_no,
+			item_code=item_code,
+		)
+		if owner in tiers:
+			same_tier.append((batch_no, free))
+
+	# Same consume ordering the tree's own pool uses, so a customer's metal is still handed back
+	# before the company's when a tree spans both tiers.
+	same_tier.sort(key=lambda bq: batch_sort_key(bq[0], ranks.get(bq[0]), "consume"))
+
+	out = []
+	remaining = limit
+	for batch_no, avail in same_tier:
+		if remaining <= eps:
+			break
+		take = flt(min(flt(avail), remaining), prec)
+		if take <= eps:
+			continue
+		out.append((batch_no, take))
+		remaining = flt(remaining - take, prec)
+	return out
+
+
+def _merge_pool(*pools):
+	"""Concatenate allocation pools, summing duplicate batches, first-seen order preserved.
+
+	``allocate_in_order`` keys its shared ``taken`` ledger by batch, so the same batch appearing
+	twice would have the second entry's free qty computed against the first entry's consumption --
+	silently under-offering. One entry per batch keeps that arithmetic honest.
+	"""
+	out, index = [], {}
+	for pool in pools:
+		for batch_no, qty in pool or []:
+			if batch_no in index:
+				i = index[batch_no]
+				out[i] = (batch_no, flt(out[i][1]) + flt(qty))
+			else:
+				index[batch_no] = len(out)
+				out.append((batch_no, flt(qty)))
 	return out
 
 
@@ -493,9 +661,30 @@ def _allocate_tree_legs(se, tree, item_code, msl_wh, recv, loss):
 	So: pass 1 takes ``recv`` from the pool in ``consume_rank`` order, pass 2 takes
 	``loss`` from what is LEFT, re-sorted into ``loss_rank`` order. A shared
 	``taken`` ledger keeps the two passes from double-booking a batch.
+
+	The pool is the tree's own issued batches first, and only if those cannot cover the need is it
+	extended with same-ownership-tier substitutes (``_tree_fallback_batches``) — the tree's own metal
+	is always returned before anyone else's. Extending the pool cannot over-disburse: ``recv + loss``
+	is already capped at the ledger's ``pending_qty`` by the ``receive_material`` guard, and
+	``allocate_in_order`` never takes more than it is asked for.
 	"""
 	prec = _se_precision()
 	pool = _tree_owed_batches(se, tree, item_code, msl_wh)
+
+	need = flt(flt(recv, prec) + flt(loss, prec), prec)
+	pool_total = flt(sum(flt(q) for _b, q in pool), prec)
+	substituted = []
+	if pool_total < flt(need - _pending_eps(), prec):
+		substituted = _tree_fallback_batches(
+			se,
+			tree,
+			item_code,
+			msl_wh,
+			offered={b: q for b, q in pool},
+			limit=flt(need - pool_total, prec),
+		)
+		pool = _merge_pool(pool, substituted)
+
 	ranks = batch_priority_map([b for b, _q in pool], with_no_wastage=True)
 	taken = {}
 
@@ -507,9 +696,9 @@ def _allocate_tree_legs(se, tree, item_code, msl_wh, recv, loss):
 
 	shortfall = flt(recv_short + loss_short, prec)
 	if shortfall > _pending_eps():
-		need = flt(flt(recv, prec) + flt(loss, prec), prec)
 		_throw_tree_shortfall(tree, item_code, msl_wh, need, shortfall, pool, prec)
 
+	_warn_tree_batch_substitution(tree, item_code, msl_wh, substituted, prec)
 	return recv_alloc, loss_alloc, ranks
 
 
@@ -546,25 +735,61 @@ def _warn_tree_customer_loss(customer_loss, prec):
 	)
 
 
-def _throw_tree_shortfall(tree, item_code, msl_wh, need, shortfall, pool, prec):
-	"""Fail fast rather than falling back to warehouse-wide FIFO.
+def _warn_tree_batch_substitution(tree, item_code, msl_wh, substituted, prec):
+	"""ONE orange warning when a tree is repaid from a batch it did not itself issue.
 
-	The MSL pool holds other operators' and other customers' metal, so a fallback
-	would silently hand back material this tree never issued.
+	Never silent, and never a throw. The substitution is always within the same ownership tier, so
+	it needs no approval -- but this site runs batch-wise valuation, where batches of the same item
+	carry materially different rates. Which batch moves is therefore a real GL movement, not a
+	bookkeeping label, and the operator has to be able to see it on the voucher.
+	"""
+	if not substituted:
+		return
+
+	merged = {}
+	for batch_no, qty in substituted:
+		merged[batch_no] = flt(flt(merged.get(batch_no)) + flt(qty), prec)
+	total = flt(sum(merged.values()), prec)
+
+	frappe.msgprint(
+		_(
+			"Tree {0}: what this tree issued of {1} is no longer available at {2}, so {3} g was "
+			"returned from batches of the SAME ownership beyond this tree's own issue. Same owner, "
+			"different metal — valuation follows the batch that actually moved:"
+		).format(tree.name, item_code, msl_wh, frappe.bold(total))
+		+ "<br><br>"
+		+ "<br>".join(
+			"{0}: {1}".format(frappe.bold(b), flt(q, prec))
+			for b, q in sorted(merged.items())
+		),
+		title=_("Substitute Batch Returned"),
+		indicator="orange",
+	)
+
+
+def _throw_tree_shortfall(tree, item_code, msl_wh, need, shortfall, pool, prec):
+	"""Fail fast once even same-ownership-tier metal cannot cover the need.
+
+	The tree's own issued batches are drawn first, and substitutes are confined to the same
+	``(inventory_type, customer)`` (``_tree_fallback_batches``). Reaching here means the warehouse
+	holds no metal this tree is entitled to at all — returning anything else would cross an
+	ownership boundary, which is the defect this whole restriction exists to prevent.
 	"""
 	frappe.throw(
 		_(
-			"Tree {0}, Item {1}: need {2} but only {3} of the batches this tree issued into "
-			"{4} is still available ({5}). Returning any other batch would hand back material "
-			"this tree never issued — check whether it was already drawn out for another job."
+			"Tree {0}, Item {1}: cannot return {2} from {3} — short by {4}. The batches this tree "
+			"issued have already been consumed there, and no remaining batch at that warehouse "
+			"shares this tree's ownership, so none may stand in for them. Available to this "
+			"tree: {5}."
 		).format(
 			tree.name,
 			item_code,
 			flt(need, prec),
-			flt(need - shortfall, prec),
 			msl_wh,
-			", ".join(f"{b}: {flt(q, prec)}" for b, q in pool) or _("none"),
-		)
+			flt(shortfall, prec),
+			", ".join(f"{b}: {flt(q, prec)}" for b, q in pool) or _("nothing"),
+		),
+		title=_("Tree Material Not Available"),
 	)
 
 

--- a/jewellery_erpnext/jewellery_erpnext/tests/test_tree_casting.py
+++ b/jewellery_erpnext/jewellery_erpnext/tests/test_tree_casting.py
@@ -1134,6 +1134,7 @@ def _run(
 	loss_item="GOLD-18KT-ML",
 	owed=None,
 	ownership=None,
+	fallback=None,
 ):
 	"""Call an op helper with persistence + warehouse/loss-item resolution mocked.
 
@@ -1145,6 +1146,9 @@ def _run(
 	single unbounded batch per item so shape-focused tests need not model batch provenance;
 	``TestTreeOwedBatches`` / ``TestReceiveBatchParity`` cover that layer directly.
 	``ownership`` stubs ``_batch_ownership`` (``{batch_no: (inventory_type, customer)}``).
+	``fallback`` stubs the same-ownership-tier substitute pool (``_tree_fallback_batches``), in the
+	same shape as ``owed``. It defaults to EMPTY, not to an unbounded batch: a test that does not
+	opt in gets the strict pre-fallback behaviour, and no test reaches the database for it.
 	"""
 	fakes = _RunResult()
 
@@ -1159,6 +1163,29 @@ def _run(
 		if isinstance(owed, dict):
 			return list(owed.get(item_code, []))
 		return list(owed)
+
+	def _fallback(_se, _tree, item_code, _msl_wh, offered=None, limit=None):
+		if fallback is None:
+			return []
+		rows = (
+			list(fallback.get(item_code, []))
+			if isinstance(fallback, dict)
+			else list(fallback)
+		)
+		# Mirror the real helper: SUBTRACT what the own pool already offers (never skip the
+		# batch outright), and stop at `limit`.
+		out = []
+		remaining = float(limit) if limit is not None else float("inf")
+		for batch_no, avail in rows:
+			if remaining <= 0:
+				break
+			free = float(avail) - float((offered or {}).get(batch_no, 0))
+			if free <= 0:
+				continue
+			take = min(free, remaining)
+			out.append((batch_no, take))
+			remaining -= take
+		return out
 
 	def _priority(batch_nos, with_no_wastage=False):
 		# Same `ownership` stub the legacy _batch_ownership patch below uses, in the
@@ -1185,6 +1212,7 @@ def _run(
 		patch.object(tse, "validate_no_prior_period_pending"),
 		patch.object(tse, "batch_priority_map", side_effect=_priority),
 		patch.object(tse, "_tree_owed_batches", side_effect=_owed),
+		patch.object(tse, "_tree_fallback_batches", side_effect=_fallback),
 		patch.object(tse, "_batch_ownership", return_value=ownership or {}),
 		patch.object(tse, "_resolve_source_warehouse", return_value=source_wh),
 		patch.object(tse, "_resolve_msl_warehouse", return_value=msl_wh),
@@ -1957,6 +1985,251 @@ class TestTreeOwedBatches(IntegrationTestCase):
 		self.assertEqual(out, [])
 
 
+class TestTreeFallbackBatches(IntegrationTestCase):
+	"""``_tree_fallback_batches`` — same-ownership-tier stand-ins for a consumed batch.
+
+	Regression origin: KGJPL-TR-26-00015. Seventeen trees issued into ONE batch at the casting
+	employee's shared MSL warehouse; the untagged ``Material Transfer (WORK ORDER)`` draws consumed
+	it oldest-first until it hit exactly zero, each tree having correctly drawn its own share. Three
+	trees were left holding a real ledger claim against a batch that no longer existed — unable to
+	Receive, and unable even to write off through ``submit_tree``, which settles leftovers through
+	this same allocator. Batch identity does not survive casting; ownership does, and ownership is
+	what the GEPL-TR-26-00150 regression actually violated.
+	"""
+
+	MSL = "EMP-MSL"
+
+	def _call(
+		self, own, available, ownership, limit, offered=None, item_code="GOLD-18KT"
+	):
+		se = SimpleNamespace(posting_date="2026-08-27", posting_time="10:00:00")
+
+		def _priority(batch_nos, with_no_wastage=False):
+			out = {}
+			for b in batch_nos or []:
+				inv, cust = ownership.get(b, (None, None))
+				out[b] = frappe._dict(
+					inventory_type=inv, customer=cust, creation="", no_wastage=False
+				)
+			return out
+
+		with (
+			patch.object(tse, "_tree_netted_owed", return_value=dict(own)),
+			patch.object(tse, "_ensure_posting_datetime"),
+			patch.object(
+				tse,
+				"capped_auto_batch_nos",
+				return_value=[frappe._dict(b) for b in available],
+			),
+			patch.object(tse, "batch_priority_map", side_effect=_priority),
+			patch.object(tse, "_pending_eps", return_value=0.0005),
+			patch.object(tse, "_se_precision", return_value=3),
+		):
+			return tse._tree_fallback_batches(
+				se,
+				SimpleNamespace(name="TREE-1"),
+				item_code,
+				self.MSL,
+				offered=dict(offered or {}),
+				limit=limit,
+			)
+
+	REG = ("Regular Stock", None)
+	CUST1 = ("Customer Goods", "CUST-1")
+	CUST2 = ("Customer Goods", "CUST-2")
+
+	def test_company_metal_stands_in_for_a_consumed_company_batch(self):
+		"""The KGJPL-TR-26-00015 case: own batch gone, same-tier metal present."""
+		out = self._call(
+			own={"B-GONE": 471.18},
+			available=[{"batch_no": "B-OTHER", "qty": 388.608}],
+			ownership={"B-GONE": self.REG, "B-OTHER": self.REG},
+			limit=5.0,
+		)
+		self.assertEqual(out, [("B-OTHER", 5.0)])
+
+	def test_customer_metal_never_repays_a_company_issue(self):
+		out = self._call(
+			own={"B-GONE": 6.0},
+			available=[{"batch_no": "B-CUST", "qty": 50.0}],
+			ownership={"B-GONE": self.REG, "B-CUST": self.CUST1},
+			limit=5.0,
+		)
+		self.assertEqual(out, [])
+
+	def test_company_metal_never_repays_a_customer_issue(self):
+		"""The GEPL-TR-26-00150 regression, restated for the fallback."""
+		out = self._call(
+			own={"B-CUST": 6.0},
+			available=[{"batch_no": "B-REG", "qty": 50.0}],
+			ownership={"B-CUST": self.CUST1, "B-REG": self.REG},
+			limit=5.0,
+		)
+		self.assertEqual(out, [])
+
+	def test_one_customers_issue_is_repaid_only_from_that_same_customer(self):
+		out = self._call(
+			own={"B-C1": 6.0},
+			available=[
+				{"batch_no": "B-C2", "qty": 50.0},
+				{"batch_no": "B-C1B", "qty": 50.0},
+			],
+			ownership={
+				"B-C1": self.CUST1,
+				"B-C1B": self.CUST1,
+				"B-C2": self.CUST2,
+			},
+			limit=4.0,
+		)
+		self.assertEqual(out, [("B-C1B", 4.0)])
+
+	def test_blank_inventory_type_is_company_metal_on_both_sides(self):
+		"""``normalize_ownership`` collapses a blank type to the company default.
+
+		Without that, a tree that issued unlabelled metal would match no candidate and the
+		fallback would be silently dead for exactly the commonest case.
+		"""
+		out = self._call(
+			own={"B-GONE": 6.0},
+			available=[{"batch_no": "B-REG", "qty": 50.0}],
+			ownership={"B-GONE": (None, None), "B-REG": self.REG},
+			limit=5.0,
+		)
+		self.assertEqual(out, [("B-REG", 5.0)])
+
+	def test_limit_caps_the_substitution_not_the_pool(self):
+		"""``limit`` is the caller's unmet need, itself bounded by the ledger's pending."""
+		out = self._call(
+			own={"B-GONE": 9999.0},
+			available=[{"batch_no": "B-REG", "qty": 500.0}],
+			ownership={"B-GONE": self.REG, "B-REG": self.REG},
+			limit=3.0,
+		)
+		self.assertEqual(out, [("B-REG", 3.0)])
+
+	def test_spills_across_several_same_tier_batches(self):
+		out = self._call(
+			own={"B-GONE": 100.0},
+			available=[
+				{"batch_no": "B-A", "qty": 2.0},
+				{"batch_no": "B-B", "qty": 10.0},
+			],
+			ownership={"B-GONE": self.REG, "B-A": self.REG, "B-B": self.REG},
+			limit=6.0,
+		)
+		self.assertEqual(out, [("B-A", 2.0), ("B-B", 4.0)])
+
+	def test_customer_tier_comes_back_first_when_the_tree_spans_both(self):
+		out = self._call(
+			own={"B-C1": 5.0, "B-GONE": 5.0},
+			available=[
+				{"batch_no": "B-REG", "qty": 50.0},
+				{"batch_no": "B-C1B", "qty": 3.0},
+			],
+			ownership={
+				"B-C1": self.CUST1,
+				"B-C1B": self.CUST1,
+				"B-GONE": self.REG,
+				"B-REG": self.REG,
+			},
+			limit=5.0,
+		)
+		self.assertEqual(out, [("B-C1B", 3.0), ("B-REG", 2.0)])
+
+	def test_what_the_own_pool_already_offers_is_not_offered_twice(self):
+		"""The own pool puts up all 4.0 of B-MINE, so the fallback must not re-offer any of it."""
+		out = self._call(
+			own={"B-MINE": 4.0},
+			available=[
+				{"batch_no": "B-MINE", "qty": 4.0},
+				{"batch_no": "B-REG", "qty": 50.0},
+			],
+			ownership={"B-MINE": self.REG, "B-REG": self.REG},
+			limit=2.0,
+			offered={"B-MINE": 4.0},
+		)
+		self.assertEqual(out, [("B-REG", 2.0)])
+
+	def test_the_residual_of_the_trees_own_batch_is_still_available_to_it(self):
+		"""Owed 81.38 of a batch the warehouse holds 326.814 of: the other 245.434 is same-tier
+		metal like any other, and stranding the tree next to it would be the same bug in a new
+		place. Regression: KGJPL-TR-26-00040 projected 223.61 g short while that residual sat
+		unclaimed in its own batch.
+		"""
+		out = self._call(
+			own={"B-MINE": 81.38},
+			available=[{"batch_no": "B-MINE", "qty": 326.814}],
+			ownership={"B-MINE": self.REG},
+			limit=100.0,
+			offered={"B-MINE": 81.38},
+		)
+		self.assertEqual(out, [("B-MINE", 100.0)])
+
+	def test_a_tree_that_issued_nothing_gets_no_substitute(self):
+		out = self._call(
+			own={},
+			available=[{"batch_no": "B-REG", "qty": 50.0}],
+			ownership={"B-REG": self.REG},
+			limit=5.0,
+		)
+		self.assertEqual(out, [])
+
+	def test_zero_limit_short_circuits_before_any_query(self):
+		se = SimpleNamespace(posting_date="2026-08-27", posting_time="10:00:00")
+		with (
+			patch.object(tse, "_tree_netted_owed") as netted,
+			patch.object(tse, "capped_auto_batch_nos") as avail,
+			patch.object(tse, "_pending_eps", return_value=0.0005),
+			patch.object(tse, "_se_precision", return_value=3),
+		):
+			out = tse._tree_fallback_batches(
+				se,
+				SimpleNamespace(name="TREE-1"),
+				"GOLD-18KT",
+				self.MSL,
+				offered={},
+				limit=0.0,
+			)
+		self.assertEqual(out, [])
+		netted.assert_not_called()
+		avail.assert_not_called()
+
+	def test_empty_same_tier_pool_returns_empty_so_the_caller_throws(self):
+		out = self._call(
+			own={"B-GONE": 6.0},
+			available=[],
+			ownership={"B-GONE": self.REG},
+			limit=5.0,
+		)
+		self.assertEqual(out, [])
+
+
+class TestMergePool(IntegrationTestCase):
+	"""``_merge_pool`` — one entry per batch, first-seen order.
+
+	``allocate_in_order`` keys its shared ``taken`` ledger by batch, so a batch appearing twice
+	would have the second entry's free qty measured against the first entry's consumption and
+	silently under-offer. That is reachable in production the moment the fallback tops up a batch
+	the tree's own pool already put up.
+	"""
+
+	def test_duplicate_batches_are_summed_not_repeated(self):
+		self.assertEqual(
+			tse._merge_pool([("B-1", 2.0)], [("B-1", 3.0)]),
+			[("B-1", 5.0)],
+		)
+
+	def test_first_seen_order_is_preserved(self):
+		self.assertEqual(
+			tse._merge_pool([("B-A", 1.0), ("B-B", 1.0)], [("B-C", 1.0), ("B-A", 4.0)]),
+			[("B-A", 5.0), ("B-B", 1.0), ("B-C", 1.0)],
+		)
+
+	def test_empty_and_none_pools_are_tolerated(self):
+		self.assertEqual(tse._merge_pool([], None, [("B-1", 1.0)]), [("B-1", 1.0)])
+		self.assertEqual(tse._merge_pool(), [])
+
+
 class TestAllocateTreeBatches(IntegrationTestCase):
 	def _alloc(self, pool, need):
 		with (
@@ -2152,7 +2425,7 @@ class TestReceiveTwoPassOwnership(IntegrationTestCase):
 		"B-REG": ("Regular Stock", None),
 	}
 
-	def _receive(self, recv, loss, owed, ownership=None):
+	def _receive(self, recv, loss, owed, ownership=None, fallback=None):
 		# _new_transfer_se resolves the SE company via get_cached_value on a
 		# warehouse name this pure-logic harness never creates; the shared _run
 		# helper does not stub it.
@@ -2163,6 +2436,7 @@ class TestReceiveTwoPassOwnership(IntegrationTestCase):
 				[{"item_code": "GOLD-18KT", "receive_qty": recv, "loss_qty": loss}],
 				owed=owed,
 				ownership=self.OWN if ownership is None else ownership,
+				fallback=fallback,
 			)
 
 	@staticmethod
@@ -2233,3 +2507,120 @@ class TestReceiveTwoPassOwnership(IntegrationTestCase):
 		)
 		self.assertEqual(self._by_batch(se_recv), {"B-1": 4.0})
 		self.assertEqual(self._by_batch(se_loss), {"B-1": 1.0, "B-2": 1.0})
+
+
+class TestReceiveWithSubstituteBatch(IntegrationTestCase):
+	"""End-to-end through ``receive_material`` when the tree's own batch has been consumed.
+
+	The production case this exists for: KGJPL-TR-26-00015 held 255.37 g of ledger pending against
+	a batch that seventeen trees had shared and the casting draws had taken to exactly zero, so
+	every Receive AND the ``submit_tree`` write-off threw for good. The tree's own metal must still
+	be returned first; only the remainder may come from a same-ownership-tier batch.
+	"""
+
+	OWN = {
+		"B-MINE": ("Regular Stock", None),
+		"B-SUB": ("Regular Stock", None),
+		"B-SUB2": ("Regular Stock", None),
+		"B-CUST": ("Customer Goods", "MHCU0012"),
+	}
+
+	def _tree(self, issue=20.0):
+		return _new_tree(
+			material_details=[
+				{
+					"item_code": "GOLD-18KT",
+					"issue_qty": issue,
+					"receive_qty": 0,
+					"loss_qty": 0,
+					"pending_qty": issue,
+				}
+			]
+		)
+
+	def _receive(self, recv, loss, owed, fallback=None, ownership=None):
+		with patch.object(tse.frappe, "get_cached_value", return_value="CO"):
+			return _run(
+				tse.receive_material,
+				self._tree(),
+				[{"item_code": "GOLD-18KT", "receive_qty": recv, "loss_qty": loss}],
+				owed=owed,
+				ownership=self.OWN if ownership is None else ownership,
+				fallback=fallback,
+			)
+
+	@staticmethod
+	def _by_batch(se):
+		out = {}
+		for row in se.items:
+			if not getattr(row, "s_warehouse", None):
+				continue  # produce row of the loss pair
+			out[row.batch_no] = out.get(row.batch_no, 0) + row.qty
+		return out
+
+	def test_a_fully_consumed_own_pool_can_still_receive(self):
+		"""KGJPL-TR-26-00015 itself: own pool empty, same-tier metal at the warehouse."""
+		(se_recv,) = self._receive(5.0, 0.0, owed=[], fallback=[("B-SUB", 388.608)])
+		self.assertEqual(self._by_batch(se_recv), {"B-SUB": 5.0})
+
+	def test_the_trees_own_batch_is_exhausted_before_any_substitute(self):
+		(se_recv,) = self._receive(
+			5.0, 0.0, owed=[("B-MINE", 2.0)], fallback=[("B-SUB", 100.0)]
+		)
+		self.assertEqual(self._by_batch(se_recv), {"B-MINE": 2.0, "B-SUB": 3.0})
+
+	def test_substitution_is_capped_at_the_need_not_the_available_pool(self):
+		(se_recv,) = self._receive(5.0, 0.0, owed=[], fallback=[("B-SUB", 9999.0)])
+		self.assertAlmostEqual(sum(self._by_batch(se_recv).values()), 5.0, places=3)
+
+	def test_no_same_tier_metal_still_throws(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._receive(5.0, 0.0, owed=[], fallback=[])
+
+	def test_submit_tree_write_off_can_use_a_substitute(self):
+		"""``submit_tree`` settles leftovers with recv = 0 through this same allocator.
+
+		Before the fallback existed, a tree whose batch was consumed could not even be closed.
+		"""
+		(se_loss,) = self._receive(0.0, 4.0, owed=[], fallback=[("B-SUB", 50.0)])
+		self.assertEqual(self._by_batch(se_loss), {"B-SUB": 4.0})
+
+	def test_substitute_rows_carry_the_batch_ownership_across(self):
+		(se_recv,) = self._receive(5.0, 0.0, owed=[], fallback=[("B-SUB", 50.0)])
+		(row,) = [r for r in se_recv.items if getattr(r, "s_warehouse", None)]
+		self.assertEqual(row.batch_no, "B-SUB")
+		self.assertEqual(row.inventory_type, "Regular Stock")
+		# _append_item only stamps `customer` when the batch has one — company metal must not
+		# carry a stray customer across the substitution.
+		self.assertIsNone(getattr(row, "customer", None))
+
+	def test_both_legs_share_one_extended_pool_without_double_booking(self):
+		se_recv, se_loss = self._receive(
+			3.0, 2.0, owed=[("B-MINE", 1.0)], fallback=[("B-SUB", 4.0)]
+		)
+		taken = {}
+		for se in (se_recv, se_loss):
+			for batch, qty in self._by_batch(se).items():
+				taken[batch] = taken.get(batch, 0) + qty
+		self.assertLessEqual(taken["B-MINE"], 1.0)
+		self.assertLessEqual(taken["B-SUB"], 4.0)
+		self.assertAlmostEqual(sum(taken.values()), 5.0, places=3)
+
+	def test_a_sufficient_own_pool_never_consults_the_fallback(self):
+		"""No behaviour change for the ordinary case — the fallback is not even called."""
+		with patch.object(tse, "_tree_fallback_batches") as fb:
+			with patch.object(tse.frappe, "get_cached_value", return_value="CO"):
+				_run(
+					tse.receive_material,
+					self._tree(),
+					[
+						{
+							"item_code": "GOLD-18KT",
+							"receive_qty": 4.0,
+							"loss_qty": 0,
+						}
+					],
+					owed=[("B-MINE", 10.0)],
+					ownership=self.OWN,
+				)
+		fb.assert_not_called()

--- a/jewellery_erpnext/tree_batch_reconciliation.py
+++ b/jewellery_erpnext/tree_batch_reconciliation.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026, Nirali and contributors
+# For license information, please see license.txt
+
+"""Read-only projection of whether each open Tree Number can still close.
+
+Companion to :mod:`tree_audit`, which checks the ledger's internal arithmetic. This one checks
+the ledger against PHYSICAL stock: can the metal a tree is still owed actually be handed back
+out of the employee's MSL warehouse, and from which batches?
+
+The failure it exists to explain: an MSL warehouse is the *employee's*, shared by every tree for
+that operator. All of them issue into it, and the untagged ``Material Transfer (WORK ORDER)``
+draws consume it oldest-first, so an early tree's batch is routinely taken to zero by later
+trees' operations -- each of which correctly drew its own share. Before the same-ownership-tier
+fallback existed (``tree_stock_entry._tree_fallback_batches``) such a tree was permanently stuck:
+it could neither Receive nor be written off through ``submit_tree``, because both settle through
+the same batch allocator.
+
+**This utility never writes.** There is no repair mode and it is not wired into any patch. What
+it produces is the projection you read BEFORE letting operators run Receive, so you know which
+trees close cleanly, which need a substitute batch, and which are genuinely short of metal and
+must settle the remainder as loss.
+
+Trees are simulated in name order against ONE shared pool, because that is how they really
+compete: the first tree to receive takes the oldest batch. A tree shown as short is short only
+under that ordering -- the aggregate shortfall for the warehouse is the number that does not
+move, and it is reported separately.
+
+Usage::
+
+    bench --site <site> execute jewellery_erpnext.tree_batch_reconciliation.report
+    bench --site <site> execute jewellery_erpnext.tree_batch_reconciliation.report \\
+        --kwargs "{'msl_warehouse': 'Casting KGJPL - 00294 WH - KGJPL'}"
+"""
+
+import frappe
+from frappe.utils import flt, nowdate, nowtime
+
+from jewellery_erpnext.jewellery_erpnext.customization.stock.batch_valuation_ledger import (
+	capped_auto_batch_nos,
+)
+from jewellery_erpnext.jewellery_erpnext.customization.utils.ownership_priority import (
+	batch_priority_map,
+	batch_sort_key,
+)
+from jewellery_erpnext.jewellery_erpnext.customization.utils.row_ownership import (
+	normalize_ownership,
+)
+from jewellery_erpnext.jewellery_erpnext.doctype.tree_number import (
+	tree_material_balance as tree_balance,
+)
+from jewellery_erpnext.jewellery_erpnext.doctype.tree_number.doc_events import (
+	tree_stock_entry as tse,
+)
+
+# Statuses that still owe metal back. "Submitted" is terminal and "Draft" has not issued yet.
+OPEN_STATUSES = ("Issued", "Partially Received", "Received")
+
+CLOSES_FROM_OWN = "CLOSES_FROM_OWN_BATCHES"
+CLOSES_WITH_SUBSTITUTE = "CLOSES_WITH_SUBSTITUTE_BATCH"
+SHORT_OF_METAL = "SHORT_OF_METAL"
+
+
+def _open_rows(msl_warehouse=None, item_code=None, company=None):
+	"""Every open ``(tree, item)`` still carrying pending, newest-first by warehouse."""
+	filters = {"status": ["in", OPEN_STATUSES]}
+	if msl_warehouse:
+		filters["msl_warehouse"] = msl_warehouse
+	if company:
+		filters["company"] = company
+
+	trees = frappe.get_all(
+		"Tree Number",
+		filters=filters,
+		fields=["name", "status", "msl_warehouse", "company", "employee", "operation"],
+		order_by="name",
+	)
+	if not trees:
+		return []
+
+	by_name = {t.name: t for t in trees}
+	md_filters = {"parent": ["in", list(by_name)]}
+	if item_code:
+		md_filters["item_code"] = item_code
+
+	eps = tree_balance.pending_eps()
+	rows = []
+	for md in frappe.get_all(
+		"Tree Material Detail",
+		filters=md_filters,
+		fields=[
+			"parent",
+			"item_code",
+			"issue_qty",
+			"receive_qty",
+			"loss_qty",
+			"pending_qty",
+		],
+		order_by="parent, idx",
+	):
+		if flt(md.pending_qty) <= eps:
+			continue
+		tree = by_name[md.parent]
+		if not tree.msl_warehouse:
+			continue
+		rows.append(frappe._dict(tree=tree, md=md))
+	return rows
+
+
+def _physical_pool(item_code, msl_warehouse):
+	"""``[(batch_no, qty)]`` actually available at the warehouse, consume-ordered."""
+	available = (
+		capped_auto_batch_nos(
+			frappe._dict(
+				posting_date=nowdate(),
+				posting_time=nowtime(),
+				item_code=item_code,
+				warehouse=msl_warehouse,
+				for_stock_levels=False,
+				consider_negative_batches=False,
+			)
+		)
+		or []
+	)
+	pool = [
+		(b.batch_no, flt(b.qty)) for b in available if b.batch_no and flt(b.qty) > 0
+	]
+	ranks = batch_priority_map([b for b, _q in pool])
+	pool.sort(key=lambda bq: batch_sort_key(bq[0], ranks.get(bq[0]), "consume"))
+	return pool, ranks
+
+
+def _owner_of(batch_no, ranks, item_code):
+	meta = ranks.get(batch_no)
+	return normalize_ownership(
+		meta.inventory_type if meta else None,
+		meta.customer if meta else None,
+		batch_no=batch_no,
+		item_code=item_code,
+	)
+
+
+def report(msl_warehouse=None, item_code=None, company=None):
+	"""Print the projection and return it as a list of dicts. Never writes."""
+	rows = _open_rows(msl_warehouse, item_code, company)
+	if not rows:
+		print("No open Tree Number rows with pending qty for that filter.")
+		return []
+
+	eps = tree_balance.pending_eps()
+	prec = tse._se_precision()
+
+	# One shared pool per (warehouse, item) -- that is the unit the trees really compete over.
+	groups = {}
+	for r in rows:
+		groups.setdefault((r.tree.msl_warehouse, r.md.item_code), []).append(r)
+
+	out = []
+	for (wh, item), members in sorted(groups.items()):
+		pool, ranks = _physical_pool(item, wh)
+		remaining = {b: q for b, q in pool}
+		physical_total = flt(sum(remaining.values()), prec)
+		pending_total = flt(sum(flt(m.md.pending_qty) for m in members), prec)
+
+		print("")
+		print("=" * 100)
+		print(f"{wh}  |  {item}")
+		print(
+			f"  physical available {physical_total}   "
+			f"open tree pending {pending_total}   "
+			f"warehouse gap {flt(pending_total - physical_total, prec)}"
+		)
+		print("-" * 100)
+		print(
+			f"{'tree':<22}{'status':<20}{'pending':>10}{'own':>10}"
+			f"{'substitute':>12}{'short':>10}  verdict"
+		)
+
+		for m in sorted(members, key=lambda x: x.tree.name):
+			tree, md = m.tree, m.md
+			need = flt(md.pending_qty, prec)
+
+			owned = tse._tree_netted_owed(tree, md.item_code, wh)
+			tiers = tse._tree_issued_tiers(owned)
+
+			# Pass 1: the tree's own batches, capped at what is left of the shared pool.
+			from_own = {}
+			left = need
+			for batch_no in sorted(
+				owned, key=lambda b: batch_sort_key(b, ranks.get(b), "consume")
+			):
+				if left <= eps:
+					break
+				take = flt(
+					min(flt(owned[batch_no]), flt(remaining.get(batch_no, 0.0)), left),
+					prec,
+				)
+				if take <= eps:
+					continue
+				from_own[batch_no] = take
+				remaining[batch_no] = flt(
+					flt(remaining.get(batch_no, 0.0)) - take, prec
+				)
+				left = flt(left - take, prec)
+
+			# Pass 2: same-ownership-tier substitutes from whatever the pool still holds.
+			from_sub = {}
+			for batch_no, _q in pool:
+				if left <= eps:
+					break
+				# NOT `batch_no in from_own`: the residual of the tree's own batch is same-tier
+				# metal like any other, and `remaining` has already had the own draw deducted.
+				if flt(remaining.get(batch_no, 0.0)) <= eps:
+					continue
+				if _owner_of(batch_no, ranks, item) not in tiers:
+					continue
+				take = flt(min(flt(remaining[batch_no]), left), prec)
+				if take <= eps:
+					continue
+				from_sub[batch_no] = take
+				remaining[batch_no] = flt(flt(remaining[batch_no]) - take, prec)
+				left = flt(left - take, prec)
+
+			own_qty = flt(sum(from_own.values()), prec)
+			sub_qty = flt(sum(from_sub.values()), prec)
+			short = flt(left, prec)
+
+			if short > eps:
+				verdict = SHORT_OF_METAL
+			elif sub_qty > eps:
+				verdict = CLOSES_WITH_SUBSTITUTE
+			else:
+				verdict = CLOSES_FROM_OWN
+
+			print(
+				f"{tree.name:<22}{tree.status:<20}{need:>10}{own_qty:>10}"
+				f"{sub_qty:>12}{short:>10}  {verdict}"
+			)
+			if from_sub:
+				print(
+					"".ljust(22)
+					+ "substitutes: "
+					+ ", ".join(f"{b}: {q}" for b, q in sorted(from_sub.items()))
+				)
+
+			out.append(
+				{
+					"tree": tree.name,
+					"status": tree.status,
+					"item_code": md.item_code,
+					"msl_warehouse": wh,
+					"pending": need,
+					"from_own_batches": from_own,
+					"from_substitute_batches": from_sub,
+					"shortfall": short,
+					"verdict": verdict,
+				}
+			)
+
+		leftover = flt(sum(v for v in remaining.values() if v > eps), prec)
+		print("-" * 100)
+		print(
+			f"  unclaimed metal left at this warehouse after all trees close: {leftover}"
+		)
+
+	short_total = flt(sum(r["shortfall"] for r in out), prec)
+	subs = [r for r in out if r["verdict"] == CLOSES_WITH_SUBSTITUTE]
+	print("")
+	print("=" * 100)
+	print(
+		f"{len(out)} open rows | {len(subs)} need a substitute batch | "
+		f"total metal that cannot be returned: {short_total}"
+	)
+	print("This is a projection only. Nothing was written.")
+	return out


### PR DESCRIPTION
…ability

- Introduced a new module `tree_batch_reconciliation.py` to project the ability of open Tree Numbers to close based on physical stock availability.
- Implemented functions to retrieve open tree rows, assess physical stock pools, and determine ownership of batches.
- Added logic to evaluate whether trees can close from their own batches, require substitutes, or are short of metal.
- Enhanced reporting capabilities to provide detailed insights on metal availability and shortfalls for each tree.
- Updated tests to cover new functionality, ensuring accurate behavior in scenarios involving batch substitutions and ownership tiers.